### PR TITLE
feat: catalog metadata annotations, tag command, and remote inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,30 @@ bin/skillctl pull quay.io/myorg/hello-world:1.0.0 -o ./skills/
 Authentication uses your existing `~/.docker/config.json` or
 Podman's `auth.json` -- no separate login needed.
 
+### Inspect with standard tools
+
+Skill images are standard OCI images. You can inspect metadata
+from any registry without downloading the image:
+
+```bash
+# View all metadata annotations (no image download)
+skopeo inspect docker://quay.io/myorg/hello-world:1.0.0
+
+# Get just the skill tags
+skopeo inspect docker://quay.io/myorg/hello-world:1.0.0 \
+  | jq -r '.Annotations["io.skillimage.tags"]'
+# → ["example","getting-started"]
+
+# Get lifecycle status
+skopeo inspect docker://quay.io/myorg/hello-world:1.0.0 \
+  | jq -r '.Annotations["io.skillimage.status"]'
+# → published
+```
+
+This works because all skill metadata is stored in OCI manifest
+annotations, not inside the image layers. A catalog UI or CI
+pipeline can read skill metadata with a single manifest fetch.
+
 ## Testing
 
 ```bash

--- a/docs/superpowers/plans/2026-04-20-catalog-metadata-annotations.md
+++ b/docs/superpowers/plans/2026-04-20-catalog-metadata-annotations.md
@@ -1,0 +1,570 @@
+# Catalog metadata annotations implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three new OCI manifest annotations (`io.skillimage.tags`,
+`io.skillimage.compatibility`, `io.skillimage.wordcount`) so the
+catalog UI can build skill cards from manifest metadata without
+downloading layer blobs.
+
+**Architecture:** Extend `buildAnnotations()` to accept a word count
+and emit three new custom annotations. Compute SKILL.md word count in
+`Pack()` before creating the layer. Extend `InspectResult` and the
+CLI inspect command to surface the new fields.
+
+**Tech Stack:** Go, oras-go, OCI image spec, Cobra
+
+**Spec:**
+`docs/superpowers/specs/2026-04-20-catalog-metadata-annotations-design.md`
+
+---
+
+## File structure
+
+| File | Role |
+| ---- | ---- |
+| `pkg/oci/annotations.go` | Annotation constants + `buildAnnotations()` |
+| `pkg/oci/pack.go` | SKILL.md word count, passes count to annotations |
+| `pkg/oci/client.go` | `InspectResult` struct |
+| `pkg/oci/inspect.go` | Reads new annotations into `InspectResult` |
+| `internal/cli/inspect.go` | Displays new fields |
+| `pkg/oci/oci_test.go` | Tests for new annotations and edge cases |
+
+No new files are created. All changes are to existing files.
+
+---
+
+## Task 1: Add annotation constants and extend buildAnnotations
+
+**Files:**
+- Modify: `pkg/oci/annotations.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pkg/oci/oci_test.go`:
+
+```go
+func TestAnnotationsIncludeTags(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: annotated-skill
+  namespace: test
+  version: 2.0.0
+  description: Skill with tags and compat.
+  tags:
+    - kubernetes
+    - debugging
+  compatibility: claude-3.5-sonnet
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("one two three four five"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/annotated-skill:2.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.Tags != `["kubernetes","debugging"]` {
+		t.Errorf("tags = %q, want %q", result.Tags, `["kubernetes","debugging"]`)
+	}
+	if result.Compatibility != "claude-3.5-sonnet" {
+		t.Errorf("compatibility = %q, want %q", result.Compatibility, "claude-3.5-sonnet")
+	}
+	if result.WordCount != "5" {
+		t.Errorf("wordcount = %q, want %q", result.WordCount, "5")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./pkg/oci/ -run TestAnnotationsIncludeTags -v`
+
+Expected: compilation error — `InspectResult` has no fields `Tags`,
+`Compatibility`, `WordCount`.
+
+- [ ] **Step 3: Add annotation key constants to annotations.go**
+
+Add below the existing imports in `pkg/oci/annotations.go`:
+
+```go
+const (
+	AnnotationTags          = "io.skillimage.tags"
+	AnnotationCompatibility = "io.skillimage.compatibility"
+	AnnotationWordCount     = "io.skillimage.wordcount"
+)
+```
+
+- [ ] **Step 4: Extend buildAnnotations signature and add new annotations**
+
+Change the `buildAnnotations` function in `pkg/oci/annotations.go` to
+accept `wordCount int` and emit the three new annotations:
+
+```go
+func buildAnnotations(sc *skillcard.SkillCard, wordCount int) map[string]string {
+	ann := make(map[string]string)
+
+	// Title: use display-name if set, otherwise name.
+	title := sc.Metadata.DisplayName
+	if title == "" {
+		title = sc.Metadata.Name
+	}
+	ann[ocispec.AnnotationTitle] = title
+
+	// Description: first 256 characters.
+	desc := sc.Metadata.Description
+	if len(desc) > 256 {
+		desc = desc[:256]
+		for len(desc) > 0 && !utf8.ValidString(desc) {
+			desc = desc[:len(desc)-1]
+		}
+	}
+	ann[ocispec.AnnotationDescription] = desc
+
+	// Version.
+	ann[ocispec.AnnotationVersion] = sc.Metadata.Version
+
+	// Authors: comma-separated "name <email>".
+	if len(sc.Metadata.Authors) > 0 {
+		var parts []string
+		for _, a := range sc.Metadata.Authors {
+			if a.Email != "" {
+				parts = append(parts, fmt.Sprintf("%s <%s>", a.Name, a.Email))
+			} else {
+				parts = append(parts, a.Name)
+			}
+		}
+		ann[ocispec.AnnotationAuthors] = strings.Join(parts, ", ")
+	}
+
+	// License.
+	if sc.Metadata.License != "" {
+		ann[ocispec.AnnotationLicenses] = sc.Metadata.License
+	}
+
+	// Vendor: namespace.
+	ann[ocispec.AnnotationVendor] = sc.Metadata.Namespace
+
+	// Created: RFC 3339 timestamp.
+	ann[ocispec.AnnotationCreated] = time.Now().UTC().Format(time.RFC3339)
+
+	// Provenance fields.
+	if sc.Provenance != nil {
+		if sc.Provenance.Source != "" {
+			ann[ocispec.AnnotationSource] = sc.Provenance.Source
+		}
+		if sc.Provenance.Commit != "" {
+			ann[ocispec.AnnotationRevision] = sc.Provenance.Commit
+		}
+	}
+
+	// Lifecycle status: initial state is always draft.
+	ann[lifecycle.StatusAnnotation] = string(lifecycle.Draft)
+
+	// Tags: JSON-encoded string array.
+	if len(sc.Metadata.Tags) > 0 {
+		tagsJSON, err := json.Marshal(sc.Metadata.Tags)
+		if err == nil {
+			ann[AnnotationTags] = string(tagsJSON)
+		}
+	}
+
+	// Compatibility.
+	if sc.Metadata.Compatibility != "" {
+		ann[AnnotationCompatibility] = sc.Metadata.Compatibility
+	}
+
+	// Word count of SKILL.md.
+	if wordCount > 0 {
+		ann[AnnotationWordCount] = strconv.Itoa(wordCount)
+	}
+
+	return ann
+}
+```
+
+Add `"encoding/json"` and `"strconv"` to the import block.
+
+- [ ] **Step 5: Verify annotations.go compiles**
+
+Run: `go build ./pkg/oci/`
+
+Expected: compilation error in `pack.go` because `buildAnnotations`
+now requires two arguments. That is expected — we fix it next.
+
+- [ ] **Step 6: Add word count computation to Pack**
+
+In `pkg/oci/pack.go`, in the `Pack` method, add SKILL.md word count
+logic between step 2 (validation) and step 3 (createLayer). Then
+update the `buildAnnotations` call to pass `wordCount`:
+
+After the validation block (after the `if len(validationErrors) > 0`
+block), add:
+
+```go
+	// 2b. Count words in SKILL.md if present.
+	var wordCount int
+	skillMDPath := filepath.Join(skillDir, "SKILL.md")
+	if data, err := os.ReadFile(skillMDPath); err == nil {
+		wordCount = len(strings.Fields(string(data)))
+	}
+```
+
+Then change line 89 from:
+
+```go
+	annotations := buildAnnotations(sc)
+```
+
+to:
+
+```go
+	annotations := buildAnnotations(sc, wordCount)
+```
+
+- [ ] **Step 7: Verify the package compiles**
+
+Run: `go build ./pkg/oci/`
+
+Expected: clean build, no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/oci/annotations.go pkg/oci/pack.go pkg/oci/oci_test.go
+git commit -s -m "feat(oci): add catalog metadata annotations
+
+Add io.skillimage.tags, io.skillimage.compatibility, and
+io.skillimage.wordcount annotations. Compute SKILL.md word count
+during pack using strings.Fields()."
+```
+
+---
+
+## Task 2: Extend InspectResult and inspect logic
+
+**Files:**
+- Modify: `pkg/oci/client.go`
+- Modify: `pkg/oci/inspect.go`
+
+- [ ] **Step 1: Add fields to InspectResult**
+
+In `pkg/oci/client.go`, add three fields to `InspectResult`:
+
+```go
+type InspectResult struct {
+	Name          string
+	DisplayName   string
+	Version       string
+	Status        string
+	Description   string
+	Authors       string
+	License       string
+	Tags          string
+	Compatibility string
+	WordCount     string
+	Digest        string
+	Created       string
+	MediaType     string
+	Size          int64
+	LayerCount    int
+}
+```
+
+- [ ] **Step 2: Read new annotations in Inspect**
+
+In `pkg/oci/inspect.go`, in the `Inspect` method, add three lines
+after the existing annotation reads (after the `created` line):
+
+```go
+	tags := ann[AnnotationTags]
+	compatibility := ann[AnnotationCompatibility]
+	wordCount := ann[AnnotationWordCount]
+```
+
+And add them to the returned `InspectResult`:
+
+```go
+	return &InspectResult{
+		Name:          name,
+		DisplayName:   displayName,
+		Version:       version,
+		Status:        status,
+		Description:   description,
+		Authors:       authors,
+		License:       license,
+		Tags:          tags,
+		Compatibility: compatibility,
+		WordCount:     wordCount,
+		Digest:        desc.Digest.String(),
+		Created:       created,
+		MediaType:     desc.MediaType,
+		Size:          totalSize,
+		LayerCount:    len(manifest.Layers),
+	}, nil
+```
+
+- [ ] **Step 3: Run the failing test from Task 1**
+
+Run: `go test ./pkg/oci/ -run TestAnnotationsIncludeTags -v`
+
+Expected: PASS — tags, compatibility, and wordcount all match.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `make test`
+
+Expected: all tests pass, including the existing ones (which use
+`writeTestSkill` which has no tags/compatibility — those annotations
+are simply absent, and existing tests don't check for them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/oci/client.go pkg/oci/inspect.go
+git commit -s -m "feat(oci): surface tags, compatibility, wordcount in inspect
+
+Extend InspectResult with three new fields and read them from
+manifest annotations."
+```
+
+---
+
+## Task 3: Display new fields in CLI inspect command
+
+**Files:**
+- Modify: `internal/cli/inspect.go`
+
+- [ ] **Step 1: Add display lines for new fields**
+
+In `internal/cli/inspect.go`, in `runInspect`, add after the
+`License` block (before the blank line `fmt.Fprintln(out)`):
+
+```go
+	if result.Tags != "" {
+		fmt.Fprintf(out, "Tags:         %s\n", result.Tags)
+	}
+	if result.Compatibility != "" {
+		fmt.Fprintf(out, "Compat:       %s\n", result.Compatibility)
+	}
+	if result.WordCount != "" {
+		fmt.Fprintf(out, "Word Count:   %s\n", result.WordCount)
+	}
+```
+
+- [ ] **Step 2: Build and manually verify**
+
+Run: `make build`
+
+Then test with the hello-world example:
+
+```bash
+bin/skillctl pack examples/hello-world
+bin/skillctl inspect examples/hello-world:1.0.0-draft
+```
+
+Expected output includes:
+
+```
+Tags:         ["example","getting-started"]
+Word Count:   18
+```
+
+(No `Compat:` line since hello-world has no `compatibility` field.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/inspect.go
+git commit -s -m "feat(cli): display tags, compatibility, word count in inspect"
+```
+
+---
+
+## Task 4: Edge case tests
+
+**Files:**
+- Modify: `pkg/oci/oci_test.go`
+
+- [ ] **Step 1: Test — no tags, no compatibility, no SKILL.md**
+
+```go
+func TestAnnotationsOmittedWhenEmpty(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: minimal-skill
+  namespace: test
+  version: 1.0.0
+  description: Minimal skill with no optional fields.
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/minimal-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.Tags != "" {
+		t.Errorf("tags should be empty, got %q", result.Tags)
+	}
+	if result.Compatibility != "" {
+		t.Errorf("compatibility should be empty, got %q", result.Compatibility)
+	}
+	if result.WordCount != "" {
+		t.Errorf("wordcount should be empty, got %q", result.WordCount)
+	}
+}
+```
+
+- [ ] **Step 2: Test — empty SKILL.md**
+
+```go
+func TestAnnotationsEmptySKILLmd(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: empty-md-skill
+  namespace: test
+  version: 1.0.0
+  description: Skill with empty SKILL.md.
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/empty-md-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.WordCount != "" {
+		t.Errorf("wordcount should be empty for empty SKILL.md, got %q", result.WordCount)
+	}
+}
+```
+
+- [ ] **Step 3: Run all edge case tests**
+
+Run: `go test ./pkg/oci/ -run "TestAnnotations" -v`
+
+Expected: all three annotation tests pass (`TestAnnotationsIncludeTags`,
+`TestAnnotationsOmittedWhenEmpty`, `TestAnnotationsEmptySKILLmd`).
+
+- [ ] **Step 4: Run full suite and lint**
+
+Run: `make test && make lint`
+
+Expected: all pass, no lint issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/oci/oci_test.go
+git commit -s -m "test(oci): add edge case tests for catalog annotations
+
+Cover: no tags/compat/SKILL.md, empty SKILL.md produces no wordcount."
+```
+
+---
+
+## Task 5: Update example skill and final verification
+
+**Files:**
+- Modify: `examples/hello-world/skill.yaml`
+
+- [ ] **Step 1: Add compatibility field to example skill**
+
+In `examples/hello-world/skill.yaml`, add after `tags`:
+
+```yaml
+  compatibility: claude-3.5-sonnet
+```
+
+- [ ] **Step 2: Full end-to-end test**
+
+```bash
+make build && make test && make lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Manual smoke test**
+
+```bash
+bin/skillctl pack examples/hello-world
+bin/skillctl inspect examples/hello-world:1.0.0-draft
+```
+
+Expected output includes all three new fields:
+
+```
+Tags:         ["example","getting-started"]
+Compat:       claude-3.5-sonnet
+Word Count:   18
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/hello-world/skill.yaml
+git commit -s -m "docs: add compatibility field to hello-world example"
+```

--- a/docs/superpowers/specs/2026-04-20-catalog-metadata-annotations-design.md
+++ b/docs/superpowers/specs/2026-04-20-catalog-metadata-annotations-design.md
@@ -1,0 +1,208 @@
+# Catalog metadata annotations
+
+## Problem
+
+The catalog UI pulls the full tar.gz layer blob (up to 10MB) for every
+skill image during listing, just to extract `skill.yaml` for a handful
+of fields not present in manifest annotations. This makes catalog page
+load slow and bandwidth-heavy.
+
+The missing fields are: `tags`, `compatibility`, and a content
+complexity indicator (word count of SKILL.md).
+
+## Decision
+
+Enrich existing OCI manifest annotations with three new custom keys.
+The frontend can then build the full catalog card from the manifest
+alone, eliminating all blob downloads during listing.
+
+### Alternatives considered
+
+| Approach | Verdict |
+| -------- | ------- |
+| ORAS referrer artifact | Requires Referrers API (OCI 1.1), two fetches, lifecycle sync overhead |
+| Separate metadata layer | Still requires blob fetch, breaks single-layer design, complicates ImageVolume mounts |
+
+Both are overkill for approximately 200 bytes of additional metadata.
+
+## Design
+
+### New annotations
+
+Three new keys in the `io.skillimage.*` namespace, set during
+`skillctl pack`:
+
+| Annotation key | Value format | Source | Example |
+| -------------- | ------------ | ------ | ------- |
+| `io.skillimage.tags` | JSON string array | `metadata.tags` | `["kubernetes","debugging"]` |
+| `io.skillimage.compatibility` | Plain string | `metadata.compatibility` | `"claude-3.5-sonnet"` |
+| `io.skillimage.wordcount` | Integer as string | SKILL.md word count | `"342"` |
+
+All three are optional. If the source field is empty or SKILL.md does
+not exist, the annotation is omitted. This matches the existing
+pattern for `license`, `source`, and `revision`.
+
+### Complete annotation map after this change
+
+| OCI annotation | Source |
+| -------------- | ------ |
+| `org.opencontainers.image.title` | `metadata.display-name` or `metadata.name` |
+| `org.opencontainers.image.description` | `metadata.description` (first 256 chars) |
+| `org.opencontainers.image.version` | `metadata.version` |
+| `org.opencontainers.image.authors` | `metadata.authors[]` comma-separated |
+| `org.opencontainers.image.licenses` | `metadata.license` |
+| `org.opencontainers.image.vendor` | `metadata.namespace` |
+| `org.opencontainers.image.created` | Pack timestamp (RFC 3339) |
+| `org.opencontainers.image.source` | `provenance.source` |
+| `org.opencontainers.image.revision` | `provenance.commit` |
+| `io.skillimage.status` | Lifecycle state (set to `draft` at pack) |
+| `io.skillimage.tags` | **New** -- `metadata.tags` as JSON array |
+| `io.skillimage.compatibility` | **New** -- `metadata.compatibility` |
+| `io.skillimage.wordcount` | **New** -- SKILL.md word count |
+
+### Word count computation
+
+Computed during `Pack()` in `pkg/oci/pack.go`, before calling
+`createLayer()`. The pack function reads `SKILL.md` from the skill
+directory (if it exists), counts words using `strings.Fields()` (which
+splits on any whitespace and handles soft line wraps, multiple spaces,
+tabs, and blank lines), and passes the count to `buildAnnotations()`.
+
+The signature of `buildAnnotations()` expands to accept the count:
+
+```go
+func buildAnnotations(sc *skillcard.SkillCard, wordCount int) map[string]string
+```
+
+If SKILL.md does not exist or is empty, `wordCount` is 0 and the
+`io.skillimage.wordcount` annotation is omitted.
+
+The frontend owns the display mapping (e.g., word count to
+"Simple"/"Medium"/"Complex" labels). The backend stores the raw
+number.
+
+## Files changed
+
+| File | Change |
+| ---- | ------ |
+| `pkg/oci/annotations.go` | Add `io.skillimage.tags`, `io.skillimage.compatibility`, `io.skillimage.wordcount`; accept `wordCount int` parameter |
+| `pkg/oci/pack.go` | Count SKILL.md words during directory walk; pass count to `buildAnnotations()` |
+| `pkg/oci/inspect.go` | Read and return new annotations |
+| `pkg/oci/client.go` | Add `Tags`, `Compatibility`, `WordCount` fields to `InspectResult` |
+| `internal/cli/inspect.go` | Display new fields in `skillctl inspect` output |
+| `pkg/oci/oci_test.go` | Test that new annotations are set correctly, including edge cases (no tags, no SKILL.md, empty SKILL.md) |
+
+## What does not change
+
+- **Promote flow** (`pkg/oci/promote.go`): copies all manifest
+  annotations forward. New annotations come along automatically.
+- **Image format**: single tar.gz layer, same media types, same config.
+- **SkillCard schema**: no changes to `skill.yaml` or `schemas/skillcard-v1.json`.
+- **Backwards compatibility**: images packed before this change lack the
+  three new annotations. Consumers treat missing annotations as
+  absent/unknown, which is the existing pattern.
+
+## Frontend impact
+
+After this change, the catalog listing flow becomes:
+
+1. `GET /v2/_catalog` -- repository names
+2. Per repo: `GET /v2/<repo>/tags/list` + `GET /v2/<repo>/manifests/<tag>` -- all catalog card data
+3. No blob download needed for listing
+
+The individual skill detail page (showing full SKILL.md content) still
+requires a layer pull, but that is a single on-demand fetch, not N
+fetches at page load.
+
+## Frontend integration guide
+
+After this change, the catalog listing no longer needs blob
+downloads. The manifest annotations contain everything needed for
+the skill card.
+
+### Annotation keys and value formats
+
+| Annotation key | Type | Parse as | Example value |
+| -------------- | ---- | -------- | ------------- |
+| `org.opencontainers.image.title` | string | display name | `"Kubernetes Troubleshooter"` |
+| `org.opencontainers.image.description` | string | truncated to 256 chars | `"Diagnoses pod failures..."` |
+| `org.opencontainers.image.version` | string | semver | `"1.2.0"` |
+| `org.opencontainers.image.authors` | string | comma-separated `name <email>` | `"Jane <j@x.com>, Bob"` |
+| `org.opencontainers.image.licenses` | string | SPDX expression | `"Apache-2.0"` |
+| `org.opencontainers.image.vendor` | string | namespace | `"acme/skills"` |
+| `org.opencontainers.image.created` | string | RFC 3339 timestamp | `"2026-04-20T14:30:00Z"` |
+| `io.skillimage.status` | string | lifecycle state enum | `"published"` |
+| `io.skillimage.tags` | string | `JSON.parse()` to `string[]` | `'["kubernetes","debugging"]'` |
+| `io.skillimage.compatibility` | string | plain string | `"claude-3.5-sonnet"` |
+| `io.skillimage.wordcount` | string | `parseInt()` to number | `"342"` |
+
+### Handling missing annotations
+
+All `io.skillimage.*` annotations are optional. Images packed before
+this change will not have `tags`, `compatibility`, or `wordcount`.
+Treat missing keys as absent/unknown:
+
+```
+tags:          missing → show no tags (empty array)
+compatibility: missing → show no badge or "Any"
+wordcount:     missing → hide complexity indicator
+```
+
+### Recommended catalog listing flow
+
+```
+1. GET /v2/_catalog                          → repo names
+2. GET /v2/<repo>/tags/list                  → tag names
+3. GET /v2/<repo>/manifests/<tag>            → manifest JSON
+   Accept: application/vnd.oci.image.manifest.v1+json
+4. Read manifest.annotations                → all catalog card data
+```
+
+No blob downloads needed. For the skill detail page (full SKILL.md
+content), continue fetching the layer blob on demand for the
+individual skill.
+
+## Standards compliance: building with podman/buildah
+
+The image `skillctl pack` produces is a standard OCI image,
+reproducible with `podman build` or `buildah` without any custom
+tooling.
+
+**Containerfile + podman:**
+
+```dockerfile
+FROM scratch
+COPY skill.yaml SKILL.md /
+```
+
+```bash
+podman build \
+  --annotation "org.opencontainers.image.title=K8s Troubleshooter" \
+  --annotation "org.opencontainers.image.version=1.0.0" \
+  --annotation "io.skillimage.status=draft" \
+  --annotation 'io.skillimage.tags=["kubernetes","debugging"]' \
+  -t registry.example.com/skills/k8s-troubleshoot:1.0.0-draft .
+```
+
+**buildah (no Containerfile):**
+
+```bash
+ctr=$(buildah from scratch)
+buildah copy "$ctr" ./my-skill/ /
+buildah config \
+  --annotation "org.opencontainers.image.title=K8s Troubleshooter" \
+  --annotation "io.skillimage.status=draft" \
+  "$ctr"
+buildah commit "$ctr" registry.example.com/skills/k8s-troubleshoot:1.0.0-draft
+```
+
+**What `skillctl pack` adds on top of standard tools:**
+
+| Concern | podman/buildah (manual) | skillctl (automatic) |
+| ------- | ---------------------- | -------------------- |
+| Containerfile | Write yourself | Not needed |
+| Word count | `wc -w SKILL.md` | Computed during pack |
+| Annotations | Type each flag | Auto-mapped from `skill.yaml` |
+| SkillCard validation | None | JSON Schema validation |
+| Lifecycle state | Manual | Enforces `draft` initial state |
+| Version format | Unchecked | Validates semver |

--- a/examples/document-reviewer/SKILL.md
+++ b/examples/document-reviewer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: document-reviewer
+description: Reviews technical documents for clarity, completeness, and consistency. Identifies gaps, ambiguities, and structural issues. Use when asked to review, critique, or provide feedback on a document before sharing or publishing.
+license: Apache-2.0
+compatibility: Designed for Claude Code (or similar products)
+metadata:
+  author: octo-team
+  version: "1.0"
+---
+
+You are a technical document reviewer.
+
+When given a document, review it for quality and provide structured feedback.
+
+Organize findings by severity:
+
+- **Critical**: Missing information that would cause misunderstanding or incorrect implementation. Contradictions between sections. Undefined terms used in key decisions.
+- **Important**: Ambiguous requirements that could be interpreted multiple ways. Missing context that readers will need. Sections that reference undocumented assumptions.
+- **Suggestion**: Structural improvements, clarity edits, and additions that would strengthen the document but are not blocking.
+
+For each finding, provide:
+
+1. What the issue is (one sentence).
+2. Where it occurs (quote or reference the relevant section).
+3. A concrete fix or question to resolve it.
+
+Follow these rules:
+
+- Review for the document's stated audience. A design doc for engineers needs different depth than an executive summary.
+- Flag inconsistencies between sections. If the overview says one thing and the details say another, call it out.
+- Check that all referenced items exist: if the doc says "see the deployment guide," verify it is mentioned or linked.
+- Do not rewrite the document. Provide targeted feedback that the author can act on.
+- If the document is well-written, say so. Not every review needs a long list of issues.
+- Limit feedback to the 5-7 most impactful findings. A review with 30 minor items is noise.

--- a/examples/document-reviewer/skill.yaml
+++ b/examples/document-reviewer/skill.yaml
@@ -1,0 +1,33 @@
+apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: document-reviewer
+  namespace: examples
+  version: 1.0.0
+  display-name: "Document Reviewer"
+  description: >
+    Reviews technical documents for clarity, completeness, and
+    consistency. Identifies gaps, ambiguities, and structural
+    issues. Provides actionable feedback organized by severity.
+  license: Apache-2.0
+  tags:
+    - review
+    - documents
+    - writing
+    - quality
+  compatibility: claude-3.5-sonnet
+  authors:
+    - name: OCTO Team
+      email: octo@redhat.com
+spec:
+  prompt: SKILL.md
+  examples:
+    - input: "Review this API design doc before I send it to the team."
+      output: |
+        **Critical:** The error response schema is undefined for
+        the /users endpoint. Consumers cannot handle failures
+        without this. **Important:** The rate limiting section
+        references "standard limits" without specifying values.
+        **Suggestion:** Add a versioning strategy section -- the
+        doc describes breaking changes but not how clients
+        migrate.

--- a/examples/document-summarizer/SKILL.md
+++ b/examples/document-summarizer/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: document-summarizer
+description: Summarizes technical documents, RFCs, design specs, and long-form content into structured, actionable summaries with key decisions, open questions, and action items. Use when asked to summarize, condense, or extract highlights from a document.
+license: Apache-2.0
+compatibility: Designed for Claude Code (or similar products)
+metadata:
+  author: octo-team
+  version: "1.0"
+---
+
+You are a document summarizer for technical teams.
+
+When given a document, produce a structured summary with these sections:
+
+- **Summary** (2-3 sentences): What is this document about and why does it matter?
+- **Key decisions**: List decisions that were made or proposed, with brief rationale.
+- **Open questions**: Unresolved items that need input or discussion.
+- **Action items**: Concrete next steps with owners if mentioned.
+- **Risk factors**: Anything that could block progress or cause problems.
+
+Follow these rules:
+
+- Preserve technical accuracy. Do not simplify domain-specific terms.
+- Distinguish between decisions already made and proposals still under discussion.
+- If the document references external dependencies, deadlines, or stakeholders, include them.
+- Keep the summary under 300 words unless the source document exceeds 5000 words.
+- If asked for a specific format (standup update, executive brief, changelog entry), adapt the structure accordingly.
+- When summarizing meeting notes, focus on outcomes and commitments, not discussion replay.

--- a/examples/document-summarizer/skill.yaml
+++ b/examples/document-summarizer/skill.yaml
@@ -1,0 +1,30 @@
+apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: document-summarizer
+  namespace: examples
+  version: 1.0.0
+  display-name: "Document Summarizer"
+  description: >
+    Summarizes technical documents, RFCs, design specs, and
+    long-form content into structured, actionable summaries
+    with key decisions, open questions, and action items.
+  license: Apache-2.0
+  tags:
+    - summarization
+    - documents
+    - productivity
+  compatibility: claude-3.5-sonnet
+  authors:
+    - name: OCTO Team
+      email: octo@redhat.com
+spec:
+  prompt: SKILL.md
+  examples:
+    - input: "Summarize this design doc for the team standup."
+      output: |
+        **Summary:** Proposes migrating auth from session tokens to
+        short-lived JWTs. **Key decision:** RS256 over HS256 for
+        multi-service verification. **Open questions:** Token
+        refresh strategy for long-running CLI sessions.
+        **Action items:** Security review by Friday.

--- a/examples/hello-world/SKILL.md
+++ b/examples/hello-world/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: hello-world
+description: A simple example skill that greets the user. Use this as a template for creating new skills.
+license: Apache-2.0
+metadata:
+  author: octo-team
+  version: "1.0"
+---
+
 You are a friendly greeter skill.
 
 When the user says hello, greet them warmly and ask how you

--- a/examples/hello-world/skill.yaml
+++ b/examples/hello-world/skill.yaml
@@ -12,6 +12,7 @@ metadata:
   tags:
     - example
     - getting-started
+  compatibility: claude-3.5-sonnet
   authors:
     - name: OCTO Team
       email: octo@redhat.com

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -24,7 +24,13 @@ func runInspect(cmd *cobra.Command, ref string) error {
 		return err
 	}
 
-	result, err := client.Inspect(context.Background(), ref)
+	ctx := context.Background()
+
+	// Try local first, fall back to remote.
+	result, err := client.Inspect(ctx, ref)
+	if err != nil {
+		result, err = client.InspectRemote(ctx, ref)
+	}
 	if err != nil {
 		return fmt.Errorf("inspecting %s: %w", ref, err)
 	}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -45,6 +45,15 @@ func runInspect(cmd *cobra.Command, ref string) error {
 	if result.License != "" {
 		fmt.Fprintf(out, "License:      %s\n", result.License)
 	}
+	if result.Tags != "" {
+		fmt.Fprintf(out, "Tags:         %s\n", result.Tags)
+	}
+	if result.Compatibility != "" {
+		fmt.Fprintf(out, "Compat:       %s\n", result.Compatibility)
+	}
+	if result.WordCount != "" {
+		fmt.Fprintf(out, "Word Count:   %s\n", result.WordCount)
+	}
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "OCI Image:\n")
 	fmt.Fprintf(out, "  Digest:     %s\n", result.Digest)

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -27,12 +28,13 @@ func runInspect(cmd *cobra.Command, ref string) error {
 	ctx := context.Background()
 
 	// Try local first, fall back to remote.
-	result, err := client.Inspect(ctx, ref)
-	if err != nil {
-		result, err = client.InspectRemote(ctx, ref)
-	}
-	if err != nil {
-		return fmt.Errorf("inspecting %s: %w", ref, err)
+	result, localErr := client.Inspect(ctx, ref)
+	if localErr != nil {
+		var remoteErr error
+		result, remoteErr = client.InspectRemote(ctx, ref)
+		if remoteErr != nil {
+			return fmt.Errorf("inspecting %s: %w", ref, errors.Join(localErr, remoteErr))
+		}
 	}
 
 	out := cmd.OutOrStdout()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,6 +22,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newPromoteCmd())
 	cmd.AddCommand(newInstallCmd())
+	cmd.AddCommand(newTagCmd())
 	cmd.AddCommand(newPruneCmd())
 
 	return cmd

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newTagCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "tag <source> <target>",
+		Short: "Create a new reference for a local skill image",
+		Long: `Create an additional tag for an existing local skill image.
+
+Works like "docker tag" or "podman tag": the target reference
+points to the same image as the source. Use this to set a
+remote registry path before pushing.
+
+Example:
+  skillctl tag examples/hello-world:1.0.0-draft \
+    quay.io/myorg/hello-world:1.0.0-draft
+  skillctl push quay.io/myorg/hello-world:1.0.0-draft`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTag(cmd, args[0], args[1])
+		},
+	}
+}
+
+func runTag(cmd *cobra.Command, src, dst string) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	if err := client.Tag(context.Background(), src, dst); err != nil {
+		return fmt.Errorf("tagging: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Tagged %s as %s\n", src, dst)
+	return nil
+}

--- a/pkg/oci/annotations.go
+++ b/pkg/oci/annotations.go
@@ -83,7 +83,7 @@ func buildAnnotations(sc *skillcard.SkillCard, wordCount int) map[string]string 
 	// Lifecycle status: initial state is always draft.
 	ann[lifecycle.StatusAnnotation] = string(lifecycle.Draft)
 
-	// Tags: JSON-encoded string array.
+	// Tags: JSON-encoded string array. Marshal of []string cannot fail in practice.
 	if len(sc.Metadata.Tags) > 0 {
 		tagsJSON, err := json.Marshal(sc.Metadata.Tags)
 		if err == nil {

--- a/pkg/oci/annotations.go
+++ b/pkg/oci/annotations.go
@@ -1,7 +1,9 @@
 package oci
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -12,9 +14,16 @@ import (
 	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
+// Custom annotation keys for catalog metadata.
+const (
+	AnnotationTags          = "io.skillimage.tags"
+	AnnotationCompatibility = "io.skillimage.compatibility"
+	AnnotationWordCount     = "io.skillimage.wordcount"
+)
+
 // buildAnnotations maps SkillCard fields to standard OCI annotation keys
 // and the custom skillimage status annotation.
-func buildAnnotations(sc *skillcard.SkillCard) map[string]string {
+func buildAnnotations(sc *skillcard.SkillCard, wordCount int) map[string]string {
 	ann := make(map[string]string)
 
 	// Title: use display-name if set, otherwise name.
@@ -73,6 +82,24 @@ func buildAnnotations(sc *skillcard.SkillCard) map[string]string {
 
 	// Lifecycle status: initial state is always draft.
 	ann[lifecycle.StatusAnnotation] = string(lifecycle.Draft)
+
+	// Tags: JSON-encoded string array.
+	if len(sc.Metadata.Tags) > 0 {
+		tagsJSON, err := json.Marshal(sc.Metadata.Tags)
+		if err == nil {
+			ann[AnnotationTags] = string(tagsJSON)
+		}
+	}
+
+	// Compatibility.
+	if sc.Metadata.Compatibility != "" {
+		ann[AnnotationCompatibility] = sc.Metadata.Compatibility
+	}
+
+	// Word count of SKILL.md.
+	if wordCount > 0 {
+		ann[AnnotationWordCount] = strconv.Itoa(wordCount)
+	}
 
 	return ann
 }

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -54,16 +54,19 @@ type PromoteOptions struct{}
 
 // InspectResult holds detailed metadata for a skill image.
 type InspectResult struct {
-	Name        string
-	DisplayName string
-	Version     string
-	Status      string
-	Description string
-	Authors     string
-	License     string
-	Digest      string
-	Created     string
-	MediaType   string
-	Size        int64
-	LayerCount  int
+	Name          string
+	DisplayName   string
+	Version       string
+	Status        string
+	Description   string
+	Authors       string
+	License       string
+	Tags          string
+	Compatibility string
+	WordCount     string
+	Digest        string
+	Created       string
+	MediaType     string
+	Size          int64
+	LayerCount    int
 }

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -52,6 +52,9 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 	authors := ann[ocispec.AnnotationAuthors]
 	license := ann[ocispec.AnnotationLicenses]
 	created := ann[ocispec.AnnotationCreated]
+	tags := ann[AnnotationTags]
+	compatibility := ann[AnnotationCompatibility]
+	wordCount := ann[AnnotationWordCount]
 
 	// Compute total size from layers.
 	var totalSize int64
@@ -60,17 +63,20 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 	}
 
 	return &InspectResult{
-		Name:        name,
-		DisplayName: displayName,
-		Version:     version,
-		Status:      status,
-		Description: description,
-		Authors:     authors,
-		License:     license,
-		Digest:      desc.Digest.String(),
-		Created:     created,
-		MediaType:   desc.MediaType,
-		Size:        totalSize,
-		LayerCount:  len(manifest.Layers),
+		Name:          name,
+		DisplayName:   displayName,
+		Version:       version,
+		Status:        status,
+		Description:   description,
+		Authors:       authors,
+		License:       license,
+		Tags:          tags,
+		Compatibility: compatibility,
+		WordCount:     wordCount,
+		Digest:        desc.Digest.String(),
+		Created:       created,
+		MediaType:     desc.MediaType,
+		Size:          totalSize,
+		LayerCount:    len(manifest.Layers),
 	}, nil
 }

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -11,16 +11,33 @@ import (
 	"github.com/redhat-et/skillimage/pkg/lifecycle"
 )
 
-// Inspect retrieves detailed metadata for a skill image stored in the local OCI layout.
+// inspectableStore is the minimal interface for reading a manifest.
+type inspectableStore interface {
+	Resolve(ctx context.Context, ref string) (ocispec.Descriptor, error)
+	Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error)
+}
+
+// Inspect retrieves detailed metadata for a skill image in the local store.
 func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error) {
-	// Resolve the reference to get the manifest descriptor.
-	desc, err := c.store.Resolve(ctx, ref)
+	return inspect(ctx, c.store, ref)
+}
+
+// InspectRemote retrieves detailed metadata for a skill image on a remote registry.
+func (c *Client) InspectRemote(ctx context.Context, ref string) (*InspectResult, error) {
+	repo, err := newRemoteRepository(ref)
+	if err != nil {
+		return nil, fmt.Errorf("creating remote repository: %w", err)
+	}
+	return inspect(ctx, repo, ref)
+}
+
+func inspect(ctx context.Context, store inspectableStore, ref string) (*InspectResult, error) {
+	desc, err := store.Resolve(ctx, ref)
 	if err != nil {
 		return nil, fmt.Errorf("resolving %s: %w", ref, err)
 	}
 
-	// Fetch and parse the manifest.
-	rc, err := c.store.Fetch(ctx, desc)
+	rc, err := store.Fetch(ctx, desc)
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest: %w", err)
 	}
@@ -41,10 +58,8 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 		ann = make(map[string]string)
 	}
 
-	// Extract name from ref (everything before the last colon).
 	name := parseNameFromTag(ref)
 
-	// Extract annotations.
 	version := ann[ocispec.AnnotationVersion]
 	status := ann[lifecycle.StatusAnnotation]
 	description := ann[ocispec.AnnotationDescription]
@@ -56,7 +71,6 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 	compatibility := ann[AnnotationCompatibility]
 	wordCount := ann[AnnotationWordCount]
 
-	// Compute total size from layers.
 	var totalSize int64
 	for _, layer := range manifest.Layers {
 		totalSize += layer.Size

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -349,3 +349,88 @@ func TestPromoteInvalidTransition(t *testing.T) {
 		t.Fatal("expected error for invalid transition draft -> published")
 	}
 }
+
+func TestAnnotationsOmittedWhenEmpty(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: minimal-skill
+  namespace: test
+  version: 1.0.0
+  description: Minimal skill with no optional fields.
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/minimal-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.Tags != "" {
+		t.Errorf("tags should be empty, got %q", result.Tags)
+	}
+	if result.Compatibility != "" {
+		t.Errorf("compatibility should be empty, got %q", result.Compatibility)
+	}
+	if result.WordCount != "" {
+		t.Errorf("wordcount should be empty, got %q", result.WordCount)
+	}
+}
+
+func TestAnnotationsEmptySKILLmd(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: empty-md-skill
+  namespace: test
+  version: 1.0.0
+  description: Skill with empty SKILL.md.
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/empty-md-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.WordCount != "" {
+		t.Errorf("wordcount should be empty for empty SKILL.md, got %q", result.WordCount)
+	}
+}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -276,6 +276,57 @@ func TestPromoteLocal(t *testing.T) {
 	}
 }
 
+func TestAnnotationsIncludeTags(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: annotated-skill
+  namespace: test
+  version: 2.0.0
+  description: Skill with tags and compat.
+  tags:
+    - kubernetes
+    - debugging
+  compatibility: claude-3.5-sonnet
+spec:
+  prompt: SKILL.md
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("one two three four five"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/annotated-skill:2.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.Tags != `["kubernetes","debugging"]` {
+		t.Errorf("tags = %q, want %q", result.Tags, `["kubernetes","debugging"]`)
+	}
+	if result.Compatibility != "claude-3.5-sonnet" {
+		t.Errorf("compatibility = %q, want %q", result.Compatibility, "claude-3.5-sonnet")
+	}
+	if result.WordCount != "5" {
+		t.Errorf("wordcount = %q, want %q", result.WordCount, "5")
+	}
+}
+
 func TestPromoteInvalidTransition(t *testing.T) {
 	skillDir := t.TempDir()
 	writeTestSkill(t, skillDir)

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -394,6 +394,40 @@ spec:
 	}
 }
 
+func TestTag(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	err = client.Tag(ctx, "test/test-skill:1.0.0-draft", "quay.io/myorg/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Tag: %v", err)
+	}
+
+	// Inspect via the new tag should return the same image.
+	result, err := client.Inspect(ctx, "quay.io/myorg/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect new tag: %v", err)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("version = %q, want %q", result.Version, "1.0.0")
+	}
+	if result.Status != "draft" {
+		t.Errorf("status = %q, want %q", result.Status, "draft")
+	}
+}
+
 func TestAnnotationsEmptySKILLmd(t *testing.T) {
 	skillDir := t.TempDir()
 	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -327,6 +327,55 @@ spec:
 	}
 }
 
+func TestWordCountExcludesFrontmatter(t *testing.T) {
+	skillDir := t.TempDir()
+	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: frontmatter-skill
+  namespace: test
+  version: 1.0.0
+  description: Skill with YAML frontmatter in SKILL.md.
+spec:
+  prompt: SKILL.md
+`)
+	skillMD := []byte(`---
+name: frontmatter-skill
+description: This has frontmatter that should not be counted.
+license: Apache-2.0
+---
+
+These five words are counted.
+`)
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), skillMD, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+
+	result, err := client.Inspect(ctx, "test/frontmatter-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	if result.WordCount != "5" {
+		t.Errorf("wordcount = %q, want %q (frontmatter should be excluded)", result.WordCount, "5")
+	}
+}
+
 func TestPromoteInvalidTransition(t *testing.T) {
 	skillDir := t.TempDir()
 	writeTestSkill(t, skillDir)

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -135,11 +135,9 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 }
 
 // ListLocal reads the store's tags and returns image metadata from manifest annotations.
-// Deduplicates by digest so that "latest" aliases don't produce duplicate rows.
 func (c *Client) ListLocal() ([]LocalImage, error) {
 	ctx := context.Background()
 	var images []LocalImage
-	seen := make(map[string]bool)
 
 	err := c.store.Tags(ctx, "", func(tags []string) error {
 		for _, tag := range tags {
@@ -147,12 +145,6 @@ func (c *Client) ListLocal() ([]LocalImage, error) {
 			if err != nil {
 				continue
 			}
-
-			digestStr := desc.Digest.String()
-			if seen[digestStr] {
-				continue
-			}
-			seen[digestStr] = true
 
 			img, err := c.imageFromManifest(ctx, tag, desc)
 			if err != nil {

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -52,11 +52,11 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
 	}
 
-	// 2b. Count words in SKILL.md if present.
+	// 2b. Count words in SKILL.md if present, excluding YAML frontmatter.
 	var wordCount int
 	skillMDPath := filepath.Join(skillDir, "SKILL.md")
 	if data, err := os.ReadFile(skillMDPath); err == nil {
-		wordCount = len(strings.Fields(string(data)))
+		wordCount = len(strings.Fields(stripFrontmatter(string(data))))
 	}
 
 	// 3. Create a tar.gz layer of all files in the directory.
@@ -136,7 +136,14 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 
 // ListLocal reads the store's tags and returns image metadata from manifest annotations.
 func (c *Client) ListLocal() ([]LocalImage, error) {
-	ctx := context.Background()
+	images, err := c.listLocal(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("listing tags: %w", err)
+	}
+	return images, nil
+}
+
+func (c *Client) listLocal(ctx context.Context) ([]LocalImage, error) {
 	var images []LocalImage
 
 	err := c.store.Tags(ctx, "", func(tags []string) error {
@@ -155,7 +162,7 @@ func (c *Client) ListLocal() ([]LocalImage, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("listing tags: %w", err)
+		return nil, err
 	}
 
 	return images, nil
@@ -297,6 +304,21 @@ func copyFileToTar(tw *tar.Writer, path, rel string) error {
 		return fmt.Errorf("copying %s: %w", rel, err)
 	}
 	return nil
+}
+
+// stripFrontmatter removes YAML frontmatter (delimited by "---") from
+// SKILL.md content so that metadata fields don't inflate the word count.
+func stripFrontmatter(s string) string {
+	if !strings.HasPrefix(s, "---") {
+		return s
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return s
+	}
+	// Skip past the closing "---" and its newline.
+	body := s[3+end+4:]
+	return body
 }
 
 // buildImageConfig creates the OCI image config JSON (FROM scratch equivalent).

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -52,6 +52,13 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
 	}
 
+	// 2b. Count words in SKILL.md if present.
+	var wordCount int
+	skillMDPath := filepath.Join(skillDir, "SKILL.md")
+	if data, err := os.ReadFile(skillMDPath); err == nil {
+		wordCount = len(strings.Fields(string(data)))
+	}
+
 	// 3. Create a tar.gz layer of all files in the directory.
 	layerBuf, uncompressedDigest, err := createLayer(skillDir)
 	if err != nil {
@@ -86,7 +93,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 	}
 
 	// 6. Build annotations from SkillCard.
-	annotations := buildAnnotations(sc)
+	annotations := buildAnnotations(sc, wordCount)
 
 	// 7. Create and push the OCI manifest.
 	manifest := ocispec.Manifest{

--- a/pkg/oci/prune.go
+++ b/pkg/oci/prune.go
@@ -24,7 +24,7 @@ type PruneResult struct {
 // promotion. For each name+version group, it keeps only the image
 // with the highest lifecycle state and removes the rest.
 func (c *Client) Prune(ctx context.Context) (*PruneResult, error) {
-	images, err := c.listLocalWithTags(ctx)
+	images, err := c.listLocal(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing images: %w", err)
 	}
@@ -69,31 +69,4 @@ func (c *Client) Prune(ctx context.Context) (*PruneResult, error) {
 	}
 
 	return &PruneResult{Removed: removed}, nil
-}
-
-// listLocalWithTags is like ListLocal but does NOT deduplicate by
-// digest, so we can see all tags including "latest".
-func (c *Client) listLocalWithTags(ctx context.Context) ([]LocalImage, error) {
-	var images []LocalImage
-
-	err := c.store.Tags(ctx, "", func(tags []string) error {
-		for _, tag := range tags {
-			desc, err := c.store.Resolve(ctx, tag)
-			if err != nil {
-				continue
-			}
-
-			img, err := c.imageFromManifest(ctx, tag, desc)
-			if err != nil {
-				continue
-			}
-			images = append(images, *img)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return images, nil
 }

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -3,10 +3,14 @@ package oci
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
 )
 
 // Push copies an image from the local OCI store to a remote registry.
@@ -38,10 +42,61 @@ func (c *Client) CopyTo(ctx context.Context, ref string, dst *Client) error {
 }
 
 // newRemoteRepository creates a remote.Repository from a full reference string
-// like "registry.example.com/namespace/name:tag".
+// like "registry.example.com/namespace/name:tag", configured with credentials
+// from Docker and Podman auth files.
 func newRemoteRepository(ref string) (*remote.Repository, error) {
 	repoRef, _ := splitRefTag(ref)
-	return remote.NewRepository(repoRef)
+	repo, err := remote.NewRepository(repoRef)
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := credentialStore()
+	if err != nil {
+		return nil, fmt.Errorf("loading credentials: %w", err)
+	}
+
+	repo.Client = &auth.Client{
+		Credential: credentials.Credential(store),
+	}
+
+	return repo, nil
+}
+
+// credentialStore returns a credential store that checks Docker config first,
+// then falls back to Podman's auth.json.
+func credentialStore() (credentials.Store, error) {
+	dockerStore, err := credentials.NewStoreFromDocker(credentials.StoreOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	podmanPath := podmanAuthPath()
+	if podmanPath == "" {
+		return dockerStore, nil
+	}
+
+	if _, err := os.Stat(podmanPath); err != nil {
+		return dockerStore, nil
+	}
+
+	podmanStore, err := credentials.NewStore(podmanPath, credentials.StoreOptions{})
+	if err != nil {
+		return dockerStore, nil
+	}
+
+	return credentials.NewStoreWithFallbacks(dockerStore, podmanStore), nil
+}
+
+func podmanAuthPath() string {
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		return filepath.Join(xdg, "containers", "auth.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "containers", "auth.json")
 }
 
 // splitRefTag splits an OCI reference into repository and tag.

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -82,6 +82,7 @@ func credentialStore() (credentials.Store, error) {
 
 	podmanStore, err := credentials.NewStore(podmanPath, credentials.StoreOptions{})
 	if err != nil {
+		// Podman config unreadable but Docker config works — fall back gracefully.
 		return dockerStore, nil
 	}
 

--- a/pkg/oci/tag.go
+++ b/pkg/oci/tag.go
@@ -1,0 +1,21 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+)
+
+// Tag creates an additional reference for an existing image in the local store.
+// This is equivalent to "docker tag" or "podman tag".
+func (c *Client) Tag(ctx context.Context, src, dst string) error {
+	desc, err := c.store.Resolve(ctx, src)
+	if err != nil {
+		return fmt.Errorf("resolving %s: %w", src, err)
+	}
+
+	if err := c.store.Tag(ctx, desc, dst); err != nil {
+		return fmt.Errorf("tagging %s as %s: %w", src, dst, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- **Catalog metadata annotations**: Add `io.skillimage.tags`, `io.skillimage.compatibility`, and `io.skillimage.wordcount` to OCI manifest annotations so the catalog UI can build skill cards from the manifest alone — eliminating 10MB blob downloads per skill during listing
- **`skillctl tag` command**: Docker/Podman-style retagging for local images, enabling the familiar tag-then-push workflow for remote registries
- **Remote inspect fallback**: `skillctl inspect` now tries the local store first, then falls back to the remote registry — fixes inability to inspect tags that only exist remotely (e.g., after remote promote)
- **Registry auth**: Push/pull/promote now use credentials from Docker and Podman auth files (was making unauthenticated requests)
- **Example skills**: Two realistic document-processing skills (summarizer, reviewer) with agentskills.io-compliant SKILL.md frontmatter
- **Frontend integration guide**: Annotation reference table and recommended catalog listing flow in the design spec
- **README**: `skopeo inspect` examples showing standards-compliant metadata access

## Design spec

`docs/superpowers/specs/2026-04-20-catalog-metadata-annotations-design.md`

## Test plan

- [x] `TestAnnotationsIncludeTags` — tags, compatibility, wordcount set correctly
- [x] `TestAnnotationsOmittedWhenEmpty` — no annotations when fields absent
- [x] `TestAnnotationsEmptySKILLmd` — empty SKILL.md produces no wordcount
- [x] `TestTag` — local retagging works, inspect via new tag resolves
- [x] All existing tests pass (promote, pack, unpack, copy, list)
- [x] `make lint` — zero issues
- [x] Manual: packed and pushed document-reviewer and document-summarizer to quay.io/skillimage
- [x] Manual: remote promote (draft → testing) and remote inspect verified on quay.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `skillctl tag` command to create skill image tag aliases
  * Two new example skills: document-reviewer and document-summarizer
  * Skill metadata (tags, compatibility, word count) now exposed via OCI manifest annotations
  * Inspect command displays skill tags, compatibility, and word count when available
  * Can retrieve skill metadata from registries without downloading image layers

* **Documentation**
  * Added guide for inspecting skill metadata using standard OCI tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->