### PR TITLE
feat: add GoReleaser and CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go test ./... -v
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 linters-settings:
   errcheck:
     exclude-functions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+linters-settings:
+  errcheck:
+    exclude-functions:
+      - fmt.Fprintf
+      - fmt.Fprintln
+      - fmt.Fprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,9 @@
 version: "2"
 
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - fmt.Fprint
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Fprint

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,49 @@
+version: 2
+
+project_name: skillctl
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - main: ./cmd/skillctl
+    binary: skillctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  github:
+    owner: redhat-et
+    name: skillimage

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -33,7 +33,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sc, err := skillcard.Parse(f)
 	if err != nil {

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -24,7 +24,7 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest: %w", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	manifestBytes, err := io.ReadAll(rc)
 	if err != nil {

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -32,7 +32,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("opening skill.yaml: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sc, err := skillcard.Parse(f)
 	if err != nil {
@@ -168,8 +168,8 @@ func (c *Client) imageFromManifest(ctx context.Context, tag string, desc ocispec
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = rc.Close() }()
 	manifestBytes, err := io.ReadAll(rc)
-	rc.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func copyFileToTar(tw *tar.Writer, path, rel string) error {
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", rel, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := io.Copy(tw, f); err != nil {
 		return fmt.Errorf("copying %s: %w", rel, err)
 	}

--- a/pkg/oci/promote.go
+++ b/pkg/oci/promote.go
@@ -55,8 +55,8 @@ func promote(ctx context.Context, store promotableStore, ref string, to lifecycl
 	if err != nil {
 		return fmt.Errorf("fetching manifest for %s: %w", ref, err)
 	}
+	defer func() { _ = rc.Close() }()
 	manifestBytes, err := io.ReadAll(rc)
-	rc.Close()
 	if err != nil {
 		return fmt.Errorf("reading manifest for %s: %w", ref, err)
 	}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -53,8 +53,8 @@ func (c *Client) Unpack(ctx context.Context, ref string, outputDir string) error
 	if err != nil {
 		return fmt.Errorf("fetching manifest: %w", err)
 	}
+	defer func() { _ = rc.Close() }()
 	manifestBytes, err := io.ReadAll(rc)
-	rc.Close()
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
 	}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -128,6 +128,18 @@ func clampFileMode(mode int64) os.FileMode {
 	return m
 }
 
+func extractFile(target string, r io.Reader, mode os.FileMode) error {
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("creating file %s: %w", target, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := io.Copy(f, r); err != nil {
+		return fmt.Errorf("writing file %s: %w", target, err)
+	}
+	return nil
+}
+
 // extractLayer fetches a layer from the store, decompresses it, and extracts
 // tar entries into targetDir with path traversal protection.
 func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targetDir string) error {
@@ -135,13 +147,13 @@ func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targ
 	if err != nil {
 		return fmt.Errorf("fetching layer: %w", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	gz, err := gzip.NewReader(rc)
 	if err != nil {
 		return fmt.Errorf("creating gzip reader: %w", err)
 	}
-	defer gz.Close()
+	defer func() { _ = gz.Close() }()
 
 	tr := tar.NewReader(gz)
 	for {
@@ -167,15 +179,9 @@ func extractLayer(ctx context.Context, c *Client, layer ocispec.Descriptor, targ
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return fmt.Errorf("creating parent directory for %s: %w", target, err)
 			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, clampFileMode(header.Mode))
-			if err != nil {
-				return fmt.Errorf("creating file %s: %w", target, err)
+			if err := extractFile(target, tr, clampFileMode(header.Mode)); err != nil {
+				return err
 			}
-			if _, err := io.Copy(f, tr); err != nil {
-				f.Close()
-				return fmt.Errorf("writing file %s: %w", target, err)
-			}
-			f.Close()
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` for cross-platform release builds (linux/darwin/windows, amd64/arm64)
- Add release workflow (triggers on `v*` tags, uses goreleaser-action v6)
- Add CI workflow (tests + golangci-lint on PRs and main pushes)

## To cut a release

```bash
git tag v0.1.0
git push origin v0.1.0
```

GoReleaser creates a GitHub release with binaries, checksums, and changelog.

## Test plan

- [x] `goreleaser check` passes locally
- [ ] CI workflow runs on this PR
- [ ] First release after merge: `git tag v0.1.0 && git push origin v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)