### PR TITLE
feat: skillctl MVP — CLI with lifecycle management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 bin/
-skillctl
+/skillctl
 *.exe
 
 # Go

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ draft --> testing --> published --> deprecated --> archived
 | archived | tag removed | digest only |
 
 Status is stored in OCI manifest annotations
-(`io.skillregistry.status`), not inside the image. Image content
+(`io.skillimage.status`), not inside the image. Image content
 is immutable across promotions.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bin/skillctl validate examples/hello-world/
 bin/skillctl pack examples/hello-world/
 
 # List local images
-bin/skillctl images
+bin/skillctl list
 
 # Inspect metadata and OCI details
 bin/skillctl inspect examples/hello-world:1.0.0-draft

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ bin/skillctl inspect examples/hello-world:1.0.0-draft
 ### Lifecycle promotion
 
 ```bash
-# Promote draft -> testing (retagged as 1.0.0-rc)
+# Promote draft -> testing (retagged as 1.0.0-testing)
 bin/skillctl promote examples/hello-world:1.0.0-draft --to testing --local
 
 # Promote testing -> published (retagged as 1.0.0 + latest)
-bin/skillctl promote examples/hello-world:1.0.0-rc --to published --local
+bin/skillctl promote examples/hello-world:1.0.0-testing --to published --local
 ```
 
 Promotion updates OCI manifest annotations and retags without
@@ -136,7 +136,7 @@ draft --> testing --> published --> deprecated --> archived
 | State | OCI tag | Example |
 | ----- | ------- | ------- |
 | draft | `<ver>-draft` | `1.0.0-draft` |
-| testing | `<ver>-rc` | `1.0.0-rc` |
+| testing | `<ver>-testing` | `1.0.0-testing` |
 | published | `<ver>` + `latest` | `1.0.0` |
 | deprecated | `<ver>` | `1.0.0` |
 | archived | tag removed | digest only |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,150 @@
+# OCI Skill Registry
+
+A framework-agnostic, OCI-based registry for AI agent skills.
+Packages skills as standard OCI images, manages their lifecycle
+(draft, testing, published, deprecated, archived), and works with
+the container tools enterprises already use: `podman`, `skopeo`,
+`crane`, and Kubernetes ImageVolumes.
+
+Companion to
+[agentoperations/agent-registry](https://github.com/agentoperations/agent-registry)
+(metadata and governance layer).
+
+## Why OCI images?
+
+Skills are packaged as standard OCI images (`FROM scratch`), not
+ORAS artifacts. This means:
+
+- `podman pull` / `skopeo copy` / `crane pull` work out of the box
+- Kubernetes ImageVolumes can mount skills directly into agent pods
+- Standard registries (Quay, GHCR, Zot) index and serve them normally
+- Signing and verification via cosign/sigstore (planned)
+
+## Quick start
+
+### Build
+
+```bash
+make build
+```
+
+### Create a skill
+
+A skill is a directory with a `skill.yaml` (SkillCard metadata)
+and a `SKILL.md` (prompt content). See `examples/hello-world/`
+for a working example.
+
+```yaml
+apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: hello-world
+  namespace: examples
+  version: 1.0.0
+  description: A simple example skill.
+spec:
+  prompt: SKILL.md
+```
+
+### Validate, pack, and inspect
+
+```bash
+# Validate the SkillCard against the JSON Schema
+bin/skillctl validate examples/hello-world/
+
+# Pack into a local OCI image (tagged as 1.0.0-draft)
+bin/skillctl pack examples/hello-world/
+
+# List local images
+bin/skillctl images
+
+# Inspect metadata and OCI details
+bin/skillctl inspect examples/hello-world:1.0.0-draft
+```
+
+### Lifecycle promotion
+
+```bash
+# Promote draft -> testing (retagged as 1.0.0-rc)
+bin/skillctl promote examples/hello-world:1.0.0-draft --to testing --local
+
+# Promote testing -> published (retagged as 1.0.0 + latest)
+bin/skillctl promote examples/hello-world:1.0.0-rc --to published --local
+```
+
+Promotion updates OCI manifest annotations and retags without
+modifying image content. The layer digest stays the same from
+draft through published.
+
+### Push and pull (remote registry)
+
+```bash
+# Push to a remote registry
+bin/skillctl push quay.io/myorg/hello-world:1.0.0-draft
+
+# Pull from a remote registry
+bin/skillctl pull quay.io/myorg/hello-world:1.0.0 -o ./skills/
+```
+
+Authentication uses your existing `~/.docker/config.json` or
+Podman's `auth.json` -- no separate login needed.
+
+## Testing
+
+```bash
+make test        # Run all tests
+make lint        # Run golangci-lint
+make fmt         # Format code
+```
+
+## Project structure
+
+| Path | Description |
+| ---- | ----------- |
+| `cmd/skillctl/` | CLI entry point |
+| `internal/cli/` | Cobra commands |
+| `pkg/skillcard/` | SkillCard parse, validate, serialize |
+| `pkg/oci/` | OCI image pack/push/pull/inspect/promote |
+| `pkg/lifecycle/` | State machine, tag rules |
+| `schemas/` | JSON Schema for SkillCard |
+| `examples/` | Sample skills |
+| `docs/` | Design specs and research |
+
+## Architecture
+
+Library-first: core logic lives in `pkg/` as importable Go
+packages. The CLI is a thin consumer. Agent runtimes, CI/CD
+pipelines, and other tools can import the library directly.
+
+```text
+consumers: skillctl CLI, agent runtimes, CI/CD
+      |
+  pkg/ (public Go API)
+  +-- skillcard/  parse, validate, serialize
+  +-- oci/        pack, push, pull, inspect, promote
+  +-- lifecycle/  state machine, tag rules
+      |
+  OCI registries (quay.io, ghcr.io, Zot)
+```
+
+## Lifecycle states
+
+```text
+draft --> testing --> published --> deprecated --> archived
+```
+
+| State | OCI tag | Example |
+| ----- | ------- | ------- |
+| draft | `<ver>-draft` | `1.0.0-draft` |
+| testing | `<ver>-rc` | `1.0.0-rc` |
+| published | `<ver>` + `latest` | `1.0.0` |
+| deprecated | `<ver>` | `1.0.0` |
+| archived | tag removed | digest only |
+
+Status is stored in OCI manifest annotations
+(`io.skillregistry.status`), not inside the image. Image content
+is immutable across promotions.
+
+## License
+
+Apache-2.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and a `SKILL.md` (prompt content). See `examples/hello-world/`
 for a working example.
 
 ```yaml
-apiVersion: skills.redhat.io/v1alpha1
+apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: hello-world

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/redhat-et/oci-skill-registry/internal/cli"
+	"github.com/redhat-et/skillimage/internal/cli"
 )
 
 var version = "dev"

--- a/cmd/skillctl/main.go
+++ b/cmd/skillctl/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-et/oci-skill-registry/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	cmd := cli.NewRootCmd(version)
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}

--- a/docs/design/2026-04-15-oci-skill-registry-design.md
+++ b/docs/design/2026-04-15-oci-skill-registry-design.md
@@ -213,7 +213,7 @@ This mirrors standard software release management.
 | State      | Tag pattern               | Example           |
 | ---------- | ------------------------- | ----------------- |
 | draft      | `<version>-draft`         | `1.2.0-draft`     |
-| testing    | `<version>-rc`            | `1.2.0-rc`        |
+| testing    | `<version>-testing`       | `1.2.0-testing`   |
 | published  | `<version>` + `latest`    | `1.2.0`, `latest` |
 | deprecated | `<version>` (no `latest`) | `1.2.0`           |
 | archived   | tag removed, digest-only  | —                 |
@@ -797,7 +797,7 @@ The server executes the following sequence atomically:
 
 1. Verify the caller has the `skill:publish` role in their OIDC
    token claims.
-1. Resolve the OCI digest of the image at the `<version>-rc` tag.
+1. Resolve the OCI digest of the image at the `<version>-testing` tag.
 1. Exchange the caller's OIDC token for a short-lived Fulcio
    certificate. The certificate subject is the approver's email
    address (or a workload identity for CI-initiated promotions).

--- a/docs/design/2026-04-16-implementation-spec.md
+++ b/docs/design/2026-04-16-implementation-spec.md
@@ -61,9 +61,7 @@ ImageVolumes. See the design doc for the full rationale.
 
 ### apiVersion
 
-`skills.redhat.io/v1alpha1` — uses a Red Hat-controlled domain.
-May change to a community domain if the project grows beyond
-Red Hat.
+`skillimage.io/v1alpha1` — project-owned domain, vendor-neutral.
 
 ## SkillCard schema
 
@@ -73,7 +71,7 @@ Red Hat.
 
 | Field | Constraints |
 | ----- | ----------- |
-| `apiVersion` | Must be `skills.redhat.io/v1alpha1` |
+| `apiVersion` | Must be `skillimage.io/v1alpha1` |
 | `kind` | Must be `SkillCard` |
 | `metadata.name` | 1-64 chars, `[a-z0-9-]`, no leading/trailing/consecutive hyphens |
 | `metadata.namespace` | 1-128 chars, `[a-z0-9-/]`, each segment follows name rules |

--- a/docs/design/2026-04-16-implementation-spec.md
+++ b/docs/design/2026-04-16-implementation-spec.md
@@ -172,7 +172,7 @@ Tag rules:
 | State | Tag pattern | Example |
 | ----- | ----------- | ------- |
 | Draft | `<version>-draft` | `1.2.0-draft` |
-| Testing | `<version>-rc` | `1.2.0-rc` |
+| Testing | `<version>-testing` | `1.2.0-testing` |
 | Published | `<version>` + `latest` | `1.2.0`, `latest` |
 | Deprecated | `<version>` (no `latest`) | `1.2.0` |
 | Archived | Tag removed, digest-only | n/a |

--- a/docs/design/2026-04-16-implementation-spec.md
+++ b/docs/design/2026-04-16-implementation-spec.md
@@ -43,7 +43,7 @@ lifecycle governance on top of standard container tooling.
 
 The SkillCard YAML inside the image has no `status` field.
 Status is stored as an OCI manifest annotation
-(`io.skillregistry.status`). This keeps image content immutable
+(`io.skillimage.status`). This keeps image content immutable
 across promotions — the same layer digest from draft through
 published. Promotion updates annotations and retags without
 repacking.
@@ -111,7 +111,7 @@ Populated at pack time from SkillCard fields:
 | `org.opencontainers.image.created` | RFC 3339 timestamp at pack time |
 | `org.opencontainers.image.source` | `provenance.source` |
 | `org.opencontainers.image.revision` | `provenance.commit` |
-| `io.skillregistry.status` | Lifecycle state (custom annotation) |
+| `io.skillimage.status` | Lifecycle state (custom annotation) |
 
 ## Package design
 
@@ -221,7 +221,7 @@ non-existent path, it uses that path as-is.
 implementation.
 
 **Promote mechanics:** Fetches manifest from registry, creates
-a new manifest with updated `io.skillregistry.status` annotation
+a new manifest with updated `io.skillimage.status` annotation
 referencing the same layer digests, pushes new manifest with new
 tag, removes old tag. No layer data crosses the wire.
 

--- a/docs/superpowers/plans/2026-04-16-skillctl-mvp.md
+++ b/docs/superpowers/plans/2026-04-16-skillctl-mvp.md
@@ -94,7 +94,7 @@ Create `schemas/skillcard-v1.json`:
   "properties": {
     "apiVersion": {
       "type": "string",
-      "const": "skills.redhat.io/v1alpha1"
+      "const": "skillimage.io/v1alpha1"
     },
     "kind": {
       "type": "string",
@@ -218,7 +218,7 @@ var SkillCardV1 []byte
 Create `examples/hello-world/skill.yaml`:
 
 ```yaml
-apiVersion: skills.redhat.io/v1alpha1
+apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: hello-world
@@ -287,7 +287,7 @@ import (
 	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
 )
 
-const validSkillYAML = `apiVersion: skills.redhat.io/v1alpha1
+const validSkillYAML = `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: hello-world
@@ -310,8 +310,8 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if sc.APIVersion != "skills.redhat.io/v1alpha1" {
-		t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skills.redhat.io/v1alpha1")
+	if sc.APIVersion != "skillimage.io/v1alpha1" {
+		t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skillimage.io/v1alpha1")
 	}
 	if sc.Kind != "SkillCard" {
 		t.Errorf("kind = %q, want %q", sc.Kind, "SkillCard")
@@ -493,7 +493,7 @@ func TestValidateValid(t *testing.T) {
 }
 
 func TestValidateMissingRequiredFields(t *testing.T) {
-	yaml := `apiVersion: skills.redhat.io/v1alpha1
+	yaml := `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test
@@ -543,7 +543,7 @@ func TestValidateInvalidName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			yaml := fmt.Sprintf(`apiVersion: skills.redhat.io/v1alpha1
+			yaml := fmt.Sprintf(`apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: %s
@@ -566,7 +566,7 @@ metadata:
 }
 
 func TestValidateInvalidSemver(t *testing.T) {
-	yaml := `apiVersion: skills.redhat.io/v1alpha1
+	yaml := `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test
@@ -1118,7 +1118,7 @@ func writeTestSkill(t *testing.T, dir string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillYAML := []byte(`apiVersion: skills.redhat.io/v1alpha1
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test-skill

--- a/docs/superpowers/plans/2026-04-16-skillctl-mvp.md
+++ b/docs/superpowers/plans/2026-04-16-skillctl-mvp.md
@@ -1031,7 +1031,7 @@ const (
 	Archived   State = "archived"
 )
 
-const StatusAnnotation = "io.skillregistry.status"
+const StatusAnnotation = "io.skillimage.status"
 
 var transitions = map[State]State{
 	Draft:      Testing,

--- a/examples/hello-world/SKILL.md
+++ b/examples/hello-world/SKILL.md
@@ -1,0 +1,4 @@
+You are a friendly greeter skill.
+
+When the user says hello, greet them warmly and ask how you
+can help. Keep responses concise and helpful.

--- a/examples/hello-world/skill.yaml
+++ b/examples/hello-world/skill.yaml
@@ -1,4 +1,4 @@
-apiVersion: skills.redhat.io/v1alpha1
+apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: hello-world

--- a/examples/hello-world/skill.yaml
+++ b/examples/hello-world/skill.yaml
@@ -1,0 +1,22 @@
+apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: hello-world
+  namespace: examples
+  version: 1.0.0
+  display-name: "Hello World"
+  description: >
+    A simple example skill that greets the user.
+    Use this as a template for creating new skills.
+  license: Apache-2.0
+  tags:
+    - example
+    - getting-started
+  authors:
+    - name: OCTO Team
+      email: octo@redhat.com
+spec:
+  prompt: SKILL.md
+  examples:
+    - input: "Hello"
+      output: "Hello! How can I help you today?"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/redhat-et/oci-skill-registry
 
 go 1.26.2
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,17 +2,19 @@ module github.com/redhat-et/oci-skill-registry
 
 go 1.26.2
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+	oras.land/oras-go/v2 v2.6.0
+)
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/redhat-et/oci-skill-registry
+module github.com/redhat-et/skillimage
 
 go 1.26.2
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/redhat-et/oci-skill-registry
 
 go 1.26.2
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,12 @@ require gopkg.in/yaml.v3 v3.0.1
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	oras.land/oras-go/v2 v2.6.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require gopkg.in/yaml.v3 v3.0.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
@@ -11,9 +15,13 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,16 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+)
+
+func defaultClient() (*oci.Client, error) {
+	storeDir, err := defaultStoreDir()
+	if err != nil {
+		return nil, err
+	}
+	return oci.NewClient(storeDir)
+}
+
+func defaultStoreDir() (string, error) {
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("finding home directory: %w", err)
+		}
+		dataDir = home + "/.local/share"
+	}
+	dir := dataDir + "/skillctl/store"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating store directory: %w", err)
+	}
+	return dir, nil
+}

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -34,14 +34,14 @@ func runImages(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tVERSION\tSTATUS\tDIGEST\tCREATED")
+	fmt.Fprintln(w, "NAME\tTAG\tSTATUS\tDIGEST\tCREATED")
 	for _, img := range images {
 		shortDigest := img.Digest
 		if len(shortDigest) > 19 {
 			shortDigest = shortDigest[:19]
 		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			img.Name, img.Version, img.Status, shortDigest, img.Created)
+			img.Name, img.Tag, img.Status, shortDigest, img.Created)
 	}
 	return w.Flush()
 }

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func newImagesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "images",
+		Short: "List skill images in local store",
+		Args:  cobra.NoArgs,
+		RunE:  runImages,
+	}
+}
+
+func runImages(cmd *cobra.Command, args []string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		return fmt.Errorf("listing images: %w", err)
+	}
+
+	if len(images) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No images found in local store.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tVERSION\tSTATUS\tDIGEST\tCREATED")
+	for _, img := range images {
+		shortDigest := img.Digest
+		if len(shortDigest) > 19 {
+			shortDigest = shortDigest[:19]
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			img.Name, img.Version, img.Status, shortDigest, img.Created)
+	}
+	return w.Flush()
+}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newInspectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "inspect <ref>",
+		Short: "Show SkillCard metadata and OCI image details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInspect(cmd, args[0])
+		},
+	}
+}
+
+func runInspect(cmd *cobra.Command, ref string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := client.Inspect(context.Background(), ref)
+	if err != nil {
+		return fmt.Errorf("inspecting %s: %w", ref, err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Skill:        %s\n", result.Name)
+	if result.DisplayName != "" {
+		fmt.Fprintf(out, "Display Name: %s\n", result.DisplayName)
+	}
+	fmt.Fprintf(out, "Version:      %s\n", result.Version)
+	fmt.Fprintf(out, "Status:       %s\n", result.Status)
+	if result.Description != "" {
+		fmt.Fprintf(out, "Description:  %s\n", result.Description)
+	}
+	if result.Authors != "" {
+		fmt.Fprintf(out, "Authors:      %s\n", result.Authors)
+	}
+	if result.License != "" {
+		fmt.Fprintf(out, "License:      %s\n", result.License)
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "OCI Image:\n")
+	fmt.Fprintf(out, "  Digest:     %s\n", result.Digest)
+	fmt.Fprintf(out, "  Created:    %s\n", result.Created)
+	fmt.Fprintf(out, "  Size:       %d bytes\n", result.Size)
+	fmt.Fprintf(out, "  Layers:     %d\n", result.LayerCount)
+
+	return nil
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var agentTargets = map[string]string{
+	"claude":   ".claude/skills",
+	"cursor":   ".cursor/skills",
+	"windsurf": ".codeium/windsurf/skills",
+	"opencode": ".config/opencode/skills",
+	"openclaw": ".openclaw/skills",
+}
+
+func newInstallCmd() *cobra.Command {
+	var target string
+	var outputDir string
+	cmd := &cobra.Command{
+		Use:   "install <ref>",
+		Short: "Install a skill from local store to an agent's skill directory",
+		Long: `Install a skill from the local store into a directory where
+an agent can find it. Use --target for a known agent or -o for
+a custom path.
+
+Supported targets:
+  claude    ~/.claude/skills/
+  cursor    ~/.cursor/skills/
+  windsurf  ~/.codeium/windsurf/skills/
+  opencode  ~/.config/opencode/skills/
+  openclaw  ~/.openclaw/skills/
+
+Examples:
+  skillctl install examples/hello-world:1.0.0-draft --target claude
+  skillctl install myorg/my-skill:1.0.0 --target cursor
+  skillctl install myorg/my-skill:1.0.0 -o ~/custom/skills/`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInstall(cmd, args[0], target, outputDir)
+		},
+	}
+	cmd.Flags().StringVarP(&target, "target", "t", "", "agent name (claude, cursor, windsurf, opencode, openclaw)")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "custom output directory")
+	return cmd
+}
+
+func runInstall(cmd *cobra.Command, ref string, target string, outputDir string) error {
+	if target == "" && outputDir == "" {
+		return fmt.Errorf("specify --target <agent> or -o <directory>")
+	}
+	if target != "" && outputDir != "" {
+		return fmt.Errorf("use --target or -o, not both")
+	}
+
+	if target != "" {
+		relPath, ok := agentTargets[strings.ToLower(target)]
+		if !ok {
+			var names []string
+			for k := range agentTargets {
+				names = append(names, k)
+			}
+			return fmt.Errorf("unknown target %q (supported: %s)", target, strings.Join(names, ", "))
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("finding home directory: %w", err)
+		}
+		outputDir = filepath.Join(home, relPath)
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", outputDir, err)
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.Unpack(context.Background(), ref, outputDir); err != nil {
+		return fmt.Errorf("installing %s: %w", ref, err)
+	}
+
+	// Extract skill name for the output message
+	skillName := ref
+	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+		skillName = ref[idx+1:]
+	}
+	if idx := strings.LastIndex(skillName, ":"); idx >= 0 {
+		skillName = skillName[:idx]
+	}
+
+	dest := filepath.Join(outputDir, skillName)
+	fmt.Fprintf(cmd.OutOrStdout(), "Installed %s to %s\n", ref, dest)
+	return nil
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -34,7 +33,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tTAG\tSTATUS\tDIGEST\tCREATED")
 	for _, img := range images {
 		shortDigest := img.Digest

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -8,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newImagesCmd() *cobra.Command {
+func newListCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "images",
-		Short: "List skill images in local store",
-		Args:  cobra.NoArgs,
-		RunE:  runImages,
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List skill images in local store",
+		Args:    cobra.NoArgs,
+		RunE:    runList,
 	}
 }
 
-func runImages(cmd *cobra.Command, args []string) error {
+func runList(cmd *cobra.Command, args []string) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/spf13/cobra"
@@ -36,28 +35,4 @@ func runPack(cmd *cobra.Command, dir string, tag string) error {
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Packed %s\nDigest: %s\n", dir, desc.Digest)
 	return nil
-}
-
-func defaultClient() (*oci.Client, error) {
-	storeDir, err := defaultStoreDir()
-	if err != nil {
-		return nil, err
-	}
-	return oci.NewClient(storeDir)
-}
-
-func defaultStoreDir() (string, error) {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("finding home directory: %w", err)
-		}
-		dataDir = home + "/.local/share"
-	}
-	dir := dataDir + "/skillctl/store"
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("creating store directory: %w", err)
-	}
-	return dir, nil
 }

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/spf13/cobra"
+)
+
+func newPackCmd() *cobra.Command {
+	var tag string
+	cmd := &cobra.Command{
+		Use:   "pack <dir>",
+		Short: "Pack a skill directory into a local OCI image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPack(cmd, args[0], tag)
+		},
+	}
+	cmd.Flags().StringVar(&tag, "tag", "", "override the image tag (default: <version>-draft)")
+	return cmd
+}
+
+func runPack(cmd *cobra.Command, dir string, tag string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	desc, err := client.Pack(context.Background(), dir, oci.PackOptions{Tag: tag})
+	if err != nil {
+		return fmt.Errorf("packing %s: %w", dir, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Packed %s\nDigest: %s\n", dir, desc.Digest)
+	return nil
+}
+
+func defaultClient() (*oci.Client, error) {
+	storeDir, err := defaultStoreDir()
+	if err != nil {
+		return nil, err
+	}
+	return oci.NewClient(storeDir)
+}
+
+func defaultStoreDir() (string, error) {
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("finding home directory: %w", err)
+		}
+		dataDir = home + "/.local/share"
+	}
+	dir := dataDir + "/skillctl/store"
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating store directory: %w", err)
+	}
+	return dir, nil
+}

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
-	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/oci"
 )
 
 func newPromoteCmd() *cobra.Command {

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+)
+
+func newPromoteCmd() *cobra.Command {
+	var toState string
+	var local bool
+	cmd := &cobra.Command{
+		Use:   "promote <ref>",
+		Short: "Promote a skill to the next lifecycle state",
+		Long: `Promote a skill image to a new lifecycle state.
+
+State transitions: draft -> testing -> published -> deprecated -> archived
+
+By default, operates on a remote registry. Use --local to promote
+images in the local store.
+
+Examples:
+  skillctl promote quay.io/acme/hr-onboarding:1.0.0-draft --to testing
+  skillctl promote test/test-skill:1.0.0-draft --to testing --local`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPromote(cmd, args[0], toState, local)
+		},
+	}
+	cmd.Flags().StringVar(&toState, "to", "", "target lifecycle state (required)")
+	_ = cmd.MarkFlagRequired("to")
+	cmd.Flags().BoolVar(&local, "local", false, "promote in local store instead of remote registry")
+	return cmd
+}
+
+func runPromote(cmd *cobra.Command, ref, toState string, local bool) error {
+	to, err := lifecycle.ParseState(toState)
+	if err != nil {
+		return fmt.Errorf("invalid target state: %w", err)
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if local {
+		if err := client.PromoteLocal(ctx, ref, to); err != nil {
+			return fmt.Errorf("promoting %s: %w", ref, err)
+		}
+	} else {
+		if err := client.Promote(ctx, ref, to, oci.PromoteOptions{}); err != nil {
+			return fmt.Errorf("promoting %s: %w", ref, err)
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Promoted %s to %s\n", ref, to)
+	return nil
+}

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newPruneCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "prune",
+		Short: "Remove local images that have been superseded by promotion",
+		Long: `Remove local skill images whose lifecycle state has been
+superseded. For each skill version, keeps only the image with the
+highest lifecycle state and removes the rest.
+
+For example, if a skill has draft, testing, and published images,
+prune removes the draft and testing images.`,
+		Args: cobra.NoArgs,
+		RunE: runPrune,
+	}
+}
+
+func runPrune(cmd *cobra.Command, args []string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	result, err := client.Prune(context.Background())
+	if err != nil {
+		return fmt.Errorf("pruning: %w", err)
+	}
+
+	if len(result.Removed) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "Nothing to prune.")
+		return nil
+	}
+
+	for _, img := range result.Removed {
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed %s:%s (%s)\n", img.Name, img.Tag, img.Status)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nPruned %d image(s).\n", len(result.Removed))
+	return nil
+}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/redhat-et/oci-skill-registry/pkg/oci"
 	"github.com/spf13/cobra"
@@ -31,7 +32,16 @@ Examples:
 	return cmd
 }
 
+func looksLocal(ref string) bool {
+	parts := strings.SplitN(ref, "/", 2)
+	return len(parts) < 2 || (!strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":"))
+}
+
 func runPull(cmd *cobra.Command, ref string, outputDir string) error {
+	if looksLocal(ref) {
+		return fmt.Errorf("%s looks like a local reference, not a remote registry\n\nTo install from the local store, use:\n  skillctl install %s --target <agent>\n  skillctl install %s -o <directory>", ref, ref, ref)
+	}
+
 	client, err := defaultClient()
 	if err != nil {
 		return err

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/spf13/cobra"
+)
+
+func newPullCmd() *cobra.Command {
+	var outputDir string
+	cmd := &cobra.Command{
+		Use:   "pull <ref>",
+		Short: "Pull a skill image from a remote registry",
+		Long: `Pull a skill image from an OCI registry to the local store.
+
+Use -o to unpack skill files to a directory. If -o points to an
+existing directory, a subdirectory named after the skill is created
+automatically.
+
+Examples:
+  skillctl pull quay.io/acme/hr-onboarding:1.0.0
+  skillctl pull quay.io/acme/hr-onboarding:1.0.0 -o ./skills/`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPull(cmd, args[0], outputDir)
+		},
+	}
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "unpack skill files to directory")
+	return cmd
+}
+
+func runPull(cmd *cobra.Command, ref string, outputDir string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	desc, err := client.Pull(context.Background(), ref, oci.PullOptions{
+		OutputDir: outputDir,
+	})
+	if err != nil {
+		return fmt.Errorf("pulling: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Pulled %s\nDigest: %s\n", ref, desc.Digest)
+	if outputDir != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Unpacked to %s\n", outputDir)
+	}
+	return nil
+}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -33,8 +33,7 @@ Examples:
 }
 
 func looksLocal(ref string) bool {
-	parts := strings.SplitN(ref, "/", 2)
-	return len(parts) < 2 || (!strings.Contains(parts[0], ".") && !strings.Contains(parts[0], ":"))
+	return !strings.Contains(ref, "/")
 }
 
 func runPull(cmd *cobra.Command, ref string, outputDir string) error {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/spf13/cobra"
+)
+
+func newPushCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "push <ref>",
+		Short: "Push a skill image from local store to a remote registry",
+		Long: `Push a skill image to a remote OCI registry.
+
+The ref should be a full OCI reference: registry/namespace/name:tag
+Example: quay.io/acme/hr-onboarding:1.0.0-draft`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPush(cmd, args[0])
+		},
+	}
+}
+
+func runPush(cmd *cobra.Command, ref string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.Push(context.Background(), ref, oci.PushOptions{}); err != nil {
+		return fmt.Errorf("pushing: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Pushed %s\n", ref)
+	return nil
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagFormat  string
+	flagVerbose bool
+)
+
+func NewRootCmd(version string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skillctl",
+		Short: "Manage AI agent skills as OCI images",
+		Long:  "skillctl packs, pushes, pulls, and manages the lifecycle of AI agent skills stored as OCI images.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.PersistentFlags().StringVar(&flagFormat, "format", "text", "output format (text, json)")
+	cmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "verbose output")
+
+	cmd.AddCommand(newValidateCmd())
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,9 +24,10 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newPackCmd())
 	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newPullCmd())
-	cmd.AddCommand(newImagesCmd())
+	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newPromoteCmd())
+	cmd.AddCommand(newPruneCmd())
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,6 +26,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newImagesCmd())
 	cmd.AddCommand(newInspectCmd())
+	cmd.AddCommand(newPromoteCmd())
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,6 +21,8 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "verbose output")
 
 	cmd.AddCommand(newValidateCmd())
+	cmd.AddCommand(newPackCmd())
+	cmd.AddCommand(newImagesCmd())
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,21 +4,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	flagFormat  string
-	flagVerbose bool
-)
-
 func NewRootCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "skillctl",
-		Short: "Manage AI agent skills as OCI images",
-		Long:  "skillctl packs, pushes, pulls, and manages the lifecycle of AI agent skills stored as OCI images.",
+		Use:     "skillctl",
+		Short:   "Manage AI agent skills as OCI images",
+		Long:    "skillctl packs, pushes, pulls, and manages the lifecycle of AI agent skills stored as OCI images.",
+		Version: version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	cmd.PersistentFlags().StringVar(&flagFormat, "format", "text", "output format (text, json)")
-	cmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "verbose output")
 
 	cmd.AddCommand(newValidateCmd())
 	cmd.AddCommand(newPackCmd())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -25,6 +25,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newImagesCmd())
+	cmd.AddCommand(newInspectCmd())
 
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -27,6 +27,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newPromoteCmd())
+	cmd.AddCommand(newInstallCmd())
 	cmd.AddCommand(newPruneCmd())
 
 	return cmd

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,6 +22,8 @@ func NewRootCmd(version string) *cobra.Command {
 
 	cmd.AddCommand(newValidateCmd())
 	cmd.AddCommand(newPackCmd())
+	cmd.AddCommand(newPushCmd())
+	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newImagesCmd())
 
 	return cmd

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+	"github.com/spf13/cobra"
+)
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate <dir|file>",
+		Short: "Validate a SkillCard against the JSON Schema",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runValidate,
+	}
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("accessing %s: %w", path, err)
+	}
+	if info.IsDir() {
+		path = filepath.Join(path, "skill.yaml")
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer f.Close()
+
+	sc, err := skillcard.Parse(f)
+	if err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	errs, err := skillcard.Validate(sc)
+	if err != nil {
+		return fmt.Errorf("validating %s: %w", path, err)
+	}
+
+	if len(errs) > 0 {
+		fmt.Fprintf(os.Stderr, "✗ %s has %d error(s):\n", path, len(errs))
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "  %s: %s\n", e.Field, e.Message)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ %s is valid\n", path)
+	return nil
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -46,11 +46,11 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(errs) > 0 {
-		fmt.Fprintf(os.Stderr, "✗ %s has %d error(s):\n", path, len(errs))
+		fmt.Fprintf(cmd.ErrOrStderr(), "✗ %s has %d error(s):\n", path, len(errs))
 		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "  %s: %s\n", e.Field, e.Message)
+			fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s\n", e.Field, e.Message)
 		}
-		os.Exit(1)
+		return fmt.Errorf("validation failed with %d error(s)", len(errs))
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "✓ %s is valid\n", path)

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -36,7 +36,7 @@ func TagForState(version string, state State) string {
 	case Draft:
 		return version + "-draft"
 	case Testing:
-		return version + "-rc"
+		return version + "-testing"
 	case Published:
 		return version
 	case Deprecated:

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -15,7 +15,7 @@ const (
 	Archived   State = "archived"
 )
 
-const StatusAnnotation = "io.skillregistry.status"
+const StatusAnnotation = "io.skillimage.status"
 
 var transitions = map[State]State{
 	Draft:      Testing,

--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -1,0 +1,58 @@
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+)
+
+type State string
+
+const (
+	Draft      State = "draft"
+	Testing    State = "testing"
+	Published  State = "published"
+	Deprecated State = "deprecated"
+	Archived   State = "archived"
+)
+
+const StatusAnnotation = "io.skillregistry.status"
+
+var transitions = map[State]State{
+	Draft:      Testing,
+	Testing:    Published,
+	Published:  Deprecated,
+	Deprecated: Archived,
+}
+
+var errInvalidState = errors.New("invalid lifecycle state")
+
+func ValidTransition(from, to State) bool {
+	next, ok := transitions[from]
+	return ok && next == to
+}
+
+func TagForState(version string, state State) string {
+	switch state {
+	case Draft:
+		return version + "-draft"
+	case Testing:
+		return version + "-rc"
+	case Published:
+		return version
+	case Deprecated:
+		return version
+	case Archived:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func ParseState(s string) (State, error) {
+	switch State(s) {
+	case Draft, Testing, Published, Deprecated, Archived:
+		return State(s), nil
+	default:
+		return "", fmt.Errorf("%w: %q", errInvalidState, s)
+	}
+}

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -43,7 +43,7 @@ func TestTagForState(t *testing.T) {
 		want    string
 	}{
 		{"1.2.0", lifecycle.Draft, "1.2.0-draft"},
-		{"1.2.0", lifecycle.Testing, "1.2.0-rc"},
+		{"1.2.0", lifecycle.Testing, "1.2.0-testing"},
 		{"1.2.0", lifecycle.Published, "1.2.0"},
 		{"1.2.0", lifecycle.Deprecated, "1.2.0"},
 		{"1.2.0", lifecycle.Archived, ""},

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -3,7 +3,7 @@ package lifecycle_test
 import (
 	"testing"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
 )
 
 func TestValidTransition(t *testing.T) {

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -1,0 +1,89 @@
+package lifecycle_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+)
+
+func TestValidTransition(t *testing.T) {
+	tests := []struct {
+		from lifecycle.State
+		to   lifecycle.State
+		want bool
+	}{
+		{lifecycle.Draft, lifecycle.Testing, true},
+		{lifecycle.Testing, lifecycle.Published, true},
+		{lifecycle.Published, lifecycle.Deprecated, true},
+		{lifecycle.Deprecated, lifecycle.Archived, true},
+		// Invalid transitions
+		{lifecycle.Draft, lifecycle.Published, false},
+		{lifecycle.Draft, lifecycle.Deprecated, false},
+		{lifecycle.Testing, lifecycle.Draft, false},
+		{lifecycle.Published, lifecycle.Testing, false},
+		{lifecycle.Published, lifecycle.Archived, false},
+		{lifecycle.Archived, lifecycle.Draft, false},
+		{lifecycle.Archived, lifecycle.Published, false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.from)+"->"+string(tt.to), func(t *testing.T) {
+			got := lifecycle.ValidTransition(tt.from, tt.to)
+			if got != tt.want {
+				t.Errorf("ValidTransition(%s, %s) = %v, want %v",
+					tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagForState(t *testing.T) {
+	tests := []struct {
+		version string
+		state   lifecycle.State
+		want    string
+	}{
+		{"1.2.0", lifecycle.Draft, "1.2.0-draft"},
+		{"1.2.0", lifecycle.Testing, "1.2.0-rc"},
+		{"1.2.0", lifecycle.Published, "1.2.0"},
+		{"1.2.0", lifecycle.Deprecated, "1.2.0"},
+		{"1.2.0", lifecycle.Archived, ""},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			got := lifecycle.TagForState(tt.version, tt.state)
+			if got != tt.want {
+				t.Errorf("TagForState(%q, %s) = %q, want %q",
+					tt.version, tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseState(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    lifecycle.State
+		wantErr bool
+	}{
+		{"draft", lifecycle.Draft, false},
+		{"testing", lifecycle.Testing, false},
+		{"published", lifecycle.Published, false},
+		{"deprecated", lifecycle.Deprecated, false},
+		{"archived", lifecycle.Archived, false},
+		{"invalid", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := lifecycle.ParseState(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseState(%q) error = %v, wantErr %v",
+					tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseState(%q) = %q, want %q",
+					tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/oci/annotations.go
+++ b/pkg/oci/annotations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // buildAnnotations maps SkillCard fields to standard OCI annotation keys
-// and the custom skillregistry status annotation.
+// and the custom skillimage status annotation.
 func buildAnnotations(sc *skillcard.SkillCard) map[string]string {
 	ann := make(map[string]string)
 
@@ -27,6 +28,9 @@ func buildAnnotations(sc *skillcard.SkillCard) map[string]string {
 	desc := sc.Metadata.Description
 	if len(desc) > 256 {
 		desc = desc[:256]
+		for len(desc) > 0 && !utf8.ValidString(desc) {
+			desc = desc[:len(desc)-1]
+		}
 	}
 	ann[ocispec.AnnotationDescription] = desc
 

--- a/pkg/oci/annotations.go
+++ b/pkg/oci/annotations.go
@@ -7,8 +7,8 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
-	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 // buildAnnotations maps SkillCard fields to standard OCI annotation keys

--- a/pkg/oci/annotations.go
+++ b/pkg/oci/annotations.go
@@ -1,0 +1,74 @@
+package oci
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+)
+
+// buildAnnotations maps SkillCard fields to standard OCI annotation keys
+// and the custom skillregistry status annotation.
+func buildAnnotations(sc *skillcard.SkillCard) map[string]string {
+	ann := make(map[string]string)
+
+	// Title: use display-name if set, otherwise name.
+	title := sc.Metadata.DisplayName
+	if title == "" {
+		title = sc.Metadata.Name
+	}
+	ann[ocispec.AnnotationTitle] = title
+
+	// Description: first 256 characters.
+	desc := sc.Metadata.Description
+	if len(desc) > 256 {
+		desc = desc[:256]
+	}
+	ann[ocispec.AnnotationDescription] = desc
+
+	// Version.
+	ann[ocispec.AnnotationVersion] = sc.Metadata.Version
+
+	// Authors: comma-separated "name <email>".
+	if len(sc.Metadata.Authors) > 0 {
+		var parts []string
+		for _, a := range sc.Metadata.Authors {
+			if a.Email != "" {
+				parts = append(parts, fmt.Sprintf("%s <%s>", a.Name, a.Email))
+			} else {
+				parts = append(parts, a.Name)
+			}
+		}
+		ann[ocispec.AnnotationAuthors] = strings.Join(parts, ", ")
+	}
+
+	// License.
+	if sc.Metadata.License != "" {
+		ann[ocispec.AnnotationLicenses] = sc.Metadata.License
+	}
+
+	// Vendor: namespace.
+	ann[ocispec.AnnotationVendor] = sc.Metadata.Namespace
+
+	// Created: RFC 3339 timestamp.
+	ann[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
+
+	// Provenance fields.
+	if sc.Provenance != nil {
+		if sc.Provenance.Source != "" {
+			ann[ocispec.AnnotationSource] = sc.Provenance.Source
+		}
+		if sc.Provenance.Commit != "" {
+			ann[ocispec.AnnotationRevision] = sc.Provenance.Commit
+		}
+	}
+
+	// Lifecycle status: initial state is always draft.
+	ann[lifecycle.StatusAnnotation] = string(lifecycle.Draft)
+
+	return ann
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -1,0 +1,40 @@
+package oci
+
+import (
+	"oras.land/oras-go/v2/content/oci"
+)
+
+// Client provides OCI operations against a local OCI layout store.
+type Client struct {
+	store     *oci.Store
+	storePath string
+}
+
+// NewClient creates a new OCI client backed by a local OCI layout store
+// at the given path. The directory is created if it does not exist.
+func NewClient(storePath string) (*Client, error) {
+	store, err := oci.New(storePath)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		store:     store,
+		storePath: storePath,
+	}, nil
+}
+
+// PackOptions configures the Pack operation.
+type PackOptions struct {
+	// Tag overrides the default tag. If empty, defaults to <version>-draft.
+	Tag string
+}
+
+// LocalImage holds metadata for an image stored in the local OCI layout.
+type LocalImage struct {
+	Name    string
+	Version string
+	Tag     string
+	Digest  string
+	Status  string
+	Created string
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -29,6 +29,16 @@ type PackOptions struct {
 	Tag string
 }
 
+// PushOptions configures the Push operation.
+type PushOptions struct{}
+
+// PullOptions configures the Pull operation.
+type PullOptions struct {
+	// OutputDir, if set, causes the pulled image to be unpacked into this
+	// directory after storing it locally.
+	OutputDir string
+}
+
 // LocalImage holds metadata for an image stored in the local OCI layout.
 type LocalImage struct {
 	Name    string

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -48,3 +48,19 @@ type LocalImage struct {
 	Status  string
 	Created string
 }
+
+// InspectResult holds detailed metadata for a skill image.
+type InspectResult struct {
+	Name        string
+	DisplayName string
+	Version     string
+	Status      string
+	Description string
+	Authors     string
+	License     string
+	Digest      string
+	Created     string
+	MediaType   string
+	Size        int64
+	LayerCount  int
+}

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -49,6 +49,9 @@ type LocalImage struct {
 	Created string
 }
 
+// PromoteOptions configures the Promote operation.
+type PromoteOptions struct{}
+
 // InspectResult holds detailed metadata for a skill image.
 type InspectResult struct {
 	Name        string

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -1,0 +1,76 @@
+package oci
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+)
+
+// Inspect retrieves detailed metadata for a skill image stored in the local OCI layout.
+func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error) {
+	// Resolve the reference to get the manifest descriptor.
+	desc, err := c.store.Resolve(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %s: %w", ref, err)
+	}
+
+	// Fetch and parse the manifest.
+	rc, err := c.store.Fetch(ctx, desc)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest: %w", err)
+	}
+	defer rc.Close()
+
+	manifestBytes, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	ann := manifest.Annotations
+	if ann == nil {
+		ann = make(map[string]string)
+	}
+
+	// Extract name from ref (everything before the last colon).
+	name := parseNameFromTag(ref)
+
+	// Extract annotations.
+	version := ann[ocispec.AnnotationVersion]
+	status := ann[lifecycle.StatusAnnotation]
+	description := ann[ocispec.AnnotationDescription]
+	displayName := ann[ocispec.AnnotationTitle]
+	authors := ann[ocispec.AnnotationAuthors]
+	license := ann[ocispec.AnnotationLicenses]
+	created := ann[ocispec.AnnotationCreated]
+
+	// Compute total size from layers.
+	var totalSize int64
+	for _, layer := range manifest.Layers {
+		totalSize += layer.Size
+	}
+
+	return &InspectResult{
+		Name:        name,
+		DisplayName: displayName,
+		Version:     version,
+		Status:      status,
+		Description: description,
+		Authors:     authors,
+		License:     license,
+		Digest:      desc.Digest.String(),
+		Created:     created,
+		MediaType:   desc.MediaType,
+		Size:        totalSize,
+		LayerCount:  len(manifest.Layers),
+	}, nil
+}

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -8,7 +8,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
 )
 
 // Inspect retrieves detailed metadata for a skill image stored in the local OCI layout.

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -243,7 +243,7 @@ func TestPromoteLocal(t *testing.T) {
 	}
 
 	// Verify new tag exists with correct status
-	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-rc")
+	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-testing")
 	if err != nil {
 		t.Fatalf("Inspect after promote to testing: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestPromoteLocal(t *testing.T) {
 	}
 
 	// Promote testing -> published
-	err = client.PromoteLocal(ctx, "test/test-skill:1.0.0-rc", lifecycle.Published)
+	err = client.PromoteLocal(ctx, "test/test-skill:1.0.0-testing", lifecycle.Published)
 	if err != nil {
 		t.Fatalf("Promote to published: %v", err)
 	}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -184,3 +184,37 @@ func TestUnpack(t *testing.T) {
 		t.Errorf("expected %s to exist: %v", promptFile, err)
 	}
 }
+
+func TestInspect(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", result.Version, "1.0.0")
+	}
+	if result.Status != "draft" {
+		t.Errorf("status = %q, want %q", result.Status, "draft")
+	}
+	if result.Name != "test/test-skill" {
+		t.Errorf("name = %q, want %q", result.Name, "test/test-skill")
+	}
+	if result.LayerCount != 1 {
+		t.Errorf("layer count = %d, want 1", result.LayerCount)
+	}
+}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
-	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/oci"
 )
 
 func writeTestSkill(t *testing.T, dir string) {
@@ -15,7 +15,7 @@ func writeTestSkill(t *testing.T, dir string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillYAML := []byte(`apiVersion: skills.redhat.io/v1alpha1
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test-skill

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -1,0 +1,111 @@
+package oci_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/oci"
+)
+
+func writeTestSkill(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillYAML := []byte(`apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: test-skill
+  namespace: test
+  version: 1.0.0
+  description: A test skill.
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Test prompt content."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPackAndListLocal(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	desc, err := client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	if desc.Digest.String() == "" {
+		t.Error("expected non-empty digest")
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(images))
+	}
+	if images[0].Name != "test/test-skill" {
+		t.Errorf("image name = %q, want %q", images[0].Name, "test/test-skill")
+	}
+	if images[0].Version != "1.0.0" {
+		t.Errorf("image version = %q, want %q", images[0].Version, "1.0.0")
+	}
+	if images[0].Tag != "1.0.0-draft" {
+		t.Errorf("image tag = %q, want %q", images[0].Tag, "1.0.0-draft")
+	}
+}
+
+func TestPackValidatesSkillCard(t *testing.T) {
+	skillDir := t.TempDir()
+	badYAML := []byte(`apiVersion: wrong/v1
+kind: SkillCard
+metadata:
+  name: BAD
+  namespace: test
+  version: 1.0.0
+  description: test
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), badYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.Pack(context.Background(), skillDir, oci.PackOptions{})
+	if err == nil {
+		t.Fatal("expected error for invalid SkillCard")
+	}
+}
+
+func TestPackMissingSkillYAML(t *testing.T) {
+	emptyDir := t.TempDir()
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.Pack(context.Background(), emptyDir, oci.PackOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing skill.yaml")
+	}
+}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -109,3 +109,78 @@ func TestPackMissingSkillYAML(t *testing.T) {
 		t.Fatal("expected error for missing skill.yaml")
 	}
 }
+
+func TestCopyToAndBack(t *testing.T) {
+	// Pack into source store
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	srcStoreDir := t.TempDir()
+	srcClient, err := oci.NewClient(srcStoreDir)
+	if err != nil {
+		t.Fatalf("NewClient (src): %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = srcClient.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	// Copy to destination store
+	dstStoreDir := t.TempDir()
+	dstClient, err := oci.NewClient(dstStoreDir)
+	if err != nil {
+		t.Fatalf("NewClient (dst): %v", err)
+	}
+
+	ref := "test/test-skill:1.0.0-draft"
+	err = srcClient.CopyTo(ctx, ref, dstClient)
+	if err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+
+	// Verify the image exists in destination
+	images, err := dstClient.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image after copy, got %d", len(images))
+	}
+}
+
+func TestUnpack(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	// Unpack to output directory
+	outputDir := t.TempDir()
+	err = client.Unpack(ctx, "test/test-skill:1.0.0-draft", outputDir)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+
+	// Verify: auto-creates subdirectory named after skill
+	expectedFile := filepath.Join(outputDir, "test-skill", "skill.yaml")
+	if _, err := os.Stat(expectedFile); err != nil {
+		t.Errorf("expected %s to exist: %v", expectedFile, err)
+	}
+
+	promptFile := filepath.Join(outputDir, "test-skill", "SKILL.md")
+	if _, err := os.Stat(promptFile); err != nil {
+		t.Errorf("expected %s to exist: %v", promptFile, err)
+	}
+}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
 	"github.com/redhat-et/oci-skill-registry/pkg/oci"
 )
 
@@ -216,5 +217,84 @@ func TestInspect(t *testing.T) {
 	}
 	if result.LayerCount != 1 {
 		t.Errorf("layer count = %d, want 1", result.LayerCount)
+	}
+}
+
+func TestPromoteLocal(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	// Promote draft -> testing
+	err = client.PromoteLocal(ctx, "test/test-skill:1.0.0-draft", lifecycle.Testing)
+	if err != nil {
+		t.Fatalf("Promote to testing: %v", err)
+	}
+
+	// Verify new tag exists with correct status
+	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-rc")
+	if err != nil {
+		t.Fatalf("Inspect after promote to testing: %v", err)
+	}
+	if result.Status != "testing" {
+		t.Errorf("status = %q, want %q", result.Status, "testing")
+	}
+
+	// Promote testing -> published
+	err = client.PromoteLocal(ctx, "test/test-skill:1.0.0-rc", lifecycle.Published)
+	if err != nil {
+		t.Fatalf("Promote to published: %v", err)
+	}
+
+	// Verify published tag
+	result, err = client.Inspect(ctx, "test/test-skill:1.0.0")
+	if err != nil {
+		t.Fatalf("Inspect after publish: %v", err)
+	}
+	if result.Status != "published" {
+		t.Errorf("status = %q, want %q", result.Status, "published")
+	}
+
+	// Verify latest tag also exists
+	result, err = client.Inspect(ctx, "test/test-skill:latest")
+	if err != nil {
+		t.Fatalf("Inspect latest after publish: %v", err)
+	}
+	if result.Status != "published" {
+		t.Errorf("latest status = %q, want %q", result.Status, "published")
+	}
+}
+
+func TestPromoteInvalidTransition(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	// Try invalid transition: draft -> published
+	err = client.PromoteLocal(ctx, "test/test-skill:1.0.0-draft", lifecycle.Published)
+	if err == nil {
+		t.Fatal("expected error for invalid transition draft -> published")
 	}
 }

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -242,25 +242,23 @@ func createLayer(dir string) (*bytes.Buffer, godigest.Digest, error) {
 			return nil
 		}
 
+		if !info.Mode().IsRegular() && !info.IsDir() {
+			return nil
+		}
+
 		header, err := tar.FileInfoHeader(info, "")
 		if err != nil {
 			return fmt.Errorf("creating tar header for %s: %w", rel, err)
 		}
-		// Use forward-slash relative paths at root of archive.
 		header.Name = filepath.ToSlash(rel)
 
 		if err := tw.WriteHeader(header); err != nil {
 			return fmt.Errorf("writing tar header for %s: %w", rel, err)
 		}
 
-		if !info.IsDir() {
-			f, err := os.Open(path)
-			if err != nil {
-				return fmt.Errorf("opening %s: %w", rel, err)
-			}
-			defer f.Close()
-			if _, err := io.Copy(tw, f); err != nil {
-				return fmt.Errorf("copying %s: %w", rel, err)
+		if info.Mode().IsRegular() {
+			if err := copyFileToTar(tw, path, rel); err != nil {
+				return err
 			}
 		}
 
@@ -288,6 +286,18 @@ func createLayer(dir string) (*bytes.Buffer, godigest.Digest, error) {
 	}
 
 	return &gzBuf, uncompressedDigest, nil
+}
+
+func copyFileToTar(tw *tar.Writer, path, rel string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", rel, err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(tw, f); err != nil {
+		return fmt.Errorf("copying %s: %w", rel, err)
+	}
+	return nil
 }
 
 // buildImageConfig creates the OCI image config JSON (FROM scratch equivalent).

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -19,8 +19,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
-	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 // Pack reads a skill directory, validates the SkillCard, creates an OCI image,

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	_ "crypto/sha256" // Register SHA256 algorithm for go-digest.
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
 
 	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
 	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
@@ -64,7 +66,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		Digest:    layerDigest,
 		Size:      int64(len(layerBytes)),
 	}
-	if err := c.store.Push(ctx, layerDesc, bytes.NewReader(layerBytes)); err != nil {
+	if err := c.store.Push(ctx, layerDesc, bytes.NewReader(layerBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return ocispec.Descriptor{}, fmt.Errorf("pushing layer: %w", err)
 	}
 
@@ -79,7 +81,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		Digest:    configDigest,
 		Size:      int64(len(configBytes)),
 	}
-	if err := c.store.Push(ctx, configDesc, bytes.NewReader(configBytes)); err != nil {
+	if err := c.store.Push(ctx, configDesc, bytes.NewReader(configBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return ocispec.Descriptor{}, fmt.Errorf("pushing config: %w", err)
 	}
 
@@ -108,7 +110,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		Annotations: annotations,
 	}
 
-	if err := c.store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil {
+	if err := c.store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
 	}
 

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -128,9 +128,11 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 }
 
 // ListLocal reads the store's tags and returns image metadata from manifest annotations.
+// Deduplicates by digest so that "latest" aliases don't produce duplicate rows.
 func (c *Client) ListLocal() ([]LocalImage, error) {
 	ctx := context.Background()
 	var images []LocalImage
+	seen := make(map[string]bool)
 
 	err := c.store.Tags(ctx, "", func(tags []string) error {
 		for _, tag := range tags {
@@ -139,47 +141,17 @@ func (c *Client) ListLocal() ([]LocalImage, error) {
 				continue
 			}
 
-			// Fetch and parse the manifest to get annotations.
-			rc, err := c.store.Fetch(ctx, desc)
+			digestStr := desc.Digest.String()
+			if seen[digestStr] {
+				continue
+			}
+			seen[digestStr] = true
+
+			img, err := c.imageFromManifest(ctx, tag, desc)
 			if err != nil {
 				continue
 			}
-			manifestBytes, err := io.ReadAll(rc)
-			rc.Close()
-			if err != nil {
-				continue
-			}
-
-			var manifest ocispec.Manifest
-			if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-				continue
-			}
-
-			ann := manifest.Annotations
-			if ann == nil {
-				continue
-			}
-
-			// Extract name from vendor/title or the tag reference itself.
-			name := parseNameFromTag(tag)
-			version := ann[ocispec.AnnotationVersion]
-			status := ann[lifecycle.StatusAnnotation]
-			created := ann[ocispec.AnnotationCreated]
-
-			// Extract just the tag portion.
-			tagPart := ""
-			if idx := strings.LastIndex(tag, ":"); idx >= 0 {
-				tagPart = tag[idx+1:]
-			}
-
-			images = append(images, LocalImage{
-				Name:    name,
-				Version: version,
-				Tag:     tagPart,
-				Digest:  desc.Digest.String(),
-				Status:  status,
-				Created: created,
-			})
+			images = append(images, *img)
 		}
 		return nil
 	})
@@ -188,6 +160,44 @@ func (c *Client) ListLocal() ([]LocalImage, error) {
 	}
 
 	return images, nil
+}
+
+// imageFromManifest fetches a manifest and extracts LocalImage metadata.
+func (c *Client) imageFromManifest(ctx context.Context, tag string, desc ocispec.Descriptor) (*LocalImage, error) {
+	rc, err := c.store.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	manifestBytes, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, err
+	}
+
+	ann := manifest.Annotations
+	if ann == nil {
+		return nil, fmt.Errorf("no annotations")
+	}
+
+	name := parseNameFromTag(tag)
+	tagPart := ""
+	if idx := strings.LastIndex(tag, ":"); idx >= 0 {
+		tagPart = tag[idx+1:]
+	}
+
+	return &LocalImage{
+		Name:    name,
+		Version: ann[ocispec.AnnotationVersion],
+		Tag:     tagPart,
+		Digest:  desc.Digest.String(),
+		Status:  ann[lifecycle.StatusAnnotation],
+		Created: ann[ocispec.AnnotationCreated],
+	}, nil
 }
 
 // parseNameFromTag extracts the "namespace/name" portion from a tag reference

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -1,0 +1,293 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	godigest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+)
+
+// Pack reads a skill directory, validates the SkillCard, creates an OCI image,
+// and stores it in the local OCI layout. It returns the manifest descriptor.
+func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (ocispec.Descriptor, error) {
+	// 1. Read and parse skill.yaml.
+	skillPath := filepath.Join(skillDir, "skill.yaml")
+	f, err := os.Open(skillPath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("opening skill.yaml: %w", err)
+	}
+	defer f.Close()
+
+	sc, err := skillcard.Parse(f)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("parsing skill.yaml: %w", err)
+	}
+
+	// 2. Validate the SkillCard.
+	validationErrors, err := skillcard.Validate(sc)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("validating skill.yaml: %w", err)
+	}
+	if len(validationErrors) > 0 {
+		var msgs []string
+		for _, ve := range validationErrors {
+			msgs = append(msgs, ve.String())
+		}
+		return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
+	}
+
+	// 3. Create a tar.gz layer of all files in the directory.
+	layerBuf, uncompressedDigest, err := createLayer(skillDir)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("creating layer: %w", err)
+	}
+
+	// 4. Push the layer blob to the store.
+	layerBytes := layerBuf.Bytes()
+	layerDigest := godigest.FromBytes(layerBytes)
+	layerDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayerGzip,
+		Digest:    layerDigest,
+		Size:      int64(len(layerBytes)),
+	}
+	if err := c.store.Push(ctx, layerDesc, bytes.NewReader(layerBytes)); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing layer: %w", err)
+	}
+
+	// 5. Create and push the OCI image config.
+	configBytes, err := buildImageConfig(uncompressedDigest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("building image config: %w", err)
+	}
+	configDigest := godigest.FromBytes(configBytes)
+	configDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    configDigest,
+		Size:      int64(len(configBytes)),
+	}
+	if err := c.store.Push(ctx, configDesc, bytes.NewReader(configBytes)); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing config: %w", err)
+	}
+
+	// 6. Build annotations from SkillCard.
+	annotations := buildAnnotations(sc)
+
+	// 7. Create and push the OCI manifest.
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+		Annotations: annotations,
+	}
+
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("marshaling manifest: %w", err)
+	}
+
+	manifestDigest := godigest.FromBytes(manifestBytes)
+	manifestDesc := ocispec.Descriptor{
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Digest:      manifestDigest,
+		Size:        int64(len(manifestBytes)),
+		Annotations: annotations,
+	}
+
+	if err := c.store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
+	}
+
+	// 8. Tag as namespace/name:tag.
+	tag := opts.Tag
+	if tag == "" {
+		tag = lifecycle.TagForState(sc.Metadata.Version, lifecycle.Draft)
+	}
+	ref := fmt.Sprintf("%s/%s:%s", sc.Metadata.Namespace, sc.Metadata.Name, tag)
+	if err := c.store.Tag(ctx, manifestDesc, ref); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("tagging image: %w", err)
+	}
+
+	return manifestDesc, nil
+}
+
+// ListLocal reads the store's tags and returns image metadata from manifest annotations.
+func (c *Client) ListLocal() ([]LocalImage, error) {
+	ctx := context.Background()
+	var images []LocalImage
+
+	err := c.store.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			desc, err := c.store.Resolve(ctx, tag)
+			if err != nil {
+				continue
+			}
+
+			// Fetch and parse the manifest to get annotations.
+			rc, err := c.store.Fetch(ctx, desc)
+			if err != nil {
+				continue
+			}
+			manifestBytes, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				continue
+			}
+
+			var manifest ocispec.Manifest
+			if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+				continue
+			}
+
+			ann := manifest.Annotations
+			if ann == nil {
+				continue
+			}
+
+			// Extract name from vendor/title or the tag reference itself.
+			name := parseNameFromTag(tag)
+			version := ann[ocispec.AnnotationVersion]
+			status := ann[lifecycle.StatusAnnotation]
+			created := ann[ocispec.AnnotationCreated]
+
+			// Extract just the tag portion.
+			tagPart := ""
+			if idx := strings.LastIndex(tag, ":"); idx >= 0 {
+				tagPart = tag[idx+1:]
+			}
+
+			images = append(images, LocalImage{
+				Name:    name,
+				Version: version,
+				Tag:     tagPart,
+				Digest:  desc.Digest.String(),
+				Status:  status,
+				Created: created,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing tags: %w", err)
+	}
+
+	return images, nil
+}
+
+// parseNameFromTag extracts the "namespace/name" portion from a tag reference
+// like "namespace/name:tag".
+func parseNameFromTag(ref string) string {
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		return ref[:idx]
+	}
+	return ref
+}
+
+// createLayer builds a tar.gz archive of all files in dir, skipping hidden
+// directories. It returns the compressed buffer and the digest of the
+// uncompressed tar (for diff_ids in the image config).
+func createLayer(dir string) (*bytes.Buffer, godigest.Digest, error) {
+	// First, build the uncompressed tar to compute its digest.
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip the root directory entry itself.
+		if rel == "." {
+			return nil
+		}
+
+		// Skip hidden directories.
+		if info.IsDir() && strings.HasPrefix(info.Name(), ".") {
+			return filepath.SkipDir
+		}
+
+		// Skip hidden files.
+		if strings.HasPrefix(info.Name(), ".") {
+			return nil
+		}
+
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return fmt.Errorf("creating tar header for %s: %w", rel, err)
+		}
+		// Use forward-slash relative paths at root of archive.
+		header.Name = filepath.ToSlash(rel)
+
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("writing tar header for %s: %w", rel, err)
+		}
+
+		if !info.IsDir() {
+			f, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("opening %s: %w", rel, err)
+			}
+			defer f.Close()
+			if _, err := io.Copy(tw, f); err != nil {
+				return fmt.Errorf("copying %s: %w", rel, err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("walking skill directory: %w", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, "", fmt.Errorf("closing tar writer: %w", err)
+	}
+
+	// Compute digest of uncompressed tar for diff_ids.
+	uncompressedDigest := godigest.FromBytes(tarBuf.Bytes())
+
+	// Now gzip the tar.
+	var gzBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzBuf)
+	if _, err := io.Copy(gw, &tarBuf); err != nil {
+		return nil, "", fmt.Errorf("compressing layer: %w", err)
+	}
+	if err := gw.Close(); err != nil {
+		return nil, "", fmt.Errorf("closing gzip writer: %w", err)
+	}
+
+	return &gzBuf, uncompressedDigest, nil
+}
+
+// buildImageConfig creates the OCI image config JSON (FROM scratch equivalent).
+func buildImageConfig(diffID godigest.Digest) ([]byte, error) {
+	config := ocispec.Image{
+		Platform: ocispec.Platform{
+			Architecture: "amd64",
+			OS:           "linux",
+		},
+		RootFS: ocispec.RootFS{
+			Type:    "layers",
+			DiffIDs: []godigest.Digest{diffID},
+		},
+	}
+	return json.Marshal(config)
+}

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	_ "crypto/sha256" // Register SHA256 algorithm for go-digest.
 	"encoding/json"
 	"fmt"
 	"io"

--- a/pkg/oci/promote.go
+++ b/pkg/oci/promote.go
@@ -106,6 +106,9 @@ func promote(ctx context.Context, store promotableStore, ref string, to lifecycl
 	// 8. Compute the new tag and tag the manifest.
 	namespaceName := parseNameFromTag(ref)
 	version := manifest.Annotations[ocispec.AnnotationVersion]
+	if version == "" {
+		return fmt.Errorf("manifest missing %s annotation; cannot compute tag", ocispec.AnnotationVersion)
+	}
 	newTag := lifecycle.TagForState(version, to)
 
 	if newTag != "" {

--- a/pkg/oci/promote.go
+++ b/pkg/oci/promote.go
@@ -1,0 +1,127 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	godigest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+)
+
+// promotableStore is the minimal interface required for promoting a skill
+// image. Both oci.Store and remote.Repository satisfy this interface.
+type promotableStore interface {
+	Resolve(ctx context.Context, ref string) (ocispec.Descriptor, error)
+	Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error)
+	Push(ctx context.Context, desc ocispec.Descriptor, r io.Reader) error
+	Tag(ctx context.Context, desc ocispec.Descriptor, ref string) error
+}
+
+// PromoteLocal promotes a skill image within the local store by
+// transitioning it from its current lifecycle state to the target state.
+// Image layers remain unchanged; only the manifest annotation and tags
+// are updated.
+func (c *Client) PromoteLocal(ctx context.Context, ref string, to lifecycle.State) error {
+	return promote(ctx, c.store, ref, to)
+}
+
+// Promote promotes a skill on a remote registry by transitioning it
+// from its current lifecycle state to the target state.
+func (c *Client) Promote(ctx context.Context, ref string, to lifecycle.State, _ PromoteOptions) error {
+	repo, err := newRemoteRepository(ref)
+	if err != nil {
+		return fmt.Errorf("creating remote repository: %w", err)
+	}
+	return promote(ctx, repo, ref, to)
+}
+
+// promote performs the lifecycle state transition on any promotable store.
+func promote(ctx context.Context, store promotableStore, ref string, to lifecycle.State) error {
+	// 1. Resolve the reference to get the manifest descriptor.
+	desc, err := store.Resolve(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("resolving %s: %w", ref, err)
+	}
+
+	// 2. Fetch the manifest bytes.
+	rc, err := store.Fetch(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("fetching manifest for %s: %w", ref, err)
+	}
+	manifestBytes, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		return fmt.Errorf("reading manifest for %s: %w", ref, err)
+	}
+
+	// 3. Unmarshal the manifest.
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return fmt.Errorf("parsing manifest for %s: %w", ref, err)
+	}
+
+	// 4. Read the current status and validate the transition.
+	if manifest.Annotations == nil {
+		return fmt.Errorf("manifest has no annotations")
+	}
+
+	currentStatus := manifest.Annotations[lifecycle.StatusAnnotation]
+	from, err := lifecycle.ParseState(currentStatus)
+	if err != nil {
+		return fmt.Errorf("parsing current state %q: %w", currentStatus, err)
+	}
+
+	if !lifecycle.ValidTransition(from, to) {
+		return fmt.Errorf("invalid transition: %s -> %s", from, to)
+	}
+
+	// 5. Update the status annotation.
+	manifest.Annotations[lifecycle.StatusAnnotation] = string(to)
+
+	// 6. Marshal the updated manifest and compute the new digest.
+	updatedBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshaling updated manifest: %w", err)
+	}
+
+	newDigest := godigest.FromBytes(updatedBytes)
+	newDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    newDigest,
+		Size:      int64(len(updatedBytes)),
+	}
+
+	// 7. Push the new manifest to the store.
+	if err := store.Push(ctx, newDesc, bytes.NewReader(updatedBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return fmt.Errorf("pushing updated manifest: %w", err)
+	}
+
+	// 8. Compute the new tag and tag the manifest.
+	namespaceName := parseNameFromTag(ref)
+	version := manifest.Annotations[ocispec.AnnotationVersion]
+	newTag := lifecycle.TagForState(version, to)
+
+	if newTag != "" {
+		tagRef := fmt.Sprintf("%s:%s", namespaceName, newTag)
+		if err := store.Tag(ctx, newDesc, tagRef); err != nil {
+			return fmt.Errorf("tagging as %s: %w", tagRef, err)
+		}
+	}
+
+	// 9. For published state, also tag as "latest".
+	if to == lifecycle.Published {
+		latestRef := fmt.Sprintf("%s:latest", namespaceName)
+		if err := store.Tag(ctx, newDesc, latestRef); err != nil {
+			return fmt.Errorf("tagging as %s: %w", latestRef, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/oci/promote.go
+++ b/pkg/oci/promote.go
@@ -12,7 +12,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
 )
 
 // promotableStore is the minimal interface required for promoting a skill

--- a/pkg/oci/prune.go
+++ b/pkg/oci/prune.go
@@ -1,0 +1,100 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+)
+
+var stateRank = map[lifecycle.State]int{
+	lifecycle.Draft:      0,
+	lifecycle.Testing:    1,
+	lifecycle.Published:  2,
+	lifecycle.Deprecated: 3,
+	lifecycle.Archived:   4,
+}
+
+// PruneResult describes what was removed by a prune operation.
+type PruneResult struct {
+	Removed []LocalImage
+}
+
+// Prune removes local images that have been superseded by a
+// promotion. For each name+version group, it keeps only the image
+// with the highest lifecycle state and removes the rest.
+func (c *Client) Prune(ctx context.Context) (*PruneResult, error) {
+	images, err := c.listLocalWithTags()
+	if err != nil {
+		return nil, fmt.Errorf("listing images: %w", err)
+	}
+
+	type groupKey struct{ name, version string }
+	groups := make(map[groupKey][]LocalImage)
+	for _, img := range images {
+		k := groupKey{img.Name, img.Version}
+		groups[k] = append(groups[k], img)
+	}
+
+	var removed []LocalImage
+	for _, imgs := range groups {
+		if len(imgs) < 2 {
+			continue
+		}
+
+		maxRank := -1
+		for _, img := range imgs {
+			state, err := lifecycle.ParseState(img.Status)
+			if err != nil {
+				continue
+			}
+			if r := stateRank[state]; r > maxRank {
+				maxRank = r
+			}
+		}
+
+		for _, img := range imgs {
+			state, err := lifecycle.ParseState(img.Status)
+			if err != nil {
+				continue
+			}
+			if stateRank[state] < maxRank {
+				fullRef := img.Name + ":" + img.Tag
+				if err := c.store.Untag(ctx, fullRef); err != nil {
+					return nil, fmt.Errorf("untagging %s: %w", fullRef, err)
+				}
+				removed = append(removed, img)
+			}
+		}
+	}
+
+	return &PruneResult{Removed: removed}, nil
+}
+
+// listLocalWithTags is like ListLocal but does NOT deduplicate by
+// digest, so we can see all tags including "latest".
+func (c *Client) listLocalWithTags() ([]LocalImage, error) {
+	ctx := context.Background()
+	var images []LocalImage
+
+	err := c.store.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			desc, err := c.store.Resolve(ctx, tag)
+			if err != nil {
+				continue
+			}
+
+			img, err := c.imageFromManifest(ctx, tag, desc)
+			if err != nil {
+				continue
+			}
+			images = append(images, *img)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}

--- a/pkg/oci/prune.go
+++ b/pkg/oci/prune.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/lifecycle"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
 )
 
 var stateRank = map[lifecycle.State]int{

--- a/pkg/oci/prune.go
+++ b/pkg/oci/prune.go
@@ -24,7 +24,7 @@ type PruneResult struct {
 // promotion. For each name+version group, it keeps only the image
 // with the highest lifecycle state and removes the rest.
 func (c *Client) Prune(ctx context.Context) (*PruneResult, error) {
-	images, err := c.listLocalWithTags()
+	images, err := c.listLocalWithTags(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing images: %w", err)
 	}
@@ -73,8 +73,7 @@ func (c *Client) Prune(ctx context.Context) (*PruneResult, error) {
 
 // listLocalWithTags is like ListLocal but does NOT deduplicate by
 // digest, so we can see all tags including "latest".
-func (c *Client) listLocalWithTags() ([]LocalImage, error) {
-	ctx := context.Background()
+func (c *Client) listLocalWithTags(ctx context.Context) ([]LocalImage, error) {
 	var images []LocalImage
 
 	err := c.store.Tags(ctx, "", func(tags []string) error {

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -1,0 +1,168 @@
+package oci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+// Pull copies an image from a remote registry into the local store.
+// If opts.OutputDir is set, the image is also unpacked into that directory.
+func (c *Client) Pull(ctx context.Context, ref string, opts PullOptions) (ocispec.Descriptor, error) {
+	repoRef := ref
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		repoRef = ref[:idx]
+	}
+
+	repo, err := remote.NewRepository(repoRef)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("creating remote repository: %w", err)
+	}
+
+	tag := tagFromRef(ref)
+	desc, err := oras.Copy(ctx, repo, tag, c.store, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("pulling %s: %w", ref, err)
+	}
+
+	// Also tag with the full ref so ListLocal can find it.
+	if err := c.store.Tag(ctx, desc, ref); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("tagging pulled image: %w", err)
+	}
+
+	if opts.OutputDir != "" {
+		if err := c.Unpack(ctx, ref, opts.OutputDir); err != nil {
+			return desc, fmt.Errorf("unpacking after pull: %w", err)
+		}
+	}
+
+	return desc, nil
+}
+
+// Unpack extracts skill files from a stored image into a directory.
+// It creates a subdirectory named after the skill (the last path segment
+// of the ref before the :tag) and extracts all layers into it.
+func (c *Client) Unpack(ctx context.Context, ref string, outputDir string) error {
+	// 1. Resolve the ref in the store.
+	desc, err := c.store.Resolve(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("resolving %s: %w", ref, err)
+	}
+
+	// 2. Fetch and parse the manifest.
+	rc, err := c.store.Fetch(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("fetching manifest: %w", err)
+	}
+	manifestBytes, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		return fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return fmt.Errorf("parsing manifest: %w", err)
+	}
+
+	// 3. Extract skill name from the ref (last segment before :tag).
+	skillName := skillNameFromRef(ref)
+
+	// 4. Create outputDir/skillName/ directory.
+	targetDir := filepath.Join(outputDir, skillName)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	// 5. For each layer, fetch, decompress gzip, extract tar entries.
+	for _, layer := range manifest.Layers {
+		if err := extractLayer(ctx, c, layer, targetDir); err != nil {
+			return fmt.Errorf("extracting layer %s: %w", layer.Digest, err)
+		}
+	}
+
+	return nil
+}
+
+// skillNameFromRef extracts the skill name from a reference like
+// "namespace/name:tag" -- it returns "name".
+func skillNameFromRef(ref string) string {
+	// Strip tag.
+	name := ref
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		name = ref[:idx]
+	}
+	// Take the last path segment.
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+// extractLayer fetches a layer from the store, decompresses it, and extracts
+// tar entries into targetDir with path traversal protection.
+func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targetDir string) error {
+	rc, err := c.store.Fetch(ctx, layer)
+	if err != nil {
+		return fmt.Errorf("fetching layer: %w", err)
+	}
+	defer rc.Close()
+
+	gz, err := gzip.NewReader(rc)
+	if err != nil {
+		return fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		// PATH TRAVERSAL PROTECTION: ensure the entry stays within targetDir.
+		cleanName := filepath.Clean(header.Name)
+		target := filepath.Join(targetDir, cleanName)
+		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) &&
+			target != filepath.Clean(targetDir) {
+			return fmt.Errorf("tar entry %q escapes target directory", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("creating directory %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			// Ensure parent directory exists.
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("creating parent directory for %s: %w", target, err)
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return fmt.Errorf("creating file %s: %w", target, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return fmt.Errorf("writing file %s: %w", target, err)
+			}
+			f.Close()
+		}
+	}
+
+	return nil
+}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -109,6 +109,20 @@ func skillNameFromRef(ref string) string {
 	return name
 }
 
+// sanitizeTarPath validates that a tar entry name stays within the target
+// directory, preventing path traversal (Zip Slip) attacks.
+func sanitizeTarPath(name string, targetDir string) (string, error) {
+	target := filepath.Join(targetDir, filepath.Clean(name))
+	rel, err := filepath.Rel(targetDir, target)
+	if err != nil {
+		return "", fmt.Errorf("tar entry %q: %w", name, err)
+	}
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		return "", fmt.Errorf("tar entry %q escapes target directory", name)
+	}
+	return target, nil
+}
+
 // extractLayer fetches a layer from the store, decompresses it, and extracts
 // tar entries into targetDir with path traversal protection.
 func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targetDir string) error {
@@ -134,12 +148,9 @@ func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targ
 			return fmt.Errorf("reading tar entry: %w", err)
 		}
 
-		// PATH TRAVERSAL PROTECTION: ensure the entry stays within targetDir.
-		cleanName := filepath.Clean(header.Name)
-		target := filepath.Join(targetDir, cleanName)
-		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) &&
-			target != filepath.Clean(targetDir) {
-			return fmt.Errorf("tar entry %q escapes target directory", header.Name)
+		target, err := sanitizeTarPath(header.Name, targetDir)
+		if err != nil {
+			return err
 		}
 
 		switch header.Typeflag {
@@ -148,7 +159,6 @@ func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targ
 				return fmt.Errorf("creating directory %s: %w", target, err)
 			}
 		case tar.TypeReg:
-			// Ensure parent directory exists.
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return fmt.Errorf("creating parent directory for %s: %w", target, err)
 			}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -24,14 +24,9 @@ func (c *Client) Pull(ctx context.Context, ref string, opts PullOptions) (ocispe
 	}
 
 	_, tag := splitRefTag(ref)
-	desc, err := oras.Copy(ctx, repo, tag, c.store, tag, oras.DefaultCopyOptions)
+	desc, err := oras.Copy(ctx, repo, tag, c.store, ref, oras.DefaultCopyOptions)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("pulling %s: %w", ref, err)
-	}
-
-	// Also tag with the full ref so ListLocal can find it.
-	if err := c.store.Tag(ctx, desc, ref); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("tagging pulled image: %w", err)
 	}
 
 	if opts.OutputDir != "" {

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -13,23 +13,17 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/registry/remote"
 )
 
 // Pull copies an image from a remote registry into the local store.
 // If opts.OutputDir is set, the image is also unpacked into that directory.
 func (c *Client) Pull(ctx context.Context, ref string, opts PullOptions) (ocispec.Descriptor, error) {
-	repoRef := ref
-	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
-		repoRef = ref[:idx]
-	}
-
-	repo, err := remote.NewRepository(repoRef)
+	repo, err := newRemoteRepository(ref)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("creating remote repository: %w", err)
 	}
 
-	tag := tagFromRef(ref)
+	_, tag := splitRefTag(ref)
 	desc, err := oras.Copy(ctx, repo, tag, c.store, tag, oras.DefaultCopyOptions)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("pulling %s: %w", ref, err)
@@ -123,6 +117,22 @@ func sanitizeTarPath(name string, targetDir string) (string, error) {
 	return target, nil
 }
 
+func clampDirMode(mode int64) os.FileMode {
+	m := os.FileMode(mode) & 0o755
+	if m == 0 {
+		m = 0o755
+	}
+	return m
+}
+
+func clampFileMode(mode int64) os.FileMode {
+	m := os.FileMode(mode) & 0o644
+	if m == 0 {
+		m = 0o644
+	}
+	return m
+}
+
 // extractLayer fetches a layer from the store, decompresses it, and extracts
 // tar entries into targetDir with path traversal protection.
 func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targetDir string) error {
@@ -155,14 +165,14 @@ func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targ
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
+			if err := os.MkdirAll(target, clampDirMode(header.Mode)); err != nil {
 				return fmt.Errorf("creating directory %s: %w", target, err)
 			}
 		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return fmt.Errorf("creating parent directory for %s: %w", target, err)
 			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, clampFileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("creating file %s: %w", target, err)
 			}

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -16,7 +16,7 @@ func (c *Client) Push(ctx context.Context, ref string, _ PushOptions) error {
 		return fmt.Errorf("creating remote repository: %w", err)
 	}
 
-	tag := tagFromRef(ref)
+	_, tag := splitRefTag(ref)
 	_, err = oras.Copy(ctx, c.store, ref, repo, tag, oras.DefaultCopyOptions)
 	if err != nil {
 		return fmt.Errorf("pushing %s: %w", ref, err)
@@ -28,7 +28,7 @@ func (c *Client) Push(ctx context.Context, ref string, _ PushOptions) error {
 // CopyTo copies an image from this client's store to another client's store.
 // This is useful for testing without a real remote registry.
 func (c *Client) CopyTo(ctx context.Context, ref string, dst *Client) error {
-	tag := tagFromRef(ref)
+	_, tag := splitRefTag(ref)
 	_, err := oras.Copy(ctx, c.store, ref, dst.store, tag, oras.DefaultCopyOptions)
 	if err != nil {
 		return fmt.Errorf("copying %s: %w", ref, err)
@@ -40,18 +40,27 @@ func (c *Client) CopyTo(ctx context.Context, ref string, dst *Client) error {
 // newRemoteRepository creates a remote.Repository from a full reference string
 // like "registry.example.com/namespace/name:tag".
 func newRemoteRepository(ref string) (*remote.Repository, error) {
-	// Strip tag for repository creation.
-	repoRef := ref
-	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
-		repoRef = ref[:idx]
-	}
+	repoRef, _ := splitRefTag(ref)
 	return remote.NewRepository(repoRef)
 }
 
-// tagFromRef extracts the tag portion after the last ":" in a reference.
-func tagFromRef(ref string) string {
-	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
-		return ref[idx+1:]
+// splitRefTag splits an OCI reference into repository and tag.
+// Handles registry ports correctly: localhost:5000/ns/name:tag splits
+// at the tag colon (after the last /), not the port colon.
+func splitRefTag(ref string) (repo, tag string) {
+	// Find the last slash to isolate the name:tag portion.
+	lastSlash := strings.LastIndex(ref, "/")
+	if lastSlash < 0 {
+		// No slash: the whole ref might be name:tag.
+		if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+			return ref[:idx], ref[idx+1:]
+		}
+		return ref, ""
 	}
-	return ref
+	// Look for a colon only after the last slash.
+	tail := ref[lastSlash+1:]
+	if idx := strings.LastIndex(tail, ":"); idx >= 0 {
+		return ref[:lastSlash+1+idx], tail[idx+1:]
+	}
+	return ref, ""
 }

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -1,0 +1,57 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+// Push copies an image from the local OCI store to a remote registry.
+func (c *Client) Push(ctx context.Context, ref string, _ PushOptions) error {
+	repo, err := newRemoteRepository(ref)
+	if err != nil {
+		return fmt.Errorf("creating remote repository: %w", err)
+	}
+
+	tag := tagFromRef(ref)
+	_, err = oras.Copy(ctx, c.store, ref, repo, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		return fmt.Errorf("pushing %s: %w", ref, err)
+	}
+
+	return nil
+}
+
+// CopyTo copies an image from this client's store to another client's store.
+// This is useful for testing without a real remote registry.
+func (c *Client) CopyTo(ctx context.Context, ref string, dst *Client) error {
+	tag := tagFromRef(ref)
+	_, err := oras.Copy(ctx, c.store, ref, dst.store, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		return fmt.Errorf("copying %s: %w", ref, err)
+	}
+
+	return nil
+}
+
+// newRemoteRepository creates a remote.Repository from a full reference string
+// like "registry.example.com/namespace/name:tag".
+func newRemoteRepository(ref string) (*remote.Repository, error) {
+	// Strip tag for repository creation.
+	repoRef := ref
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		repoRef = ref[:idx]
+	}
+	return remote.NewRepository(repoRef)
+}
+
+// tagFromRef extracts the tag portion after the last ":" in a reference.
+func tagFromRef(ref string) string {
+	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		return ref[idx+1:]
+	}
+	return ref
+}

--- a/pkg/skillcard/skillcard.go
+++ b/pkg/skillcard/skillcard.go
@@ -1,0 +1,75 @@
+package skillcard
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+type SkillCard struct {
+	APIVersion string      `yaml:"apiVersion" json:"api_version"`
+	Kind       string      `yaml:"kind" json:"kind"`
+	Metadata   Metadata    `yaml:"metadata" json:"metadata"`
+	Provenance *Provenance `yaml:"provenance,omitempty" json:"provenance,omitempty"`
+	Spec       *Spec       `yaml:"spec,omitempty" json:"spec,omitempty"`
+}
+
+type Metadata struct {
+	Name          string   `yaml:"name" json:"name"`
+	DisplayName   string   `yaml:"display-name,omitempty" json:"display_name,omitempty"`
+	Namespace     string   `yaml:"namespace" json:"namespace"`
+	Version       string   `yaml:"version" json:"version"`
+	Description   string   `yaml:"description" json:"description"`
+	License       string   `yaml:"license,omitempty" json:"license,omitempty"`
+	Compatibility string   `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
+	Tags          []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Authors       []Author `yaml:"authors,omitempty" json:"authors,omitempty"`
+	AllowedTools  string   `yaml:"allowed-tools,omitempty" json:"allowed_tools,omitempty"`
+}
+
+type Author struct {
+	Name  string `yaml:"name" json:"name"`
+	Email string `yaml:"email,omitempty" json:"email,omitempty"`
+}
+
+type Provenance struct {
+	Source string `yaml:"source,omitempty" json:"source,omitempty"`
+	Commit string `yaml:"commit,omitempty" json:"commit,omitempty"`
+	Path   string `yaml:"path,omitempty" json:"path,omitempty"`
+}
+
+type Spec struct {
+	Prompt       string       `yaml:"prompt,omitempty" json:"prompt,omitempty"`
+	Examples     []Example    `yaml:"examples,omitempty" json:"examples,omitempty"`
+	Dependencies []Dependency `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+}
+
+type Example struct {
+	Input  string `yaml:"input" json:"input"`
+	Output string `yaml:"output" json:"output"`
+}
+
+type Dependency struct {
+	Name    string `yaml:"name" json:"name"`
+	Version string `yaml:"version" json:"version"`
+}
+
+func Parse(r io.Reader) (*SkillCard, error) {
+	var sc SkillCard
+	dec := yaml.NewDecoder(r)
+	dec.KnownFields(true)
+	if err := dec.Decode(&sc); err != nil {
+		return nil, fmt.Errorf("parsing skillcard YAML: %w", err)
+	}
+	return &sc, nil
+}
+
+func Serialize(sc *SkillCard, w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	if err := enc.Encode(sc); err != nil {
+		return fmt.Errorf("serializing skillcard: %w", err)
+	}
+	return enc.Close()
+}

--- a/pkg/skillcard/skillcard_test.go
+++ b/pkg/skillcard/skillcard_test.go
@@ -2,6 +2,7 @@ package skillcard_test
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -82,5 +83,133 @@ func TestSerialize(t *testing.T) {
 	}
 	if roundtrip.Metadata.Version != sc.Metadata.Version {
 		t.Errorf("roundtrip version = %q, want %q", roundtrip.Metadata.Version, sc.Metadata.Version)
+	}
+}
+
+func TestValidateValid(t *testing.T) {
+	sc, err := skillcard.Parse(strings.NewReader(validSkillYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	errs, err := skillcard.Validate(sc)
+	if err != nil {
+		t.Fatalf("validate error: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no validation errors, got %v", errs)
+	}
+}
+
+func TestValidateMissingRequiredFields(t *testing.T) {
+	yaml := `apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: test
+`
+	sc, err := skillcard.Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	errs, err := skillcard.Validate(sc)
+	if err != nil {
+		t.Fatalf("validate error: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Fatal("expected validation errors for missing required fields")
+	}
+	for _, required := range []string{"namespace", "version", "description"} {
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e.Field, required) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected error for missing %q, got errors: %v", required, errs)
+		}
+	}
+}
+
+func TestValidateInvalidName(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"valid", "hello-world", false},
+		{"valid single char", "a", false},
+		{"uppercase", "Hello", true},
+		{"spaces", "hello world", true},
+		{"leading hyphen", "-hello", true},
+		{"trailing hyphen", "hello-", true},
+		{"consecutive hyphens", "hello--world", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := fmt.Sprintf(`apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: %s
+  namespace: test
+  version: 1.0.0
+  description: test
+`, tt.value)
+			sc, err := skillcard.Parse(strings.NewReader(yaml))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			errs, _ := skillcard.Validate(sc)
+			hasErr := len(errs) > 0
+			if hasErr != tt.wantErr {
+				t.Errorf("name=%q: hasErr=%v, wantErr=%v, errs=%v",
+					tt.value, hasErr, tt.wantErr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateInvalidSemver(t *testing.T) {
+	yaml := `apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: test
+  namespace: test
+  version: not-semver
+  description: test
+`
+	sc, err := skillcard.Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	errs, _ := skillcard.Validate(sc)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Field, "version") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected semver validation error, got: %v", errs)
+	}
+}
+
+func TestValidateWrongAPIVersion(t *testing.T) {
+	yaml := `apiVersion: wrong/v1
+kind: SkillCard
+metadata:
+  name: test
+  namespace: test
+  version: 1.0.0
+  description: test
+`
+	sc, err := skillcard.Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	errs, _ := skillcard.Validate(sc)
+	if len(errs) == 0 {
+		t.Fatal("expected error for wrong apiVersion")
 	}
 }

--- a/pkg/skillcard/skillcard_test.go
+++ b/pkg/skillcard/skillcard_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
-const validSkillYAML = `apiVersion: skills.redhat.io/v1alpha1
+const validSkillYAML = `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: hello-world
@@ -32,8 +32,8 @@ func TestParse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if sc.APIVersion != "skills.redhat.io/v1alpha1" {
-		t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skills.redhat.io/v1alpha1")
+	if sc.APIVersion != "skillimage.io/v1alpha1" {
+		t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skillimage.io/v1alpha1")
 	}
 	if sc.Kind != "SkillCard" {
 		t.Errorf("kind = %q, want %q", sc.Kind, "SkillCard")
@@ -101,7 +101,7 @@ func TestValidateValid(t *testing.T) {
 }
 
 func TestValidateMissingRequiredFields(t *testing.T) {
-	yaml := `apiVersion: skills.redhat.io/v1alpha1
+	yaml := `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test
@@ -147,7 +147,7 @@ func TestValidateInvalidName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			yaml := fmt.Sprintf(`apiVersion: skills.redhat.io/v1alpha1
+			yaml := fmt.Sprintf(`apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: %s
@@ -170,7 +170,7 @@ metadata:
 }
 
 func TestValidateInvalidSemver(t *testing.T) {
-	yaml := `apiVersion: skills.redhat.io/v1alpha1
+	yaml := `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: test

--- a/pkg/skillcard/skillcard_test.go
+++ b/pkg/skillcard/skillcard_test.go
@@ -1,0 +1,86 @@
+package skillcard_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/redhat-et/oci-skill-registry/pkg/skillcard"
+)
+
+const validSkillYAML = `apiVersion: skills.redhat.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: hello-world
+  namespace: examples
+  version: 1.0.0
+  display-name: "Hello World"
+  description: A simple example skill.
+  license: Apache-2.0
+  tags:
+    - example
+  authors:
+    - name: Test Author
+      email: test@example.com
+spec:
+  prompt: SKILL.md
+`
+
+func TestParse(t *testing.T) {
+	sc, err := skillcard.Parse(strings.NewReader(validSkillYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc.APIVersion != "skills.redhat.io/v1alpha1" {
+		t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skills.redhat.io/v1alpha1")
+	}
+	if sc.Kind != "SkillCard" {
+		t.Errorf("kind = %q, want %q", sc.Kind, "SkillCard")
+	}
+	if sc.Metadata.Name != "hello-world" {
+		t.Errorf("name = %q, want %q", sc.Metadata.Name, "hello-world")
+	}
+	if sc.Metadata.Namespace != "examples" {
+		t.Errorf("namespace = %q, want %q", sc.Metadata.Namespace, "examples")
+	}
+	if sc.Metadata.Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", sc.Metadata.Version, "1.0.0")
+	}
+	if sc.Metadata.DisplayName != "Hello World" {
+		t.Errorf("display-name = %q, want %q", sc.Metadata.DisplayName, "Hello World")
+	}
+	if len(sc.Metadata.Authors) != 1 || sc.Metadata.Authors[0].Name != "Test Author" {
+		t.Errorf("authors = %v, want [{Test Author test@example.com}]", sc.Metadata.Authors)
+	}
+	if sc.Spec == nil || sc.Spec.Prompt != "SKILL.md" {
+		t.Errorf("spec.prompt = %v, want SKILL.md", sc.Spec)
+	}
+}
+
+func TestParseInvalidYAML(t *testing.T) {
+	_, err := skillcard.Parse(strings.NewReader("not: [valid: yaml"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestSerialize(t *testing.T) {
+	sc, err := skillcard.Parse(strings.NewReader(validSkillYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := skillcard.Serialize(sc, &buf); err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	roundtrip, err := skillcard.Parse(&buf)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if roundtrip.Metadata.Name != sc.Metadata.Name {
+		t.Errorf("roundtrip name = %q, want %q", roundtrip.Metadata.Name, sc.Metadata.Name)
+	}
+	if roundtrip.Metadata.Version != sc.Metadata.Version {
+		t.Errorf("roundtrip version = %q, want %q", roundtrip.Metadata.Version, sc.Metadata.Version)
+	}
+}

--- a/pkg/skillcard/validate.go
+++ b/pkg/skillcard/validate.go
@@ -1,0 +1,115 @@
+package skillcard
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/redhat-et/oci-skill-registry/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+var compiledSchema *jsonschema.Schema
+
+func init() {
+	// Load and compile the JSON Schema once at package init time
+	var schemaDoc any
+	if err := json.Unmarshal(schemas.SkillCardV1, &schemaDoc); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal embedded schema: %v", err))
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("skillcard-v1.json", schemaDoc); err != nil {
+		panic(fmt.Sprintf("failed to add schema resource: %v", err))
+	}
+
+	var err error
+	compiledSchema, err = compiler.Compile("skillcard-v1.json")
+	if err != nil {
+		panic(fmt.Sprintf("failed to compile schema: %v", err))
+	}
+}
+
+// ValidationError represents a single validation error with field path and message.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e ValidationError) String() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// Validate validates a SkillCard against the JSON Schema and additional semantic rules.
+// Returns a slice of ValidationError for any validation failures.
+func Validate(sc *SkillCard) ([]ValidationError, error) {
+	var errors []ValidationError
+
+	// Marshal SkillCard to YAML, then unmarshal to map[string]any to preserve kebab-case keys
+	yamlBytes, err := yaml.Marshal(sc)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling skillcard for validation: %w", err)
+	}
+
+	var doc map[string]any
+	if err := yaml.Unmarshal(yamlBytes, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshaling skillcard for validation: %w", err)
+	}
+
+	// Validate against JSON Schema
+	if err := compiledSchema.Validate(doc); err != nil {
+		// Extract validation errors
+		if validationErr, ok := err.(*jsonschema.ValidationError); ok {
+			errors = append(errors, collectValidationErrors(validationErr)...)
+		} else {
+			return nil, fmt.Errorf("unexpected validation error type: %w", err)
+		}
+	}
+
+	// Additional semver validation
+	if sc.Metadata.Version != "" {
+		if _, err := semver.StrictNewVersion(sc.Metadata.Version); err != nil {
+			errors = append(errors, ValidationError{
+				Field:   "metadata.version",
+				Message: fmt.Sprintf("invalid semantic version: %v", err),
+			})
+		}
+	}
+
+	return errors, nil
+}
+
+// collectValidationErrors recursively collects leaf validation errors from the jsonschema ValidationError tree.
+func collectValidationErrors(ve *jsonschema.ValidationError) []ValidationError {
+	var errors []ValidationError
+
+	// If there are causes, recurse into them
+	if len(ve.Causes) > 0 {
+		for _, cause := range ve.Causes {
+			errors = append(errors, collectValidationErrors(cause)...)
+		}
+		return errors
+	}
+
+	// This is a leaf error - extract field path and message
+	fieldPath := strings.Join(ve.InstanceLocation, ".")
+	if fieldPath == "" {
+		fieldPath = "(root)"
+	}
+
+	message := ve.Error()
+	// Clean up the error message to remove the instance location prefix
+	// The error format is typically: "instanceLocation: message"
+	if idx := strings.Index(message, ": "); idx != -1 {
+		message = message[idx+2:]
+	}
+
+	errors = append(errors, ValidationError{
+		Field:   fieldPath,
+		Message: message,
+	})
+
+	return errors
+}

--- a/pkg/skillcard/validate.go
+++ b/pkg/skillcard/validate.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/redhat-et/oci-skill-registry/schemas"
+	"github.com/redhat-et/skillimage/schemas"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
 )

--- a/schemas/embed.go
+++ b/schemas/embed.go
@@ -1,0 +1,6 @@
+package schemas
+
+import _ "embed"
+
+//go:embed skillcard-v1.json
+var SkillCardV1 []byte

--- a/schemas/skillcard-v1.json
+++ b/schemas/skillcard-v1.json
@@ -9,7 +9,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "const": "skills.redhat.io/v1alpha1"
+      "const": "skillimage.io/v1alpha1"
     },
     "kind": {
       "type": "string",

--- a/schemas/skillcard-v1.json
+++ b/schemas/skillcard-v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://skills.redhat.io/schemas/skillcard-v1.json",
+  "$id": "https://skillimage.io/schemas/skillcard-v1.json",
   "title": "SkillCard",
   "description": "Schema for AI agent skill metadata",
   "type": "object",

--- a/schemas/skillcard-v1.json
+++ b/schemas/skillcard-v1.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://skills.redhat.io/schemas/skillcard-v1.json",
+  "title": "SkillCard",
+  "description": "Schema for AI agent skill metadata",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata"],
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "type": "string",
+      "const": "skills.redhat.io/v1alpha1"
+    },
+    "kind": {
+      "type": "string",
+      "const": "SkillCard"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "namespace", "version", "description"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*(/[a-z0-9]+(-[a-z0-9]+)*)*$"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display-name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "license": {
+          "type": "string"
+        },
+        "compatibility": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "email": { "type": "string" }
+            }
+          }
+        },
+        "allowed-tools": {
+          "type": "string"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source": { "type": "string" },
+        "commit": { "type": "string" },
+        "path": { "type": "string" }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "prompt": { "type": "string" },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "input": { "type": "string" },
+              "output": { "type": "string" }
+            }
+          }
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "version": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements `skillctl` CLI with 10 commands: `validate`, `pack`, `push`, `pull`, `inspect`, `list`/`ls`, `promote`, `install`, `prune`
- Skills are packaged as standard OCI images (not ORAS artifacts) — compatible with podman, skopeo, crane, and K8s ImageVolumes
- Lifecycle state machine: draft → testing → published → deprecated → archived
- Status tracked via OCI manifest annotations (image content stays immutable across promotions)
- Library-first architecture: core logic in `pkg/` (skillcard, oci, lifecycle), CLI is a thin consumer
- `install` command deploys skills to agent-specific directories (Claude, Cursor, Windsurf, OpenCode, OpenClaw)

## Key design decisions

- **OCI images, not ORAS artifacts**: ensures compatibility with standard container tooling and K8s ImageVolumes
- **Status in annotations**: promotion changes the manifest digest but not the layer digest — content is immutable
- **apiVersion `skillimage.io/v1alpha1`**: project-owned domain, vendor-neutral
- **`-testing` tag suffix** instead of `-rc`: clearer for our audience, valid semver pre-release label

## Test plan

- [ ] `make test` — all unit tests pass (skillcard, lifecycle, oci packages)
- [ ] `make lint` — golangci-lint clean
- [ ] Full workflow: `validate` → `pack` → `list` → `inspect` → `promote` (draft→testing→published) → `prune`
- [ ] `install --target claude` deploys skill to `~/.claude/skills/`
- [ ] `pull` with local-looking ref shows helpful error pointing to `install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `skillctl` command-line tool for creating, validating, and managing AI agent skills as OCI images.
  * Added skill lifecycle management with state transitions: draft → testing → published → deprecated → archived.
  * Implemented commands for pack, push, pull, inspect, promote, install, list, validate, and prune operations.

* **Documentation**
  * Added comprehensive README documenting the OCI Skill Registry framework and usage workflows.

* **Examples**
  * Added hello-world example skill demonstrating skill creation format and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->