### PR TITLE
feat: add Red Hat media type profile for oc-mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 # Environment
 .env
 .env.local
+
+# Scratch/working documents
+scratch/

--- a/docs/slides/oci-skill-distribution-deck.html
+++ b/docs/slides/oci-skill-distribution-deck.html
@@ -1,970 +1,1526 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>OCI-Based Skill Distribution</title>
-  <link href="https://cdn.jsdelivr.net/npm/@rhds/tokens@3.0.2/css/global.min.css" rel="stylesheet">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&family=Red+Hat+Text:wght@400;500;700&family=Red+Hat+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <style>
-    /* === RESET & BASE === */
-    :root { color-scheme: dark; }
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+<!DOCTYPE html><html lang="en-US"><head><title>OCI-Based Skill Distribution</title><meta property="og:title" content="OCI-Based Skill Distribution"><meta name="author" content="Pavel Anni"><meta property="article:author" content="Pavel Anni"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0"><meta name="apple-mobile-web-app-capable" content="yes"><meta http-equiv="X-UA-Compatible" content="ie=edge"><meta property="og:type" content="website"><meta name="twitter:card" content="summary"><style>@media screen{body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button,body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{appearance:none;background-color:initial;border:0;color:inherit;cursor:pointer;font-size:inherit;opacity:.8;outline:none;padding:0;transition:opacity .2s linear;-webkit-tap-highlight-color:transparent}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:disabled,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:disabled,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:disabled{cursor:not-allowed;opacity:.15!important}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover{opacity:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:active,body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:active,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:active{opacity:.6}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button:hover:not(:disabled),body[data-bespoke-view=overview] button.bespoke-marp-overview-close:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button:hover:not(:disabled),body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button:hover:not(:disabled){transition:none}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-prev{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNNjggOTAgMjggNTBsNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button.bespoke-marp-presenter-info-page-next{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJtMzIgOTAgNDAtNDAtNDAtNDAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNNDAgNzBIMjBWNTBtMjAgMEwyMCA3MG00MC00MGgyMHYyMG0tMjAgMCAyMC0yMCIgY2xhc3M9ImEiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button.exit[data-bespoke-marp-osc=fullscreen]{background-image:url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4fTwvc3R5bGU+PC9kZWZzPjxyZWN0IHdpZHRoPSI4MCIgaGVpZ2h0PSI2MCIgeD0iMTAiIHk9IjIwIiBjbGFzcz0iYSIgcng9IjUuNjciLz48cGF0aCBkPSJNMjAgNTBoMjB2MjBtLTIwIDAgMjAtMjBtNDAgMEg2MFYzMG0yMCAwTDYwIDUwIiBjbGFzcz0iYSIvPjwvc3ZnPg==")}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNODcuOCA0Ny41Qzg5IDUwIDg3LjcgNTIgODUgNTJIMzVhOC43IDguNyAwIDAgMS03LjItNC41bC0xNS42LTMxQzExIDE0IDEyLjIgMTIgMTUgMTJoNTBhOC44IDguOCAwIDAgMSA3LjIgNC41ek02MCA1MnYzNm0tMTAgMGgyME00NSA0MmgyMCIvPjwvc3ZnPg==") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=overview] button.bespoke-marp-overview-close,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-bigger{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODBNNTIgOTBWMTAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button.bespoke-marp-presenter-note-smaller{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgc3Ryb2tlLXdpZHRoPSI1IiBkPSJNMTIgNTBoODAiLz48L3N2Zz4=") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview]{background:#0000 url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmF7ZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2Utd2lkdGg6NXB4O3J4OjVweDtyeTo1cHg7d2lkdGg6MjVweDtoZWlnaHQ6MjVweH08L3N0eWxlPjwvZGVmcz48cmVjdCB4PSIyMCIgeT0iMjAiIGNsYXNzPSJhIi8+PHJlY3QgeD0iNTUiIHk9IjIwIiBjbGFzcz0iYSIvPjxyZWN0IHg9IjIwIiB5PSI1NSIgY2xhc3M9ImEiLz48cmVjdCB4PSI1NSIgeT0iNTUiIGNsYXNzPSJhIi8+PC9zdmc+") no-repeat 50%;background-size:contain;overflow:hidden;text-indent:100%;white-space:nowrap}}@keyframes __bespoke_marp_transition_reduced_outgoing__{0%{opacity:1}to{opacity:0}}@keyframes __bespoke_marp_transition_reduced_incoming__{0%{mix-blend-mode:plus-lighter;opacity:0}to{mix-blend-mode:plus-lighter;opacity:1}}.bespoke-marp-note,.bespoke-marp-osc,.bespoke-progress-parent{display:none;transition:none}@media screen{::view-transition-group(*){animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-timing-function:ease}::view-transition-new(*),::view-transition-old(*){animation-delay:0s;animation-direction:var(--marp-bespoke-transition-animation-direction,normal);animation-duration:var(--marp-bespoke-transition-animation-duration,.5s);animation-fill-mode:both;animation-name:var(--marp-bespoke-transition-animation-name,var(--marp-bespoke-transition-animation-name-fallback,__bespoke_marp_transition_no_animation__));mix-blend-mode:normal}::view-transition-old(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_outgoing__;animation-timing-function:ease}::view-transition-new(*){--marp-bespoke-transition-animation-name-fallback:__bespoke_marp_transition_reduced_incoming__;animation-timing-function:ease}::view-transition-new(root),::view-transition-old(root){animation-timing-function:linear}::view-transition-new(__bespoke_marp_transition_osc__),::view-transition-old(__bespoke_marp_transition_osc__){animation-duration:0s!important;animation-name:__bespoke_marp_transition_osc__!important}::view-transition-new(__bespoke_marp_transition_osc__){opacity:0!important}.bespoke-marp-transition-warming-up::view-transition-group(*),.bespoke-marp-transition-warming-up::view-transition-new(*),.bespoke-marp-transition-warming-up::view-transition-old(*){animation-play-state:paused!important}body,html{height:100%;margin:0}body{background:#000;overflow:hidden}svg.bespoke-marp-slide{content-visibility:hidden;interactivity:inert;opacity:0;pointer-events:none;z-index:-1}svg.bespoke-marp-slide:not(.bespoke-marp-active) *{view-transition-name:none!important}svg.bespoke-marp-slide.bespoke-marp-active{content-visibility:visible;interactivity:auto;opacity:1;pointer-events:auto;z-index:0}svg.bespoke-marp-slide.bespoke-marp-active.bespoke-marp-active-ready *{animation-name:__bespoke_marp__!important}@supports not (content-visibility:hidden){svg.bespoke-marp-slide[data-bespoke-marp-load=hideable]{display:none}svg.bespoke-marp-slide[data-bespoke-marp-load=hideable].bespoke-marp-active{display:block}}}@media screen and (prefers-reduced-motion:reduce){svg.bespoke-marp-slide *{view-transition-name:none!important}}@media screen{[data-bespoke-marp-fragment=inactive]{visibility:hidden}body[data-bespoke-view=""] .bespoke-marp-parent,body[data-bespoke-view=next] .bespoke-marp-parent{inset:0;position:absolute}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc{background:#000000a6;border-radius:7px;bottom:50px;color:#fff;contain:paint;display:block;font-family:Helvetica,Arial,sans-serif;font-size:16px;left:50%;line-height:0;opacity:1;padding:12px;position:absolute;touch-action:manipulation;transform:translateX(-50%);transition:opacity .2s linear;-webkit-user-select:none;user-select:none;view-transition-name:__bespoke_marp_transition_osc__;white-space:nowrap;will-change:transform;z-index:1}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*){margin-left:6px}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child),body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>:where(*):where(:first-child){margin-left:0}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span,body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span{opacity:.8}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>span[data-bespoke-marp-osc=page]{display:inline-block;min-width:140px;text-align:center}body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=""] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=fullscreen],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=next],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=overview],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=presenter],body[data-bespoke-view=next] .bespoke-marp-parent>.bespoke-marp-osc>button[data-bespoke-marp-osc=prev]{height:32px;line-height:32px;width:32px}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive{cursor:none}body[data-bespoke-view=""] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc,body[data-bespoke-view=next] .bespoke-marp-parent.bespoke-marp-inactive>.bespoke-marp-osc{opacity:0;pointer-events:none}body[data-bespoke-view=""] svg.bespoke-marp-slide,body[data-bespoke-view=next] svg.bespoke-marp-slide{height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent{background:#222;display:flex;height:5px;width:100%}body[data-bespoke-view=""] .bespoke-progress-parent+:where(.bespoke-marp-parent){top:5px}body[data-bespoke-view=""] .bespoke-progress-parent .bespoke-progress-bar{background:#0288d1;flex:0 0 0;transition:flex-basis .2s cubic-bezier(0,1,1,1)}body[data-bespoke-view=next]{background:#0000}body[data-bespoke-view=presenter]{background:#161616}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container{display:grid;font-family:Helvetica,Arial,sans-serif;grid-template:"current dragbar next" minmax(140px,1fr) "current dragbar note" 2fr "info    dragbar note" 3em;grid-template-columns:minmax(3px,var(--bespoke-marp-presenter-split-ratio,66%)) 0 minmax(3px,1fr);height:100%;left:0;position:absolute;top:0;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent){grid-area:current;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide){height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container :where(.bespoke-marp-parent) :where(svg.bespoke-marp-slide).bespoke-marp-active{filter:drop-shadow(0 3px 10px rgba(0,0,0,.5))}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container{background:#0288d1;cursor:col-resize;grid-area:dragbar;margin-left:-3px;opacity:0;position:relative;transition:opacity .4s linear .1s;width:6px;z-index:10}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container:hover{opacity:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-dragbar-container.active{opacity:1;transition-delay:0s}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container{background:#222;cursor:pointer;display:none;grid-area:next;overflow:hidden;position:relative}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-next-container iframe.bespoke-marp-presenter-next{background:#0000;border:0;display:block;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));height:calc(100% - 40px);left:20px;pointer-events:none;position:absolute;interactivity:inert;top:20px;-webkit-user-select:none;user-select:none;width:calc(100% - 40px)}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container{background:#222;color:#eee;grid-area:note;position:relative;z-index:1}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper{display:block;inset:0;position:absolute}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons{background:#000000a6;border-radius:4px;bottom:0;display:flex;gap:4px;margin:12px;opacity:0;padding:6px;pointer-events:none;position:absolute;right:0;transition:opacity .2s linear}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-buttons:focus-within,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-presenter-note-wrapper:focus-within+.bespoke-marp-presenter-note-buttons,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container:hover .bespoke-marp-presenter-note-buttons{opacity:1;pointer-events:auto}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note{box-sizing:border-box;font-size:calc(1.1em*var(--bespoke-marp-note-font-scale, 1));height:calc(100% - 40px);margin:20px;overflow:auto;padding-right:3px;white-space:pre-wrap;width:calc(100% - 40px);word-wrap:break-word;scrollbar-color:#eeeeee80 #0000;scrollbar-width:thin}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar{width:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-track{background:#0000}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note::-webkit-scrollbar-thumb{background:#eeeeee80;border-radius:6px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note:empty{pointer-events:none}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note.active{display:block}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:first-child{margin-top:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-note-container .bespoke-marp-note p:last-child{margin-bottom:0}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container{align-items:center;box-sizing:border-box;color:#eee;display:flex;flex-wrap:nowrap;grid-area:info;justify-content:center;overflow:hidden;padding:0 10px}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time,body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{box-sizing:border-box;display:block;padding:0 10px;white-space:nowrap;width:100%}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container button{height:1.5em;line-height:1.5em;width:1.5em}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area{order:2;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-page-area .bespoke-marp-presenter-info-page{display:inline-block;min-width:120px;text-align:center}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-time{color:#999;order:1;text-align:left}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer{color:#999;order:3;text-align:right}body[data-bespoke-view=presenter] .bespoke-marp-presenter-container .bespoke-marp-presenter-info-container .bespoke-marp-presenter-info-timer:hover{cursor:pointer}body[data-bespoke-view=overview]{background:#161616;overflow:auto}body[data-bespoke-view=overview] [data-bespoke-marp-fragment=inactive]{visibility:visible}body[data-bespoke-view=overview] .bespoke-marp-overview-header{backdrop-filter:blur(4px);background:#222222d9;box-shadow:0 3px 10px #00000080;box-sizing:border-box;display:flex;height:48px;inset:0 0 auto;justify-content:flex-end;padding:10px;position:fixed;z-index:1}body[data-bespoke-view=overview] button.bespoke-marp-overview-close{height:28px;line-height:28px;transform:rotate(45deg);width:28px}body[data-bespoke-view=overview] .bespoke-marp-parent{display:grid;gap:40px;grid-template-columns:repeat(auto-fit,minmax(0,240px));justify-content:space-around;padding:30px}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide{--bov-selected:#0000;--bov-focus:#161616;--bov-focus-outline:#0000;background-image:conic-gradient(#161616 0 0),conic-gradient(var(--bov-focus) 0 0),conic-gradient(var(--bov-focus-outline) 0 0),conic-gradient(var(--bov-selected) 0 0);background-position:5px 5px,3px 3px,2px 2px,0 0;background-repeat:no-repeat;background-size:calc(100% - 10px) calc(100% - 10px),calc(100% - 6px) calc(100% - 6px),calc(100% - 4px) calc(100% - 4px),100% 100%;content-visibility:visible;cursor:pointer;filter:drop-shadow(0 3px 10px rgba(0,0,0,.5));margin:-6px;padding:6px;interactivity:auto;opacity:1;outline:0;pointer-events:auto;scroll-margin-block:30px;width:100%;z-index:0}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide *,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active *{pointer-events:none;interactivity:inert}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus-outline:#161616}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:focus-visible,body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:hover{--bov-focus:#999}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide:active{--bov-focus:#eee}body[data-bespoke-view=overview] .bespoke-marp-parent svg.bespoke-marp-slide.bespoke-marp-active{--bov-selected:#0288d1}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent{padding-top:78px}body[data-bespoke-view=overview]:has(.bespoke-marp-overview-header) .bespoke-marp-parent svg.bespoke-marp-slide{scroll-margin-top:78px}.bespoke-marp-overview{background:#000000a6;inset:0;opacity:0;pointer-events:none;position:fixed;transition:opacity .1s ease;z-index:10}.bespoke-marp-overview iframe{background:#222;border:0;display:block;height:100%;left:0;position:absolute;top:0;width:100%}.bespoke-marp-overview[data-open="1"]{opacity:1;pointer-events:auto}}@media print{.bespoke-marp-overview,.bespoke-marp-presenter-info-container,.bespoke-marp-presenter-next-container,.bespoke-marp-presenter-note-container{display:none}}</style><style>@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&family=Red+Hat+Text:wght@400;500;700&family=Red+Hat+Mono:wght@400;700&display=swap');div#\:\$p > svg > foreignObject > section{width:1280px;height:720px;box-sizing:border-box;overflow:hidden;position:relative;scroll-snap-align:center center;-webkit-text-size-adjust:100%;text-size-adjust:100%}div#\:\$p > svg > foreignObject > section::after{bottom:0;content:attr(data-marpit-pagination);padding:inherit;pointer-events:none;position:absolute;right:0}div#\:\$p > svg > foreignObject > section:not([data-marpit-pagination])::after{display:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-size:2em;margin-block:0.67em}div#\:\$p > svg > foreignObject > section video::-webkit-media-controls{will-change:transform}@page {size:1280px 720px;margin:0}@media print{html, body{background-color:#fff;margin:0;page-break-inside:avoid;break-inside:avoid-page}div#\:\$p > svg > foreignObject > section{page-break-before:always;break-before:page}div#\:\$p > svg > foreignObject > section, div#\:\$p > svg > foreignObject > section *{-webkit-print-color-adjust:exact!important;animation-delay:0s!important;animation-duration:0s!important;color-adjust:exact!important;print-color-adjust:exact!important;transition:none!important}div#\:\$p > svg[data-marpit-svg]{display:block;height:100vh;width:100vw}}div#\:\$p > svg > foreignObject > :where(section){container-type:size}div#\:\$p > svg > foreignObject > section img[data-marp-twemoji]{background:transparent;height:1em;margin:0 .05em 0 .1em;vertical-align:-.1em;width:1em}div#\:\$p > svg > foreignObject > section{--fgColor-danger:light-dark(#d1242f, #f85149);--bgColor-attention-muted:light-dark(#fff8c5, #bb800926);--bgColor-muted:light-dark(#f6f8fa, #151b23);--bgColor-neutral-muted:light-dark(#818b981f, #656c7633);--borderColor-accent-emphasis:light-dark(#0969da, #1f6feb);--borderColor-attention-emphasis:light-dark(#9a6700, #9e6a03);--borderColor-danger-emphasis:light-dark(#cf222e, #da3633);--borderColor-default:light-dark(#d1d9e0, #3d444d);--borderColor-done-emphasis:light-dark(#8250df, #8957e5);--borderColor-success-emphasis:light-dark(#1a7f37, #238636);--color-prettylights-syntax-brackethighlighter-angle:light-dark(#59636e, #9198a1);--color-prettylights-syntax-brackethighlighter-unmatched:light-dark(#82071e, #f85149);--color-prettylights-syntax-carriage-return-bg:light-dark(#cf222e, #b62324);--color-prettylights-syntax-carriage-return-text:light-dark(#f6f8fa, #f0f6fc);--color-prettylights-syntax-comment:light-dark(#59636e, #9198a1);--color-prettylights-syntax-constant:light-dark(#0550ae, #79c0ff);--color-prettylights-syntax-constant-other-reference-link:light-dark(#0a3069, #a5d6ff);--color-prettylights-syntax-entity:light-dark(#6639ba, #d2a8ff);--color-prettylights-syntax-entity-tag:light-dark(#0550ae, #7ee787);--color-prettylights-syntax-invalid-illegal-text:light-dark(var(--fgColor-danger), var(--fgColor-danger));--color-prettylights-syntax-keyword:light-dark(#cf222e, #ff7b72);--color-prettylights-syntax-markup-changed-bg:light-dark(#ffd8b5, #5a1e02);--color-prettylights-syntax-markup-changed-text:light-dark(#953800, #ffdfb6);--color-prettylights-syntax-markup-deleted-bg:light-dark(#ffebe9, #67060c);--color-prettylights-syntax-markup-deleted-text:light-dark(#82071e, #ffdcd7);--color-prettylights-syntax-markup-heading:light-dark(#0550ae, #1f6feb);--color-prettylights-syntax-markup-ignored-bg:light-dark(#0550ae, #1158c7);--color-prettylights-syntax-markup-ignored-text:light-dark(#d1d9e0, #f0f6fc);--color-prettylights-syntax-markup-inserted-bg:light-dark(#dafbe1, #033a16);--color-prettylights-syntax-markup-inserted-text:light-dark(#116329, #aff5b4);--color-prettylights-syntax-markup-list:light-dark(#3b2300, #f2cc60);--color-prettylights-syntax-meta-diff-range:light-dark(#8250df, #d2a8ff);--color-prettylights-syntax-string:light-dark(#0a3069, #a5d6ff);--color-prettylights-syntax-string-regexp:light-dark(#116329, #7ee787);--color-prettylights-syntax-sublimelinter-gutter-mark:light-dark(#818b98, #3d444d);--color-prettylights-syntax-variable:light-dark(#953800, #ffa657);--fgColor-accent:light-dark(#0969da, #4493f8);--fgColor-attention:light-dark(#9a6700, #d29922);--fgColor-done:light-dark(#8250df, #ab7df8);--fgColor-muted:light-dark(#59636e, #9198a1);--fgColor-success:light-dark(#1a7f37, #3fb950);--bgColor-default:light-dark(#fff, #0d1117);--borderColor-muted:light-dark(#d1d9e0b3, #3d444db3);--color-prettylights-syntax-invalid-illegal-bg:light-dark(var(--bgColor-danger-muted), var(--bgColor-danger-muted));--color-prettylights-syntax-markup-bold:light-dark(#1f2328, #f0f6fc);--color-prettylights-syntax-markup-italic:light-dark(#1f2328, #f0f6fc);--color-prettylights-syntax-storage-modifier-import:light-dark(#1f2328, #f0f6fc);--fgColor-default:light-dark(#1f2328, #f0f6fc);--focus-outlineColor:light-dark(var(--borderColor-accent-emphasis), var(--borderColor-accent-emphasis));--borderColor-neutral-muted:light-dark(var(--borderColor-muted), var(--borderColor-muted));--base-size-16:calc(var(--marpit-root-font-size, 1rem) * 1);--base-size-24:calc(var(--marpit-root-font-size, 1rem) * 1.5);--base-size-4:calc(var(--marpit-root-font-size, 1rem) * 0.25);--base-size-40:calc(var(--marpit-root-font-size, 1rem) * 2.5);--base-size-8:calc(var(--marpit-root-font-size, 1rem) * 0.5);--base-text-weight-medium:500;--base-text-weight-normal:400;--base-text-weight-semibold:600;--fontStack-monospace:ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;--fontStack-sansSerif:-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";}/*!
+ * Marp default theme.
+ *
+ * @theme default
+ * @author Yuki Hattori
+ *
+ * @auto-scaling true
+ * @size 16:9 1280px 720px
+ * @size 4:3 960px 720px
+ */div#\:\$p > svg > foreignObject > section [data-theme=light],div#\:\$p > svg > foreignObject > section{color-scheme:light}div#\:\$p > svg > foreignObject > section [data-theme=dark],div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background-color:var(--bgColor-default);color:var(--fgColor-default);font-family:var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");font-size:16px;font-weight:var(--base-text-weight-normal, 400);line-height:1.5;margin:0;word-wrap:break-word}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:16px}div#\:\$p > svg > foreignObject > section a{text-decoration:underline;text-underline-offset:calc(var(--marpit-root-font-size, 1rem) * .2)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link:before{background-color:currentColor;content:" ";display:inline-block;height:16px;-webkit-mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');width:16px}div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section figcaption,div#\:\$p > svg > foreignObject > section figure{display:block}div#\:\$p > svg > foreignObject > section summary{display:list-item}div#\:\$p > svg > foreignObject > section [hidden]{display:none!important}div#\:\$p > svg > foreignObject > section a{background-color:transparent;color:var(--fgColor-accent);text-decoration:none}div#\:\$p > svg > foreignObject > section abbr[title]{border-bottom:none;-webkit-text-decoration:underline dotted;text-decoration:underline dotted}div#\:\$p > svg > foreignObject > section b,div#\:\$p > svg > foreignObject > section strong{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section dfn{font-style:italic}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){border-bottom:1px solid var(--borderColor-muted);font-size:2em;font-weight:var(--base-text-weight-semibold, 600);margin:.67em 0;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section mark{background-color:var(--bgColor-attention-muted);color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section small{font-size:90%}div#\:\$p > svg > foreignObject > section sub,div#\:\$p > svg > foreignObject > section sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}div#\:\$p > svg > foreignObject > section sub{bottom:-.25em}div#\:\$p > svg > foreignObject > section sup{top:-.5em}div#\:\$p > svg > foreignObject > section img{border-style:none;box-sizing:content-box;max-width:100%}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section kbd,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp{font-family:monospace;font-size:1em}div#\:\$p > svg > foreignObject > section figure{margin:1em var(--base-size-40)}div#\:\$p > svg > foreignObject > section hr{background:transparent;background-color:var(--borderColor-default);border:0;box-sizing:content-box;height:.25em;margin:var(--base-size-24) 0;overflow:hidden;padding:0}div#\:\$p > svg > foreignObject > section input{font:inherit;font-family:inherit;font-size:inherit;line-height:inherit;margin:0;overflow:visible}div#\:\$p > svg > foreignObject > section [type=button],div#\:\$p > svg > foreignObject > section [type=reset],div#\:\$p > svg > foreignObject > section [type=submit]{-webkit-appearance:button;-moz-appearance:button;appearance:button}div#\:\$p > svg > foreignObject > section [type=checkbox],div#\:\$p > svg > foreignObject > section [type=radio]{box-sizing:border-box;padding:0}div#\:\$p > svg > foreignObject > section [type=number]::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section [type=number]::-webkit-outer-spin-button{height:auto}div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-cancel-button,div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-decoration{-webkit-appearance:none;appearance:none}div#\:\$p > svg > foreignObject > section ::-webkit-input-placeholder{color:inherit;opacity:.54}div#\:\$p > svg > foreignObject > section ::-webkit-file-upload-button{-webkit-appearance:button;appearance:button;font:inherit}div#\:\$p > svg > foreignObject > section a:hover{text-decoration:underline}div#\:\$p > svg > foreignObject > section ::-moz-placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section ::placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section hr:after,div#\:\$p > svg > foreignObject > section hr:before{content:"";display:table}div#\:\$p > svg > foreignObject > section hr:after{clear:both}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;border-spacing:0;display:block;font-variant:tabular-nums;max-width:100%;overflow:auto;width:-moz-max-content;width:max-content}div#\:\$p > svg > foreignObject > section td,div#\:\$p > svg > foreignObject > section th{padding:0}div#\:\$p > svg > foreignObject > section details summary{cursor:pointer}div#\:\$p > svg > foreignObject > section [role=button]:focus,div#\:\$p > svg > foreignObject > section a:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=radio]:focus:not(:focus-visible){outline:1px solid transparent}div#\:\$p > svg > foreignObject > section [role=button]:focus-visible,div#\:\$p > svg > foreignObject > section a:focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section a:not([class]):focus,div#\:\$p > svg > foreignObject > section a:not([class]):focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{outline-offset:0}div#\:\$p > svg > foreignObject > section kbd{background-color:var(--bgColor-muted);border-bottom-color:var(--borderColor-neutral-muted);border:1px solid var(--borderColor-neutral-muted);border-radius:6px;box-shadow:inset 0 -1px 0 var(--borderColor-neutral-muted);color:var(--fgColor-default);display:inline-block;font:11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);line-height:10px;padding:var(--base-size-4);vertical-align:middle}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-weight:var(--base-text-weight-semibold, 600);line-height:1.25;margin-bottom:var(--base-size-16);margin-top:var(--base-size-24)}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:1px solid var(--borderColor-muted);font-size:1.5em;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.25em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:.875em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){color:var(--fgColor-muted);font-size:.85em;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section p{margin-bottom:10px;margin-top:0}div#\:\$p > svg > foreignObject > section blockquote{border-left:.25em solid var(--borderColor-default);color:var(--fgColor-muted);margin:0;padding:0 1em}div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section ul{margin-bottom:0;margin-top:0;padding-left:2em}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ul ol{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol ol ol,div#\:\$p > svg > foreignObject > section ol ul ol,div#\:\$p > svg > foreignObject > section ul ol ol,div#\:\$p > svg > foreignObject > section ul ul ol{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section dd{margin-left:0}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp,div#\:\$p > svg > foreignObject > section tt{font-family:var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);font-size:12px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){margin-bottom:0;margin-top:0;word-wrap:normal}div#\:\$p > svg > foreignObject > section .octicon{display:inline-block;fill:currentColor;overflow:visible!important;vertical-align:text-bottom}div#\:\$p > svg > foreignObject > section input::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section input::-webkit-outer-spin-button{-webkit-appearance:none;appearance:none;margin:0}div#\:\$p > svg > foreignObject > section .mr-2{margin-right:var(--base-size-8, 8px)!important}div#\:\$p > svg > foreignObject > section:after,div#\:\$p > svg > foreignObject > section:before{display:table}div#\:\$p > svg > foreignObject > section:after{clear:both}div#\:\$p > svg > foreignObject > section>:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section>:last-child{margin-bottom:0!important}div#\:\$p > svg > foreignObject > section a:not([href]){color:inherit;text-decoration:none}div#\:\$p > svg > foreignObject > section .absent{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section .anchor{float:left;line-height:1;margin-left:-20px;padding-right:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .anchor:focus{outline:none}div#\:\$p > svg > foreignObject > section blockquote,div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section dl,div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section p,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section table,div#\:\$p > svg > foreignObject > section ul{margin-bottom:var(--base-size-16);margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) .octicon-link{color:var(--fgColor-default);vertical-align:middle;visibility:hidden}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor{text-decoration:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link{visibility:visible}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) code,div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) tt,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) code,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) tt,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) code,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) tt,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) code,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) tt,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) code,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) tt,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) code,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) tt{font-size:inherit;padding:0 .2em}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6){display:inline-block}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6) .anchor{margin-left:-40px}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2){border-bottom:0;padding-bottom:0}div#\:\$p > svg > foreignObject > section ol.no-list,div#\:\$p > svg > foreignObject > section ul.no-list{list-style-type:none;padding:0}div#\:\$p > svg > foreignObject > section ol[type="a s"]{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section ol[type="A s"]{list-style-type:upper-alpha}div#\:\$p > svg > foreignObject > section ol[type="i s"]{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol[type="I s"]{list-style-type:upper-roman}div#\:\$p > svg > foreignObject > section div>ol:not([type]),div#\:\$p > svg > foreignObject > section ol[type="1"]{list-style-type:decimal}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ol ul,div#\:\$p > svg > foreignObject > section ul ol,div#\:\$p > svg > foreignObject > section ul ul{margin-bottom:0;margin-top:0}div#\:\$p > svg > foreignObject > section li>p{margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section li+li{margin-top:.25em}div#\:\$p > svg > foreignObject > section dl{padding:0}div#\:\$p > svg > foreignObject > section dl dt{font-size:1em;font-style:italic;font-weight:var(--base-text-weight-semibold, 600);margin-top:var(--base-size-16);padding:0}div#\:\$p > svg > foreignObject > section dl dd{margin-bottom:var(--base-size-16);padding:0 var(--base-size-16)}div#\:\$p > svg > foreignObject > section table th{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border:1px solid var(--borderColor-default);padding:6px 13px}div#\:\$p > svg > foreignObject > section table td>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section table tr{background-color:var(--bgColor-default);border-top:1px solid var(--borderColor-muted)}div#\:\$p > svg > foreignObject > section table tr:nth-child(2n){background-color:var(--bgColor-muted)}div#\:\$p > svg > foreignObject > section table img{background-color:transparent}div#\:\$p > svg > foreignObject > section img[align=right]{padding-left:20px}div#\:\$p > svg > foreignObject > section img[align=left]{padding-right:20px}div#\:\$p > svg > foreignObject > section .emoji{background-color:transparent;max-width:none;vertical-align:text-top}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame,div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){border:1px solid var(--borderColor-default);float:left;margin:13px 0 0;padding:7px;width:auto}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) img{display:block;float:left}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) :is(span, marp-span){clear:both;color:var(--fgColor-default);display:block;padding:5px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center :is(span, marp-span) img{margin:0 auto;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right>:is(span, marp-span){display:block;margin:13px 0 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right :is(span, marp-span) img{margin:0;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left{display:block;float:left;margin-right:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left :is(span, marp-span){margin:13px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right{display:block;float:right;margin-left:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section tt{background-color:var(--bgColor-neutral-muted);border-radius:6px;font-size:85%;margin:0;padding:.2em .4em;white-space:break-spaces}div#\:\$p > svg > foreignObject > section code br,div#\:\$p > svg > foreignObject > section tt br{display:none}div#\:\$p > svg > foreignObject > section del code{text-decoration:inherit}div#\:\$p > svg > foreignObject > section samp{font-size:85%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{font-size:100%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent;border:0;margin:0;padding:0;white-space:pre;word-break:normal}div#\:\$p > svg > foreignObject > section .highlight{margin-bottom:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre){margin-bottom:0;word-break:normal}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background-color:var(--bgColor-muted);border-radius:6px;color:var(--fgColor-default);font-size:85%;line-height:1.45;overflow:auto;padding:var(--base-size-16)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) tt{display:inline;line-height:inherit;margin:0;overflow:visible;padding:0;word-wrap:normal;background-color:transparent;border:0}div#\:\$p > svg > foreignObject > section .csv-data td,div#\:\$p > svg > foreignObject > section .csv-data th{font-size:12px;line-height:1;overflow:hidden;padding:5px;text-align:left;white-space:nowrap}div#\:\$p > svg > foreignObject > section .csv-data .blob-num{background:var(--bgColor-default);border:0;padding:10px var(--base-size-8) 9px;text-align:right}div#\:\$p > svg > foreignObject > section .csv-data tr{border-top:0}div#\:\$p > svg > foreignObject > section .csv-data th{background:var(--bgColor-muted);border-top:0;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:before{content:"["}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:after{content:"]"}div#\:\$p > svg > foreignObject > section .footnotes{border-top:1px solid var(--borderColor-default);color:var(--fgColor-muted);font-size:12px}div#\:\$p > svg > foreignObject > section div#\:\$p > svg > foreignObject > section section.footnotes{--marpit-root-font-size:12px}div#\:\$p > svg > foreignObject > section .footnotes ol,div#\:\$p > svg > foreignObject > section .footnotes ol ul{padding-left:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes ol ul{display:inline-block;margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes li{position:relative}div#\:\$p > svg > foreignObject > section .footnotes li:target:before{border:2px solid var(--borderColor-accent-emphasis);border-radius:6px;bottom:calc(var(--base-size-8)*-1);content:"";left:calc(var(--base-size-24)*-1);pointer-events:none;position:absolute;right:calc(var(--base-size-8)*-1);top:calc(var(--base-size-8)*-1)}div#\:\$p > svg > foreignObject > section .footnotes li:target{color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section .footnotes .data-footnote-backref g-emoji{font-family:monospace}div#\:\$p > svg > foreignObject > section .pl-c{color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section .pl-c1,div#\:\$p > svg > foreignObject > section .pl-s .pl-v{color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section .pl-e,div#\:\$p > svg > foreignObject > section .pl-en{color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section .pl-s .pl-s1,div#\:\$p > svg > foreignObject > section .pl-smi{color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section .pl-ent{color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section .pl-k{color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section .pl-pds,div#\:\$p > svg > foreignObject > section .pl-s,div#\:\$p > svg > foreignObject > section .pl-s .pl-pse .pl-s1,div#\:\$p > svg > foreignObject > section .pl-sr,div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sra,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sre{color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section .pl-smw,div#\:\$p > svg > foreignObject > section .pl-v{color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section .pl-bu{color:var(--color-prettylights-syntax-brackethighlighter-unmatched)}div#\:\$p > svg > foreignObject > section .pl-ii{background-color:var(--color-prettylights-syntax-invalid-illegal-bg);color:var(--color-prettylights-syntax-invalid-illegal-text)}div#\:\$p > svg > foreignObject > section .pl-c2{background-color:var(--color-prettylights-syntax-carriage-return-bg);color:var(--color-prettylights-syntax-carriage-return-text)}div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce{color:var(--color-prettylights-syntax-string-regexp);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ml{color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section .pl-mh,div#\:\$p > svg > foreignObject > section .pl-mh .pl-en,div#\:\$p > svg > foreignObject > section .pl-ms{color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-mi{color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section .pl-mb{color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-md{background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section .pl-mi1{background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section .pl-mc{background-color:var(--color-prettylights-syntax-markup-changed-bg);color:var(--color-prettylights-syntax-markup-changed-text)}div#\:\$p > svg > foreignObject > section .pl-mi2{background-color:var(--color-prettylights-syntax-markup-ignored-bg);color:var(--color-prettylights-syntax-markup-ignored-text)}div#\:\$p > svg > foreignObject > section .pl-mdr{color:var(--color-prettylights-syntax-meta-diff-range);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ba{color:var(--color-prettylights-syntax-brackethighlighter-angle)}div#\:\$p > svg > foreignObject > section .pl-sg{color:var(--color-prettylights-syntax-sublimelinter-gutter-mark)}div#\:\$p > svg > foreignObject > section .pl-corl{color:var(--color-prettylights-syntax-constant-other-reference-link);text-decoration:underline}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section button:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section summary:focus:not(:focus-visible){box-shadow:none;outline:none}div#\:\$p > svg > foreignObject > section [tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section details-dialog:focus:not(:focus-visible){outline:none}div#\:\$p > svg > foreignObject > section g-emoji{display:inline-block;font-family:Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;font-size:1em;font-style:normal!important;font-weight:var(--base-text-weight-normal, 400);line-height:1;min-width:1ch;vertical-align:-.075em}div#\:\$p > svg > foreignObject > section g-emoji img{height:1em;width:1em}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote){display:block}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):not(:has(.snippet-clipboard-content,>:is(pre, marp-pre))){width:-moz-fit-content;width:fit-content}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):has(.snippet-clipboard-content,>:is(pre, marp-pre)):focus-visible{outline:2px solid var(--focus-outlineColor);outline-offset:2px}div#\:\$p > svg > foreignObject > section .task-list-item{list-style-type:none}div#\:\$p > svg > foreignObject > section .task-list-item label{font-weight:var(--base-text-weight-normal, 400)}div#\:\$p > svg > foreignObject > section .task-list-item.enabled label{cursor:pointer}div#\:\$p > svg > foreignObject > section .task-list-item+.task-list-item{margin-top:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .task-list-item .handle{display:none}div#\:\$p > svg > foreignObject > section .task-list-item-checkbox{margin:0 .2em .25em -1.4em;vertical-align:middle}div#\:\$p > svg > foreignObject > section ul:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section ol:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section .contains-task-list:focus-within .task-list-item-convert-container,div#\:\$p > svg > foreignObject > section .contains-task-list:hover .task-list-item-convert-container{clip-path:none;display:block;height:24px;overflow:visible;width:auto}div#\:\$p > svg > foreignObject > section ::-webkit-calendar-picker-indicator{filter:invert(50%)}div#\:\$p > svg > foreignObject > section .markdown-alert{border-left:.25em solid var(--borderColor-default);color:inherit;margin-bottom:var(--base-size-16);padding:var(--base-size-8) var(--base-size-16)}div#\:\$p > svg > foreignObject > section .markdown-alert>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section .markdown-alert>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section .markdown-alert .markdown-alert-title{align-items:center;display:flex;font-weight:var(--base-text-weight-medium, 500);line-height:1}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note{border-left-color:var(--borderColor-accent-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note .markdown-alert-title{color:var(--fgColor-accent)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important{border-left-color:var(--borderColor-done-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important .markdown-alert-title{color:var(--fgColor-done)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning{border-left-color:var(--borderColor-attention-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning .markdown-alert-title{color:var(--fgColor-attention)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip{border-left-color:var(--borderColor-success-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip .markdown-alert-title{color:var(--fgColor-success)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution{border-left-color:var(--borderColor-danger-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution .markdown-alert-title{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section>:first-child>.heading-element:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre):has(+.zeroclipboard-container){min-height:52px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:var(--h1-color);font-size:1.6em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:none}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-size:1.3em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1.05em}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-size:.9em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--heading-strong-color);font-weight:inherit}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6)::part(auto-scaling){max-height:563px}div#\:\$p > svg > foreignObject > section hr{height:0;padding-top:.25em}div#\:\$p > svg > foreignObject > section img{background-color:transparent}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){border:1px solid var(--borderColor-default);line-height:1.15;overflow:visible}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)::part(auto-scaling){max-height:529px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-doctag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-tag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-variable),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-type),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable.language_){color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_.inherited__),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.function_){color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attribute),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-literal),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-number),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-operator),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-class),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-id),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable){color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-string),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-regexp),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-string){color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-built_in),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-symbol){color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-code),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-comment),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-formula){color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-name),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-quote),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-pseudo),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-tag){color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-subst){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-section){color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-bullet){color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-emphasis){color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-strong){color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-addition){background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-deletion){background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header{color:var(--header-footer-color);font-size:18px;left:30px;margin:0;position:absolute}div#\:\$p > svg > foreignObject > section header{top:21px}div#\:\$p > svg > foreignObject > section footer{bottom:21px}div#\:\$p > svg > foreignObject > section{--h1-color:light-dark(#246, #cee7ff);--header-footer-color:light-dark(hsla(0,0%,40%,.75), hsla(0,0%,60%,.75));--heading-strong-color:light-dark(#48c, #7bf);--paginate-color:light-dark(#777, #999);--base-size-4:4px;--base-size-8:8px;--base-size-16:16px;--base-size-24:24px;--base-size-40:40px;align-items:stretch;display:block;flex-flow:column nowrap;font-size:29px;height:720px;padding:78.5px;place-content:safe center center;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:29px}div#\:\$p > svg > foreignObject > section>:last-child,div#\:\$p > svg > foreignObject > section[data-footer]>:nth-last-child(2){margin-bottom:0}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:after{bottom:21px;color:var(--paginate-color);font-size:24px;padding:0;position:absolute;right:30px}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:24px}div#\:\$p > svg > foreignObject > section[data-color] :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section[data-color] :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section[data-color] :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section[data-color] :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section[data-color] :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section[data-color] :is(h6, marp-h6){color:currentcolor}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > :where(section):not([\20 root]){--color-background: #000000;--color-foreground: #ffffff;--color-highlight: #ee0000;--color-dimmed: #a3a3a3;}div#\:\$p > svg > foreignObject > section{font-family:'Red Hat Text', sans-serif;background:#000000;color:#ffffff}div#\:\$p > svg > foreignObject > section::after{color:#a3a3a3;font-family:'Red Hat Mono', monospace;font-size:0.7em}div#\:\$p > svg > foreignObject > section::after{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1), div#\:\$p > svg > foreignObject > section :is(h2, marp-h2), div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-family:'Red Hat Display', sans-serif;color:#ffffff}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-weight:900}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-weight:700}div#\:\$p > svg > foreignObject > section code{font-family:'Red Hat Mono', monospace;background:#292929;border-radius:3px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:#1f1f1f;border:1px solid #383838;border-radius:3px}div#\:\$p > svg > foreignObject > section a{color:#f56e6e}div#\:\$p > svg > foreignObject > section strong{color:#ffffff}div#\:\$p > svg > foreignObject > section em{color:#c7c7c7}div#\:\$p > svg > foreignObject > section .accent{color:#ee0000}div#\:\$p > svg > foreignObject > section .tag{display:inline-block;padding:2px 14px;border:1px solid #383838;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#c7c7c7;margin:2px}div#\:\$p > svg > foreignObject > section section.tag{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .tag-accent{display:inline-block;padding:2px 14px;border:1px solid #ee0000;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#ee0000;margin:2px}div#\:\$p > svg > foreignObject > section section.tag-accent{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .muted{color:#a3a3a3}div#\:\$p > svg > foreignObject > section .small{font-size:0.75em}div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 0.75em}div#\:\$p > svg > foreignObject > section.lead :is(h1, marp-h1){font-size:2.8em}div#\:\$p > svg > foreignObject > section.lead .subtitle{color:#a3a3a3;font-size:1.1em;max-width:680px}div#\:\$p > svg > foreignObject > section.lead div#\:\$p > svg > foreignObject > section section.subtitle{--marpit-root-font-size: 1.1em}div#\:\$p > svg > foreignObject > section table{font-size:0.85em;background:transparent}div#\:\$p > svg > foreignObject > section th{background:#1f1f1f;border-color:#383838}div#\:\$p > svg > foreignObject > section td{border-color:#383838}div#\:\$p > svg > foreignObject > section.thankyou :is(h1, marp-h1){font-size:5em;text-align:center}div#\:\$p > svg > foreignObject > section.thankyou{display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
+</style></head><body><div class="bespoke-marp-osc"><button data-bespoke-marp-osc="prev" tabindex="-1" title="Previous slide">Previous slide</button><span data-bespoke-marp-osc="page"></span><button data-bespoke-marp-osc="next" tabindex="-1" title="Next slide">Next slide</button><button data-bespoke-marp-osc="fullscreen" tabindex="-1" title="Toggle fullscreen (f)">Toggle fullscreen</button><button data-bespoke-marp-osc="overview" tabindex="-1" title="Toggle overview view (o)">Toggle overview view</button><button data-bespoke-marp-osc="presenter" tabindex="-1" title="Open presenter view (p)">Open presenter view</button></div><div id=":$p"><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="1" data-paginate="true" data-class="lead" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="lead" data-marpit-pagination="1" style="--paginate:true;--class:lead;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h1 id="distributing-ai-skills-at-span-classaccententerprise-scalespan">Distributing AI Skills at <span class="accent">Enterprise Scale</span></h1>
+<p>Package, sign, and distribute agent skills as OCI artifacts — using the same registries and trust chains you already run for container images.</p>
+<p><span class="tag-accent">OCI Artifacts</span> <span class="tag">ORAS</span> <span class="tag">Sigstore</span> <span class="tag">Image Volumes</span></p>
+<p><span class="muted small">Pavel Anni · Office of CTO · Red Hat</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="2" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="2" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="your-agent-is-only-as-good-as-its-span-classaccentskillsspan">Your Agent Is Only as Good as Its <span class="accent">Skills</span></h2>
+<p>Skills are the unit of specialization. Each skill lives in its own subdirectory and gives the agent domain expertise.</p>
+<ul>
+<li><strong>SKILL.md</strong> — instructions in Agent Skills spec format</li>
+<li><strong>skill.yaml</strong> — metadata: tools, resources, versioning</li>
+</ul>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>skills/
+├── resume-screener/
+│   ├── SKILL.md
+│   └── skill.yaml
+├── policy-comparator/
+│   ├── SKILL.md
+│   └── skill.yaml
+└── checklist-auditor/
+    ├── SKILL.md
+    └── skill.yaml
+</code></pre>
+<p><span class="muted small">Agent Skills Specification — agentskills.io</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="3" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="3" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="todays-skill-distribution-is-span-classaccentad-hocspan">Today's Skill Distribution Is <span class="accent">Ad-Hoc</span></h2>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>How it works</th>
+<th>Drawback</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Copy from a Friend</strong></td>
+<td>Slack messages, email, shared drives</td>
+<td>No versioning. No provenance. No audit trail.</td>
+</tr>
+<tr>
+<td><strong>Clone from GitHub</strong></td>
+<td>git clone the repo, copy the directory</td>
+<td>No signing. No atomic versioning. Auth is coarse-grained.</td>
+</tr>
+<tr>
+<td><strong>Mount a ConfigMap</strong></td>
+<td>Embed skill text in a K8s ConfigMap</td>
+<td>1 MiB limit. No versioning. Mixes config with content.</td>
+</tr>
+</tbody>
+</table>
+<p>These get you started, but none provide the <strong>versioning, signing, and auditability</strong> that enterprise deployments require.</p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="4" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="enterprise-deployments-need-span-classaccenttrust-infrastructurespan">Enterprise Deployments Need <span class="accent">Trust Infrastructure</span></h2>
+<ul>
+<li><img class="emoji" draggable="false" alt="🔒" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f512.svg" data-marp-twemoji=""/> <strong>Signing</strong> — Cryptographic proof of who published a skill and that it hasn't been tampered with</li>
+<li><img class="emoji" draggable="false" alt="📋" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cb.svg" data-marp-twemoji=""/> <strong>Auditability</strong> — Registry logs show who pulled what, when, and where it was deployed</li>
+<li><img class="emoji" draggable="false" alt="🔄" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f504.svg" data-marp-twemoji=""/> <strong>Versioning</strong> — Immutable tags, semantic versions, rollback to a known-good skill set</li>
+<li><img class="emoji" draggable="false" alt="📌" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cc.svg" data-marp-twemoji=""/> <strong>Reproducibility</strong> — Pin skills by digest (sha256) for byte-identical deployments across environments</li>
+<li><img class="emoji" draggable="false" alt="🔑" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f511.svg" data-marp-twemoji=""/> <strong>Access control</strong> — Registry RBAC, pull secrets, org-scoped namespaces — the same policies you use for images</li>
+</ul>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="5" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="5" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="oci-is-not-just-for-span-classaccentcontainer-imagesspan">OCI Is Not Just for <span class="accent">Container Images</span></h2>
+<p>The OCI Distribution Specification is <strong>content-agnostic</strong>. Any blob + a manifest + a media type = a valid OCI artifact.</p>
+<p>The <strong>ORAS</strong> project (OCI Registry As Storage) makes this practical: push any content to any OCI registry with standard tooling.</p>
+<p><span class="tag">Helm Charts</span> <span class="tag">WASM Modules</span> <span class="tag">ML Models</span> <span class="tag">Policy Bundles</span> <span class="tag-accent">Agent Skills</span></p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>┌────────────────────────────────────────────────────┐
+│      OCI Registry (Quay / GHCR / Harbor / Zot)     │
+└────────────────────────────────────────────────────┘
+    ↓  Same protocol, same auth, same RBAC  ↓
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│  Container   │  │    Helm      │  │    Agent     │
+│   Images     │  │   Charts     │  │   Skills ★   │
+└──────────────┘  └──────────────┘  └──────────────┘
+</code></pre>
+<p><span class="muted small">ORAS — oras.land · OCI Distribution Spec</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="6" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="a-skill-becomes-an-span-classaccentoci-artifactspan">A Skill Becomes an <span class="accent">OCI Artifact</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Skill Directory  →  skillctl pack  →  OCI Layout  →  skillctl push  →  Registry
+</code></pre>
+<p><strong>What goes into the artifact:</strong></p>
+<ul>
+<li><code>SKILL.md</code> — instructions</li>
+<li><code>skill.yaml</code> — SkillCard metadata</li>
+<li>Any supporting files in the directory</li>
+</ul>
+<p><strong>What the registry provides:</strong></p>
+<ul>
+<li>Immutable digest + mutable tags</li>
+<li>RBAC &amp; pull secrets</li>
+<li>Cosign / sigstore signatures</li>
+</ul>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="7" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="7" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="the-workflow-span-classaccentpack-push-mountspan">The Workflow: <span class="accent">Pack, Push, Mount</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># Pack skill into a local OCI layout</span>
+$ skillctl pack examples/skills/resume-screener
+Packed skill → oci-layout · sha256:65af81ce... · 1226 bytes
 
-    /* === COLOR VARIABLES === */
-    :root {
-      --bg-primary: #000000;
-      --bg-secondary: #1f1f1f;
-      --bg-surface: #292929;
-      --text-primary: #ffffff;
-      --text-secondary: #c7c7c7;
-      --text-muted: #a3a3a3;
-      --accent: #ee0000;
-      --accent-dark: #a60000;
-      --accent-light: #f56e6e;
-      --tag-border: #383838;
-      --icon-filter: brightness(0) invert(1);
-      --icon-filter-accent: invert(12%) sepia(100%) saturate(10000%) hue-rotate(0deg) brightness(95%);
-      --font-display: var(--rh-font-family-heading, 'Red Hat Display', sans-serif);
-      --font-body: var(--rh-font-family-body-text, 'Red Hat Text', sans-serif);
-      --font-mono: var(--rh-font-family-code, 'Red Hat Mono', monospace);
-    }
+<span class="hljs-comment"># Push to registry (uses podman/docker credentials)</span>
+$ skillctl push examples/skills/resume-screener \
+    quay.io/docsclaw/skill-resume-screener:1.0.0
+Pushed → quay.io/docsclaw/skill-resume-screener:1.0.0
 
-    body {
-      font-family: var(--font-body);
-      background: var(--bg-primary);
-      color: var(--text-primary);
-      overflow: hidden;
-      height: 100vh;
-      width: 100vw;
-    }
+<span class="hljs-comment"># Push as mountable image (for image volumes)</span>
+$ skillctl push --as-image examples/skills/resume-screener \
+    quay.io/docsclaw/skill-resume-screener:1.0.0-image
 
-    /* === SLIDE CONTAINER === */
-    .deck { position: relative; width: 100%; height: 100vh; }
-    .slide {
-      display: none;
-      flex-direction: column;
-      justify-content: center;
-      width: 100%;
-      height: 100vh;
-      padding: var(--rh-space-4xl, 80px) var(--rh-space-3xl, 64px);
-      position: relative;
-      overflow: hidden;
-    }
-    .slide.active { display: flex; }
+<span class="hljs-comment"># Inspect remotely (no download needed)</span>
+$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
+Name: resume-screener · Version: 1.0.0 · Tools: [read_file]
+</code></pre>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="8" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="every-skill-has-a-span-classaccentmachine-readable-identityspan">Every Skill Has a <span class="accent">Machine-Readable Identity</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
 
-    /* === AMBIENT GLOW === */
-    .slide::before {
-      content: '';
-      position: absolute;
-      top: -20%;
-      right: -10%;
-      width: 60%;
-      height: 60%;
-      background: radial-gradient(ellipse, rgba(238,0,0,0.08) 0%, transparent 70%);
-      pointer-events: none;
-      z-index: 0;
-    }
-    .slide:nth-child(even)::before {
-      top: -10%;
-      right: auto;
-      left: -15%;
-    }
-    .slide:first-child::before {
-      background: radial-gradient(ellipse, rgba(238,0,0,0.12) 0%, transparent 70%);
-    }
-    .slide:last-child::before {
-      top: -30%;
-      right: -5%;
-      width: 80%;
-      height: 80%;
-      background: radial-gradient(ellipse, rgba(238,0,0,0.14) 0%, transparent 70%);
-    }
+Name:          resume-screener
+Namespace:     official
+Version:       1.0.0
+Description:   Screen resumes against a job description...
+Author:        Red Hat ET
+License:       Apache-2.0
+Tools:         [read_file]
+Memory:        32Mi
+CPU:           100m
+</code></pre>
+<p><strong>What SkillCard enables:</strong></p>
+<ul>
+<li><img class="emoji" draggable="false" alt="🔍" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f50d.svg" data-marp-twemoji=""/> <strong>Discovery</strong> — search by name, namespace, category, author</li>
+<li><img class="emoji" draggable="false" alt="📐" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4d0.svg" data-marp-twemoji=""/> <strong>Resource planning</strong> — CPU and memory hints before deployment</li>
+<li><img class="emoji" draggable="false" alt="🔗" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f517.svg" data-marp-twemoji=""/> <strong>Compatibility</strong> — required tools, dependencies, min agent version</li>
+<li><img class="emoji" draggable="false" alt="✅" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/2705.svg" data-marp-twemoji=""/> <strong>Governance</strong> — license, author, namespace for org-level trust policies</li>
+</ul>
+<blockquote>
+<p><strong>Future: Skill Catalog</strong> — A UI that queries registries, reads SkillCards, and presents a searchable catalog — browse by category, check signing status, deploy with one click.</p>
+</blockquote>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="9" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="image-volumes-mount-skills-span-classaccentdirectlyspan">Image Volumes: Mount Skills <span class="accent">Directly</span></h2>
+<p>On OpenShift 4.20+ / Kubernetes 1.33+, the kubelet can mount an OCI image as a <strong>read-only volume</strong> — no init container needed.</p>
+<ul>
+<li>Kubelet pulls and caches skill images</li>
+<li>Read-only mount — immutable at runtime</li>
+<li>No emptyDir, no node storage consumed</li>
+</ul>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">volumes:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-resume-screener</span>
+    <span class="hljs-attr">image:</span>
+      <span class="hljs-attr">reference:</span> <span class="hljs-string">quay.io/docsclaw/skill-resume-screener:1.0.0</span>
+      <span class="hljs-attr">pullPolicy:</span> <span class="hljs-string">IfNotPresent</span>
 
-    .slide > * { position: relative; z-index: 1; }
+<span class="hljs-attr">containers:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">docsclaw</span>
+    <span class="hljs-attr">volumeMounts:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-resume-screener</span>
+        <span class="hljs-attr">mountPath:</span> <span class="hljs-string">/skills/resume-screener</span>
+</code></pre>
+<p><span class="muted small">KEP-4639 · Kubernetes 1.33+ · OpenShift 4.20+</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="10" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="init-container-for-span-classaccentolder-clustersspan">Init Container for <span class="accent">Older Clusters</span></h2>
+<p>For Kubernetes &lt; 1.33 or OpenShift &lt; 4.20, use skillctl as an init container to pull skills before the agent starts.</p>
+<ul>
+<li>Pull at pod startup, verify signatures</li>
+<li>Cache on a PVC across restarts</li>
+<li>Share the volume with the main container</li>
+</ul>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">initContainers:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-puller</span>
+    <span class="hljs-attr">image:</span> <span class="hljs-string">ghcr.io/redhat-et/skillctl:latest</span>
+    <span class="hljs-attr">command:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;skillctl&quot;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;pull&quot;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;--verify&quot;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;-o&quot;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;/skills&quot;</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;quay.io/docsclaw/skill-resume-screener:1.0.0&quot;</span>
+</code></pre>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="11" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="11" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="from-ad-hoc-to-span-classaccentsupply-chainspan">From Ad-Hoc to <span class="accent">Supply Chain</span></h2>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>Before</th>
+<th>After (OCI)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Distribution</strong></td>
+<td>git clone or manual copy</td>
+<td>Push/pull with standard tooling</td>
+</tr>
+<tr>
+<td><strong>Versioning</strong></td>
+<td>Branch/tag only</td>
+<td>Semver tags + immutable digests</td>
+</tr>
+<tr>
+<td><strong>Signing</strong></td>
+<td>None</td>
+<td>Cosign / sigstore signing</td>
+</tr>
+<tr>
+<td><strong>Audit</strong></td>
+<td>No trail</td>
+<td>Registry access logs</td>
+</tr>
+<tr>
+<td><strong>Auth</strong></td>
+<td>Repo level only</td>
+<td>Per-namespace RBAC + pull secrets</td>
+</tr>
+<tr>
+<td><strong>Size</strong></td>
+<td>ConfigMap 1 MiB limit</td>
+<td>No limits</td>
+</tr>
+<tr>
+<td><strong>Runtime</strong></td>
+<td>Mutable</td>
+<td>Read-only image volume mount</td>
+</tr>
+</tbody>
+</table>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="12" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h2 id="try-it-span-classaccenttodayspan">Try It <span class="accent">Today</span></h2>
+<ul>
+<li><img class="emoji" draggable="false" alt="💻" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4bb.svg" data-marp-twemoji=""/> <strong>Hands-on:</strong> spin up a local Zot registry, pack a skill, push, inspect, pull — 5 minutes end to end</li>
+<li><img class="emoji" draggable="false" alt="🔀" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f500.svg" data-marp-twemoji=""/> <strong>Review the PR:</strong> design decisions, media types, and annotation schema are documented in the design spec — feedback welcome</li>
+<li><img class="emoji" draggable="false" alt="🤝" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f91d.svg" data-marp-twemoji=""/> <strong>Community:</strong> should we propose SkillCard alignment to the Agent Skills OCI Artifacts Specification?</li>
+<li><img class="emoji" draggable="false" alt="🔏" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f50f.svg" data-marp-twemoji=""/> <strong>Next milestone:</strong> full sigstore integration for keyless skill signing and verification</li>
+</ul>
+<p><span class="tag-accent">github.com/redhat-et/docsclaw</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="13" data-paginate="true" data-class="thankyou" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="thankyou" data-marpit-pagination="13" style="--paginate:true;--class:thankyou;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="13" data-size="16:9">
+<h1 id="thank-span-classaccentyouspan">Thank <span class="accent">You</span></h1>
+<p>Pavel Anni · Office of CTO · Red Hat</p>
+</section>
+<script>!function(){"use strict";const t={h1:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"1"},style:"display: block; font-size: 2em; margin-block-start: 0.67em; margin-block-end: 0.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h2:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"2"},style:"display: block; font-size: 1.5em; margin-block-start: 0.83em; margin-block-end: 0.83em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h3:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"3"},style:"display: block; font-size: 1.17em; margin-block-start: 1em; margin-block-end: 1em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h4:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"4"},style:"display: block; margin-block-start: 1.33em; margin-block-end: 1.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h5:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"5"},style:"display: block; font-size: 0.83em; margin-block-start: 1.67em; margin-block-end: 1.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h6:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"6"},style:"display: block; font-size: 0.67em; margin-block-start: 2.33em; margin-block-end: 2.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},span:{proto:()=>HTMLSpanElement},pre:{proto:()=>HTMLElement,style:"display: block; font-family: monospace; white-space: pre; margin: 1em 0; --marp-auto-scaling-white-space: pre;"}},e="data-marp-auto-scaling-wrapper",i="data-marp-auto-scaling-svg",n="data-marp-auto-scaling-container";class s extends HTMLElement{container;containerSize;containerObserver;svg;svgComputedStyle;svgPreserveAspectRatio="xMinYMid meet";wrapper;wrapperSize;wrapperObserver;constructor(){super();const t=t=>([e])=>{const{width:i,height:n}=e.contentRect;this[t]={width:i,height:n},this.updateSVGRect()};this.attachShadow({mode:"open"}),this.containerObserver=new ResizeObserver(t("containerSize")),this.wrapperObserver=new ResizeObserver((...e)=>{t("wrapperSize")(...e),this.flushSvgDisplay()})}static get observedAttributes(){return["data-downscale-only"]}connectedCallback(){this.shadowRoot.innerHTML=`\n<style>\n  svg[${i}] { display: block; width: 100%; height: auto; vertical-align: top; }\n  span[${n}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }\n</style>\n<div ${e}>\n  <svg part="svg" ${i}>\n    <foreignObject><span ${n}><slot></slot></span></foreignObject>\n  </svg>\n</div>\n    `.split(/\n\s*/).join(""),this.wrapper=this.shadowRoot.querySelector(`div[${e}]`)??void 0;const t=this.svg;this.svg=this.wrapper?.querySelector(`svg[${i}]`)??void 0,this.svg!==t&&(this.svgComputedStyle=this.svg?window.getComputedStyle(this.svg):void 0),this.container=this.svg?.querySelector(`span[${n}]`)??void 0,this.observe()}disconnectedCallback(){this.svg=void 0,this.svgComputedStyle=void 0,this.wrapper=void 0,this.container=void 0,this.observe()}attributeChangedCallback(){this.observe()}flushSvgDisplay(){const{svg:t}=this;t&&(t.style.display="inline",requestAnimationFrame(()=>{t.style.display=""}))}observe(){this.containerObserver.disconnect(),this.wrapperObserver.disconnect(),this.wrapper&&this.wrapperObserver.observe(this.wrapper),this.container&&this.containerObserver.observe(this.container),this.svgComputedStyle&&this.observeSVGStyle(this.svgComputedStyle)}observeSVGStyle(t){const e=()=>{const i=(()=>{const e=t.getPropertyValue("--preserve-aspect-ratio");if(e)return e.trim();return`x${(({textAlign:t,direction:e})=>{if(t.endsWith("left"))return"Min";if(t.endsWith("right"))return"Max";if("start"===t||"end"===t){let i="rtl"===e;return"end"===t&&(i=!i),i?"Max":"Min"}return"Mid"})(t)}YMid meet`})();i!==this.svgPreserveAspectRatio&&(this.svgPreserveAspectRatio=i,this.updateSVGRect()),t===this.svgComputedStyle&&requestAnimationFrame(e)};e()}updateSVGRect(){let t=Math.ceil(this.containerSize?.width??0);const e=Math.ceil(this.containerSize?.height??0);void 0!==this.dataset.downscaleOnly&&(t=Math.max(t,this.wrapperSize?.width??0));const i=this.svg?.querySelector(":scope > foreignObject");if(i?.setAttribute("width",`${t}`),i?.setAttribute("height",`${e}`),this.svg&&(this.svg.setAttribute("viewBox",`0 0 ${t} ${e}`),this.svg.setAttribute("preserveAspectRatio",this.svgPreserveAspectRatio),this.svg.style.height=t<=0||e<=0?"0":""),this.container){const t=this.svgPreserveAspectRatio.toLowerCase();this.container.style.marginLeft=t.startsWith("xmid")||t.startsWith("xmax")?"auto":"0",this.container.style.marginRight=t.startsWith("xmi")?"auto":"0"}}}const r=(t,{attrs:e={},style:i})=>class extends t{constructor(...t){super(...t);for(const[t,i]of Object.entries(e))this.hasAttribute(t)||this.setAttribute(t,i);this._shadow()}static get observedAttributes(){return["data-auto-scaling"]}connectedCallback(){this._update()}attributeChangedCallback(){this._update()}_shadow(){if(!this.shadowRoot)try{this.attachShadow({mode:"open"})}catch(t){if(!(t instanceof Error&&"NotSupportedError"===t.name))throw t}return this.shadowRoot}_update(){const t=this._shadow();if(t){const e=i?`<style>:host { ${i} }</style>`:"";let n="<slot></slot>";const{autoScaling:s}=this.dataset;if(void 0!==s){n=`<marp-auto-scaling exportparts="svg:auto-scaling" ${"downscale-only"===s?"data-downscale-only":""}>${n}</marp-auto-scaling>`}t.innerHTML=e+n}}};let o;const a=Symbol(),l=()=>o??(o=!!document.createElement("div",{is:"marp-auto-scaling"}).outerHTML.startsWith("<div is"),o);let c;const d="marpitSVGPolyfill:setZoomFactor,",h=Symbol(),g=Symbol();const p=()=>{const t="Apple Computer, Inc."===navigator.vendor,e=t?[v]:[],i={then:e=>(t?(async()=>{if(void 0===c){const t=document.createElement("canvas");t.width=10,t.height=10;const e=t.getContext("2d"),i=new Image(10,10),n=new Promise(t=>{i.addEventListener("load",()=>t())});i.crossOrigin="anonymous",i.src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%201%201%22%3E%3CforeignObject%20width%3D%221%22%20height%3D%221%22%20requiredExtensions%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%3E%3Cdiv%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%20style%3D%22width%3A%201px%3B%20height%3A%201px%3B%20background%3A%20red%3B%20position%3A%20relative%22%3E%3C%2Fdiv%3E%3C%2FforeignObject%3E%3C%2Fsvg%3E",await n,e.drawImage(i,0,0),c=e.getImageData(5,5,1,1).data[3]<128}return c})().then(t=>{null==e||e(t?[v]:[])}):null==e||e([]),i)};return Object.assign(e,i)};let m,u;function v(t){const e="object"==typeof t&&t.target||document,i="object"==typeof t?t.zoom:t;window[g]||(Object.defineProperty(window,g,{configurable:!0,value:!0}),document.body.style.zoom=1.0001,document.body.offsetHeight,document.body.style.zoom=1,window.addEventListener("message",({data:t,origin:e})=>{if(e===window.origin)try{if(t&&"string"==typeof t&&t.startsWith(d)){const[,e]=t.split(","),i=Number.parseFloat(e);Number.isNaN(i)||(u=i)}}catch(t){console.error(t)}}));let n=!1;Array.from(e.querySelectorAll("svg[data-marpit-svg]"),t=>{var e,s,r,o;t.style.transform||(t.style.transform="translateZ(0)");const a=i||u||t.currentScale||1;m!==a&&(m=a,n=a);const l=t.getBoundingClientRect(),{length:c}=t.children;for(let i=0;i<c;i+=1){const n=t.children[i];if(n.getScreenCTM){const t=n.getScreenCTM();if(t){const i=null!==(s=null===(e=n.x)||void 0===e?void 0:e.baseVal.value)&&void 0!==s?s:0,c=null!==(o=null===(r=n.y)||void 0===r?void 0:r.baseVal.value)&&void 0!==o?o:0,d=n.children.length;for(let e=0;e<d;e+=1){const s=n.children[e];if("SECTION"===s.tagName){const{style:e}=s;e.transformOrigin||(e.transformOrigin=`${-i}px ${-c}px`),e.transform=`scale(${a}) matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.e-l.left}, ${t.f-l.top}) translateZ(0.0001px)`;break}}}}}}),!1!==n&&Array.from(e.querySelectorAll("iframe"),({contentWindow:t})=>{null==t||t.postMessage(`${d}${n}`,"null"===window.origin?"*":window.origin)})}function w({once:t=!1,target:e=document}={}){const i=function(t=document){if(t[h])return t[h];let e=!0;const i=()=>{e=!1,delete t[h]};Object.defineProperty(t,h,{configurable:!0,value:i});let n=[],s=!1;(async()=>{try{n=await p()}finally{s=!0}})();const r=()=>{for(const e of n)e({target:t});s&&0===n.length||e&&window.requestAnimationFrame(r)};return r(),i}(e);return t?(i(),()=>{}):i}m=1,u=void 0;const b=Symbol(),y=(e=document)=>{if("undefined"==typeof window)throw new Error("Marp Core's browser script is valid only in browser context.");if(((e=document)=>{const i=window[a];i||customElements.define("marp-auto-scaling",s);for(const n of Object.keys(t)){const s=`marp-${n}`,o=t[n].proto();l()&&o!==HTMLElement?i||customElements.define(s,r(o,{style:t[n].style}),{extends:n}):(i||customElements.define(s,r(HTMLElement,t[n])),e.querySelectorAll(`${n}[is="${s}"]`).forEach(t=>{t.outerHTML=t.outerHTML.replace(new RegExp(`^<${n}`,"i"),`<${s}`).replace(new RegExp(`</${n}>$`,"i"),`</${s}>`)}))}window[a]=!0})(e),e[b])return e[b];const i=w({target:e}),n=()=>{i(),delete e[b]},o=Object.assign(n,{cleanup:n,update:()=>y(e)});return Object.defineProperty(e,b,{configurable:!0,value:o}),o},f=document.currentScript;y(f?f.getRootNode():document)}();
+</script></foreignObject></svg></div><div class="bespoke-marp-note" data-index="0" tabindex="0"><p>Tips: Arrow keys or click to navigate. Press N to toggle notes.
+Context: This feature was implemented in PR #21 on redhat-et/docsclaw.
+The design spec is at docs/dev/2026-04-12-oci-skill-distribution-design.md.</p></div><div class="bespoke-marp-note" data-index="1" tabindex="0"><p>Agent Skills Specification: agentskills.io/specification
 
-    /* === TYPOGRAPHY === */
-    h1 {
-      font-family: var(--font-display);
-      font-size: var(--rh-font-size-heading-2xl, 3rem);
-      font-weight: 900;
-      line-height: 1.1;
-      margin-bottom: var(--rh-space-lg, 24px);
-    }
-    h2 {
-      font-family: var(--font-display);
-      font-size: var(--rh-font-size-heading-lg, 2rem);
-      font-weight: 700;
-      line-height: 1.2;
-      margin-bottom: var(--rh-space-lg, 24px);
-    }
-    h3 {
-      font-family: var(--font-display);
-      font-size: var(--rh-font-size-heading-md, 1.5rem);
-      font-weight: 700;
-      line-height: 1.3;
-      margin-bottom: var(--rh-space-md, 16px);
-    }
-    .subtitle {
-      font-size: var(--rh-font-size-body-text-xl, 1.25rem);
-      color: var(--text-muted);
-      max-width: 680px;
-      line-height: 1.6;
-    }
-    .accent { color: var(--accent); }
-    .body-text {
-      font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-      color: var(--text-secondary);
-      line-height: 1.7;
-      max-width: 800px;
-    }
+Skills are the unit of specialization for an agent. Each skill is a self-contained
+directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
+discovers and loads them at startup.
 
-    /* === LOGO === */
-    .rh-logo { height: 28px; width: auto; }
-    .rh-logo.small { height: 20px; }
-    .rh-logo.large { height: 40px; }
+Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.</p></div><div class="bespoke-marp-note" data-index="2" tabindex="0"><p>Each of these methods gets progressively closer to enterprise readiness —
+ConfigMaps are already Kubernetes-native — but all three lack the supply chain
+guarantees (signing, versioning, audit) that regulated environments require.
 
-    /* === ICONS === */
-    .rh-icon { height: 48px; width: 48px; filter: var(--icon-filter); vertical-align: middle; }
-    .rh-icon.small { height: 24px; width: 24px; }
-    .rh-icon.medium { height: 48px; width: 48px; }
-    .rh-icon.large { height: 64px; width: 64px; }
-    .rh-icon.xl { height: 96px; width: 96px; }
-    .rh-icon.accent { filter: var(--icon-filter-accent); }
+ConfigMaps have a 1 MiB size limit (etcd constraint), so larger skills with
+examples or data files won't fit.</p></div><div class="bespoke-marp-note" data-index="3" tabindex="0"><p>This is the core motivation. When you deploy AI agents in a regulated enterprise,
+you need the same supply chain guarantees you have for container images: signed
+artifacts, vulnerability scanning, access control, and audit logs.
 
-    /* === BREADCRUMB === */
-    .breadcrumb {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      color: var(--text-muted);
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      position: absolute;
-      top: var(--rh-space-xl, 32px);
-      left: var(--rh-space-3xl, 64px);
-      display: flex;
-      align-items: center;
-      gap: var(--rh-space-sm, 8px);
-    }
+Reproducibility matters because you need to prove which exact skill version
+produced an agent's output — especially in regulated industries (finance,
+healthcare, government).</p></div><div class="bespoke-marp-note" data-index="4" tabindex="0"><p>ORAS (OCI Registry As Storage): oras.land
 
-    /* === SLIDE LABEL === */
-    .slide-label {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      color: var(--accent);
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      margin-bottom: var(--rh-space-md, 16px);
-    }
+The OCI Distribution Specification was designed to be content-agnostic. Media types
+let registries and tools distinguish content without special handling. Helm charts
+have been distributed as OCI artifacts since Helm 3.8 (2022). WASM modules, ML models,
+and policy bundles are also distributed this way.
 
-    /* === TAGS === */
-    .tags { display: flex; flex-wrap: wrap; gap: var(--rh-space-sm, 8px); margin-top: var(--rh-space-lg, 24px); }
-    .tag {
-      display: inline-block;
-      padding: var(--rh-space-xs, 4px) var(--rh-space-md, 16px);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-pill, 64px);
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-      color: var(--text-secondary);
-    }
-    .tag.accent { border-color: var(--accent); color: var(--accent); }
+Key insight: your Quay/Harbor/GHCR registry can already store and serve non-image content.
+No infrastructure changes needed.</p></div><div class="bespoke-marp-note" data-index="5" tabindex="0"><p>Community alignment: This implementation aligns with the Agent Skills OCI Artifacts
+Specification by Thomas Vitale.
 
-    /* === ATTRIBUTION === */
-    .attribution {
-      font-family: var(--font-body);
-      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-      color: var(--text-muted);
-      position: absolute;
-      bottom: var(--rh-space-xl, 32px);
-      left: var(--rh-space-3xl, 64px);
-    }
-    .source {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      color: var(--text-muted);
-      position: absolute;
-      bottom: var(--rh-space-xl, 32px);
-      left: var(--rh-space-3xl, 64px);
-    }
+Media types used:
+- application/vnd.oci.image.layer.v1.tar+gzip (skill content layer)
+- application/vnd.oci.image.config.v1+json (config with SkillCard metadata)
 
-    /* === GRID LAYOUTS === */
-    .two-col {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: var(--rh-space-2xl, 48px);
-      margin-top: var(--rh-space-lg, 24px);
-      width: 100%;
-      max-width: 1100px;
-    }
-    .three-col {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      gap: var(--rh-space-lg, 24px);
-      margin-top: var(--rh-space-lg, 24px);
-      width: 100%;
-      max-width: 1100px;
-    }
+The custom annotations (io.docsclaw.skill.*) carry SkillCard metadata in the manifest
+for fast inspection without pulling the full layer.</p></div><div class="bespoke-marp-note" data-index="6" tabindex="0"><p>The --as-image flag produces an OCI image (with rootfs layer) instead of an OCI artifact.
+This is required for Kubernetes image volumes, which expect a proper container image that
+the kubelet can pull via the container runtime.
 
-    /* === CARDS === */
-    .card {
-      background: var(--bg-secondary);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-lg, 24px);
-      box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21,21,21,0.2));
-    }
-    .card h3 { font-size: var(--rh-font-size-heading-sm, 1.25rem); }
-    .card p {
-      font-size: var(--rh-font-size-body-text-md, 1rem);
-      color: var(--text-secondary);
-      line-height: 1.6;
-      margin-top: var(--rh-space-sm, 8px);
-    }
-    .card .drawback {
-      color: var(--accent-light);
-      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-      margin-top: var(--rh-space-sm, 8px);
-      font-style: italic;
-    }
+Credential resolution is automatic: skillctl reads podman/docker auth configs, so if you've
+done 'podman login quay.io', push/pull just works.</p></div><div class="bespoke-marp-note" data-index="7" tabindex="0"><p>SkillCard schema: docsclaw.io/v1alpha1 kind: SkillCard. The metadata travels inside the
+OCI manifest annotations, so 'skill inspect' reads it without pulling the full layer.
 
-    /* === ARCHITECTURE BOXES === */
-    .arch-diagram {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: var(--rh-space-md, 16px);
-      margin-top: var(--rh-space-lg, 24px);
-      width: 100%;
-      max-width: 1000px;
-    }
-    .arch-row {
-      display: flex;
-      gap: var(--rh-space-md, 16px);
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-    }
-    .arch-box {
-      background: var(--bg-surface);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-md, 16px) var(--rh-space-lg, 24px);
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-      text-align: center;
-      display: flex;
-      align-items: center;
-      gap: var(--rh-space-sm, 8px);
-      box-shadow: var(--rh-box-shadow-sm, 0 2px 4px 0 rgba(21,21,21,0.2));
-    }
-    .arch-box.highlight {
-      border-color: var(--accent);
-      background: rgba(238, 0, 0, 0.08);
-    }
-    .arch-box.wide { flex: 1; justify-content: center; }
-    .arch-arrow {
-      font-size: 1.5rem;
-      color: var(--text-muted);
-    }
-    .arch-arrow-down {
-      font-size: 1.5rem;
-      color: var(--text-muted);
-      text-align: center;
-    }
+Future vision: a Skill Catalog UI that queries registries, reads SkillCard metadata, and
+presents a searchable, browsable catalog of available skills — like a curated app store
+for agent capabilities.
 
-    /* === CODE BLOCK === */
-    .code-block {
-      background: var(--bg-secondary);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-lg, 24px);
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-      line-height: 1.8;
-      color: var(--text-secondary);
-      overflow-x: auto;
-      max-width: 900px;
-      margin-top: var(--rh-space-md, 16px);
-    }
-    .code-block .cmd { color: var(--accent-light); }
-    .code-block .comment { color: var(--text-muted); }
-    .code-block .arg { color: #6ec8f5; }
+The SkillCard schema is intentionally extensible: additional fields (compatibility matrix,
+test results, usage metrics) can be added without breaking existing skills.</p></div><div class="bespoke-marp-note" data-index="8" tabindex="0"><p>Image Volumes (KEP-4639): GA in Kubernetes 1.33 / OpenShift 4.20.
 
-    /* === YAML BLOCK === */
-    .yaml-block {
-      background: var(--bg-secondary);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-lg, 24px);
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      line-height: 1.7;
-      color: var(--text-secondary);
-      overflow-x: auto;
-      max-width: 560px;
-      flex-shrink: 0;
-    }
-    .yaml-block .key { color: #6ec8f5; }
-    .yaml-block .val { color: var(--text-primary); }
-    .yaml-block .comment { color: var(--text-muted); }
+The kubelet pulls the image via the container runtime and mounts it read-only into the pod.
+No init container, no PVC, no emptyDir. The image is cached in the node's container image
+store — subsequent pods that use the same skill image don't need to pull again.
 
-    /* === COMPARISON === */
-    .compare-col { padding: var(--rh-space-lg, 24px); }
-    .compare-col h3 { margin-bottom: var(--rh-space-md, 16px); }
-    .compare-col.before { opacity: 0.7; }
-    .compare-col.after { border-left: var(--rh-border-width-md, 2px) solid var(--accent); padding-left: var(--rh-space-2xl, 48px); }
-    .compare-list {
-      list-style: none;
-      padding: 0;
-    }
-    .compare-list li {
-      font-size: var(--rh-font-size-body-text-md, 1rem);
-      color: var(--text-secondary);
-      line-height: 1.8;
-      padding-left: var(--rh-space-lg, 24px);
-      position: relative;
-    }
-    .compare-list li::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: 10px;
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-    }
-    .before .compare-list li::before { background: var(--text-muted); }
-    .after .compare-list li::before { background: var(--accent); }
+This is the exact same mechanism used for container images, so existing image pull policies
+(IfNotPresent, Always), pull secrets, and registry mirrors all work.</p></div><div class="bespoke-marp-note" data-index="9" tabindex="0"><p>For older clusters, the init container approach uses skillctl to pull skills from the
+registry before the main container starts. Use a PVC (not emptyDir) to persist the skill
+cache across pod restarts and avoid filling node ephemeral storage.
 
-    /* === FEATURE LIST === */
-    .feature-list {
-      list-style: none;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: var(--rh-space-md, 16px);
-      margin-top: var(--rh-space-md, 16px);
-      max-width: 800px;
-    }
-    .feature-list li {
-      display: flex;
-      align-items: flex-start;
-      gap: var(--rh-space-md, 16px);
-      font-size: var(--rh-font-size-body-text-lg, 1.125rem);
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
-    .feature-list li img { margin-top: 2px; flex-shrink: 0; }
-
-    /* === DIRECTORY TREE === */
-    .dir-tree {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-md, 1rem);
-      line-height: 1.8;
-      color: var(--text-secondary);
-      background: var(--bg-secondary);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-lg, 24px) var(--rh-space-xl, 32px);
-      max-width: 480px;
-    }
-    .dir-tree .highlight { color: var(--accent-light); }
-
-    /* === BIG NUMBER === */
-    .big-number {
-      font-family: var(--font-display);
-      font-size: 6rem;
-      font-weight: 900;
-      color: var(--accent);
-      line-height: 1;
-      margin-bottom: var(--rh-space-md, 16px);
-    }
-
-    /* === CONTROLS === */
-    .controls {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: var(--rh-space-sm, 8px) var(--rh-space-xl, 32px);
-      z-index: 100;
-    }
-    .nav-hint {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      color: var(--text-muted);
-      opacity: 0.5;
-    }
-    .progress {
-      font-family: var(--font-mono);
-      font-size: var(--rh-font-size-body-text-xs, 0.75rem);
-      color: var(--text-muted);
-    }
-    .progress .current { color: var(--accent); font-weight: 700; }
-
-    /* === NOTES PANEL === */
-    .notes-panel {
-      position: fixed;
-      bottom: 32px;
-      right: 0;
-      width: 380px;
-      max-height: 60vh;
-      background: var(--bg-secondary);
-      border: var(--rh-border-width-sm, 1px) solid var(--tag-border);
-      border-radius: var(--rh-border-radius-default, 3px) 0 0 var(--rh-border-radius-default, 3px);
-      padding: var(--rh-space-lg, 24px);
-      font-size: var(--rh-font-size-body-text-sm, 0.875rem);
-      color: var(--text-secondary);
-      line-height: 1.6;
-      overflow-y: auto;
-      transform: translateX(100%);
-      transition: transform 0.3s ease;
-      z-index: 200;
-      font-family: var(--font-body);
-    }
-    .notes-panel.visible { transform: translateX(0); }
-    .notes-panel a { color: var(--accent-light); }
-
-    /* === LOGO FOOTER === */
-    .logo-footer {
-      position: absolute;
-      bottom: var(--rh-space-3xl, 64px);
-      left: 50%;
-      transform: translateX(-50%);
-    }
-
-    /* === THANK YOU === */
-    .thank-you-slide {
-      align-items: center;
-      text-align: center;
-      justify-content: center;
-    }
-    .thank-you-slide h1 {
-      font-size: 5rem;
-    }
-    .thank-you-slide .attribution {
-      position: static;
-      margin-top: var(--rh-space-xl, 32px);
-    }
-
-    /* === ANIMATIONS === */
-    .animate-in { opacity: 0; transform: translateY(20px); }
-    .slide.active .animate-in {
-      animation: fadeSlideUp 0.6s ease-out forwards;
-    }
-    .slide.active .animate-in:nth-child(2) { animation-delay: 0.1s; }
-    .slide.active .animate-in:nth-child(3) { animation-delay: 0.2s; }
-    .slide.active .animate-in:nth-child(4) { animation-delay: 0.3s; }
-    .slide.active .animate-in:nth-child(5) { animation-delay: 0.4s; }
-    .slide.active .animate-in:nth-child(6) { animation-delay: 0.5s; }
-    .slide.active .animate-in:nth-child(7) { animation-delay: 0.6s; }
-
-    @keyframes fadeSlideUp {
-      from { opacity: 0; transform: translateY(20px); }
-      to   { opacity: 1; transform: translateY(0); }
-    }
-
-    /* === RESPONSIVE === */
-    @media (max-width: 768px) {
-      .slide { padding: var(--rh-space-xl, 32px) var(--rh-space-lg, 24px); }
-      h1 { font-size: 2rem; }
-      h2 { font-size: 1.5rem; }
-      .two-col, .three-col { grid-template-columns: 1fr; }
-      .breadcrumb { left: var(--rh-space-lg, 24px); }
-      .attribution, .source { left: var(--rh-space-lg, 24px); }
-      .big-number { font-size: 4rem; }
-      .thank-you-slide h1 { font-size: 3rem; }
-    }
-  </style>
-</head>
-<body>
-  <div class="deck">
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 1: TITLE                                                -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>Tips:</strong><br>- Arrow keys or click to navigate<br>- Press N to toggle these notes<br>- Works in any modern browser &mdash; share the HTML file directly<br>- For best results, use fullscreen (F11)<br><br><strong>Context:</strong> This feature was implemented in PR #21 on redhat-et/docsclaw. The design spec is at docs/dev/2026-04-12-oci-skill-distribution-design.md.<br><br>[IMAGE OPPORTUNITY] Prompt for AI image gen: &quot;Abstract dark background with glowing red container outlines transforming into neural network nodes, conveying the idea of packaging intelligence for distribution. Style: minimal, geometric, dark with red accents.&quot;">
-      <div class="breadcrumb">
-        <svg class="rh-logo small" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 613 145" role="img" aria-label="Red Hat"><title>Red Hat</title><path d="M127.47,83.49c12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42l-7.45-32.36c-1.72-7.12-3.23-10.35-15.73-16.6C124.89,8.69,103.76.5,97.51.5,91.69.5,90,8,83.06,8c-6.68,0-11.64-5.6-17.89-5.6-6,0-9.91,4.09-12.93,12.5,0,0-8.41,23.72-9.49,27.16A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33C22.27,52,.5,55,.5,74.22c0,31.48,74.59,70.28,133.65,70.28,45.28,0,56.7-20.48,56.7-36.65,0-12.72-11-27.16-30.83-35.78" fill="#e00"/><path d="M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33l3.66-9.06A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45,12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42Z"/><path d="M579.74,92.8c0,11.89,7.15,17.67,20.19,17.67a52.11,52.11,0,0,0,11.89-1.68V95a24.84,24.84,0,0,1-7.68,1.16c-5.37,0-7.36-1.68-7.36-6.73V68.3h15.56V54.1H596.78v-18l-17,3.68V54.1H568.49V68.3h11.25Zm-53,.32c0-3.68,3.69-5.47,9.26-5.47a43.12,43.12,0,0,1,10.1,1.26v7.15a21.51,21.51,0,0,1-10.63,2.63c-5.46,0-8.73-2.1-8.73-5.57m5.2,17.56c6,0,10.84-1.26,15.36-4.31v3.37h16.82V74.08c0-13.56-9.14-21-24.39-21-8.52,0-16.94,2-26,6.1l6.1,12.52c6.52-2.74,12-4.42,16.83-4.42,7,0,10.62,2.73,10.62,8.31v2.73a49.53,49.53,0,0,0-12.62-1.58c-14.31,0-22.93,6-22.93,16.73,0,9.78,7.78,17.24,20.19,17.24m-92.44-.94h18.09V80.92h30.29v28.82H506V36.12H487.93V64.41H457.64V36.12H439.55ZM370.62,81.87c0-8,6.31-14.1,14.62-14.1A17.22,17.22,0,0,1,397,72.09V91.54A16.36,16.36,0,0,1,385.24,96c-8.2,0-14.62-6.1-14.62-14.09m26.61,27.87h16.83V32.44l-17,3.68V57.05a28.3,28.3,0,0,0-14.2-3.68c-16.19,0-28.92,12.51-28.92,28.5a28.25,28.25,0,0,0,28.4,28.6,25.12,25.12,0,0,0,14.93-4.83ZM320,67c5.36,0,9.88,3.47,11.67,8.83H308.47C310.15,70.3,314.36,67,320,67M291.33,82c0,16.2,13.25,28.82,30.28,28.82,9.36,0,16.2-2.53,23.25-8.42l-11.26-10c-2.63,2.74-6.52,4.21-11.14,4.21a14.39,14.39,0,0,1-13.68-8.83h39.65V83.55c0-17.67-11.88-30.39-28.08-30.39a28.57,28.57,0,0,0-29,28.81M262,51.58c6,0,9.36,3.78,9.36,8.31S268,68.2,262,68.2H244.11V51.58Zm-36,58.16h18.09V82.92h13.77l13.89,26.82H292l-16.2-29.45a22.27,22.27,0,0,0,13.88-20.72c0-13.25-10.41-23.45-26-23.45H226Z" fill="#fff"/></svg>
-        <span>› Office of CTO</span>
-      </div>
-      <div class="slide-label animate-in">DocsClaw &middot; April 2026</div>
-      <h1 class="animate-in">Distributing AI Skills<br>at <span class="accent">Enterprise Scale</span></h1>
-      <p class="subtitle animate-in">Package, sign, and distribute agent skills as OCI artifacts &mdash; using the same registries and trust chains you already run for container images.</p>
-      <div class="tags animate-in">
-        <span class="tag accent">OCI Artifacts</span>
-        <span class="tag">ORAS</span>
-        <span class="tag">Sigstore</span>
-        <span class="tag">Image Volumes</span>
-      </div>
-      <div class="attribution">Pavel Anni &middot; Office of CTO &middot; Red Hat</div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 2: HOW SKILLS WORK                                      -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>Agent Skills Specification:</strong> <a href='https://agentskills.io/specification'>agentskills.io/specification</a><br><br>Skills are the unit of specialization for an agent. Each skill is a self-contained directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent discovers and loads them at startup.<br><br>Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/brain.svg" alt=""> Skills</div>
-      <h2 class="animate-in">Your Agent Is Only as Good<br>as Its <span class="accent">Skills</span></h2>
-      <div class="two-col animate-in">
-        <div>
-          <p class="body-text">Skills are the unit of specialization. Each skill lives in its own subdirectory and gives the agent domain expertise.</p>
-          <ul class="feature-list" style="margin-top: 24px;">
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/notepad.svg" alt=""> <span><strong>SKILL.md</strong> &mdash; instructions in Agent Skills spec format</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/checklist.svg" alt=""> <span><strong>skill.yaml</strong> &mdash; metadata: tools, resources, versioning</span></li>
-          </ul>
-        </div>
-        <div class="dir-tree">
-          skills/<br>
-          <span class="highlight">&boxvr;&HorizontalLine;&HorizontalLine; resume-screener/</span><br>
-          &boxv;&ensp;&ensp; &boxvr;&HorizontalLine;&HorizontalLine; SKILL.md<br>
-          &boxv;&ensp;&ensp; &boxur;&HorizontalLine;&HorizontalLine; skill.yaml<br>
-          <span class="highlight">&boxvr;&HorizontalLine;&HorizontalLine; policy-comparator/</span><br>
-          &boxv;&ensp;&ensp; &boxvr;&HorizontalLine;&HorizontalLine; SKILL.md<br>
-          &boxv;&ensp;&ensp; &boxur;&HorizontalLine;&HorizontalLine; skill.yaml<br>
-          <span class="highlight">&boxur;&HorizontalLine;&HorizontalLine; checklist-auditor/</span><br>
-          &ensp;&ensp;&ensp; &boxvr;&HorizontalLine;&HorizontalLine; SKILL.md<br>
-          &ensp;&ensp;&ensp; &boxur;&HorizontalLine;&HorizontalLine; skill.yaml
-        </div>
-      </div>
-      <div class="source">Agent Skills Specification &mdash; agentskills.io</div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 3: CURRENT DISTRIBUTION IS AD-HOC                       -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="Each of these methods gets progressively closer to enterprise readiness &mdash; ConfigMaps are already Kubernetes-native &mdash; but all three lack the supply chain guarantees (signing, versioning, audit) that regulated environments require.<br><br>ConfigMaps have a 1 MiB size limit (etcd constraint), so larger skills with examples or data files won't fit.">
-      <div class="slide-label animate-in"><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/alert.svg" alt=""> The Problem</div>
-      <h2 class="animate-in">Today's Skill Distribution Is <span class="accent">Ad-Hoc</span></h2>
-      <div class="three-col animate-in">
-        <div class="card">
-          <h3><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/share.svg" alt=""> Copy from a Friend</h3>
-          <p>Slack messages, email attachments, shared drives. "Hey, can you send me that skill you wrote?"</p>
-          <p class="drawback">No versioning. No provenance. No audit trail.</p>
-        </div>
-        <div class="card">
-          <h3><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/social/github.svg" alt=""> Clone from GitHub</h3>
-          <p>git clone the repo, copy the directory. Works for open source, common for personal agents.</p>
-          <p class="drawback">No signing. No atomic versioning. Auth is coarse-grained.</p>
-        </div>
-        <div class="card">
-          <h3><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/kubernetes-pod.svg" alt=""> Mount a ConfigMap</h3>
-          <p>Embed skill text in a Kubernetes ConfigMap. A natural first step for K8s deployments.</p>
-          <p class="drawback">1 MiB limit. No versioning. Mixes config with content.</p>
-        </div>
-      </div>
-      <p class="body-text animate-in" style="margin-top: 32px;">These get you started, but none provide the <strong style="color: var(--text-primary);">versioning, signing, and auditability</strong> that enterprise deployments require.</p>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 4: ENTERPRISE NEEDS MORE                                -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="This is the core motivation. When you deploy AI agents in a regulated enterprise, you need the same supply chain guarantees you have for container images: signed artifacts, vulnerability scanning, access control, and audit logs.<br><br>Reproducibility matters because you need to prove which exact skill version produced an agent's output &mdash; especially in regulated industries (finance, healthcare, government).">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/secured.svg" alt=""> Enterprise Requirements</div>
-      <h2 class="animate-in">Enterprise Deployments Need<br><span class="accent">Trust Infrastructure</span></h2>
-      <ul class="feature-list animate-in">
-        <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/padlock-locked.svg" alt=""> <span><strong>Signing</strong> &mdash; Cryptographic proof of who published a skill and that it hasn't been tampered with</span></li>
-        <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/report.svg" alt=""> <span><strong>Auditability</strong> &mdash; Registry logs show who pulled what, when, and where it was deployed</span></li>
-        <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/lifecycle.svg" alt=""> <span><strong>Versioning</strong> &mdash; Immutable tags, semantic versions, rollback to a known-good skill set</span></li>
-        <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/automation.svg" alt=""> <span><strong>Reproducibility</strong> &mdash; Pin skills by digest (sha256) for byte-identical deployments across environments</span></li>
-        <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/key.svg" alt=""> <span><strong>Access control</strong> &mdash; Registry RBAC, pull secrets, org-scoped namespaces &mdash; the same policies you use for images</span></li>
-      </ul>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 5: OCI IS NOT JUST FOR CONTAINER IMAGES                 -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>ORAS (OCI Registry As Storage):</strong> <a href='https://oras.land'>oras.land</a><br><br>The OCI Distribution Specification was designed to be content-agnostic. Media types let registries and tools distinguish content without special handling. Helm charts have been distributed as OCI artifacts since Helm 3.8 (2022). WASM modules, ML models, and policy bundles are also distributed this way.<br><br>Key insight: your Quay/Harbor/GHCR registry can already store and serve non-image content. No infrastructure changes needed.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-registry.svg" alt=""> Key Insight</div>
-      <h2 class="animate-in">OCI Is Not Just for <span class="accent">Container Images</span></h2>
-      <div class="two-col animate-in">
-        <div>
-          <p class="body-text">The OCI Distribution Specification is <strong style="color: var(--text-primary);">content-agnostic</strong>. Any blob + a manifest + a media type = a valid OCI artifact.</p>
-          <p class="body-text" style="margin-top: 16px;">The <strong style="color: var(--text-primary);">ORAS</strong> project (OCI Registry As Storage) makes this practical: push any content to any OCI registry with standard tooling.</p>
-          <div class="tags" style="margin-top: 24px;">
-            <span class="tag">Helm Charts</span>
-            <span class="tag">WASM Modules</span>
-            <span class="tag">ML Models</span>
-            <span class="tag">Policy Bundles</span>
-            <span class="tag accent">Agent Skills</span>
-          </div>
-        </div>
-        <div class="arch-diagram" style="margin-top: 0;">
-          <div class="arch-box wide">
-            <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-registry.svg" alt="">
-            OCI Registry (Quay / GHCR / Harbor / Zot)
-          </div>
-          <div class="arch-arrow-down">&darr;&ensp;&ensp;Same protocol, same auth, same RBAC&ensp;&ensp;&darr;</div>
-          <div class="arch-row">
-            <div class="arch-box">
-              <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-image.svg" alt="">
-              Container Images
-            </div>
-            <div class="arch-box">
-              <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/certification.svg" alt="">
-              Helm Charts
-            </div>
-            <div class="arch-box highlight">
-              <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/brain.svg" alt="">
-              Agent Skills
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="source">ORAS &mdash; oras.land &middot; OCI Distribution Spec &mdash; github.com/opencontainers/distribution-spec</div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 6: SKILLS AS OCI ARTIFACTS                              -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>Community alignment:</strong> This implementation aligns with the Agent Skills OCI Artifacts Specification by Thomas Vitale (<a href='https://github.com/ThomasVitale/agents-skills-oci-artifacts-spec'>github.com/ThomasVitale/agents-skills-oci-artifacts-spec</a>).<br><br>Media types used:<br>- application/vnd.oci.image.layer.v1.tar+gzip (skill content layer)<br>- application/vnd.oci.image.config.v1+json (config with SkillCard metadata)<br><br>The custom annotations (io.docsclaw.skill.*) carry SkillCard metadata in the manifest for fast inspection without pulling the full layer.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-image.svg" alt=""> Architecture</div>
-      <h2 class="animate-in">A Skill Becomes an <span class="accent">OCI Artifact</span></h2>
-      <div class="arch-diagram animate-in">
-        <div class="arch-row">
-          <div class="arch-box">
-            <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/folder.svg" alt="">
-            Skill Directory
-          </div>
-          <div class="arch-arrow">&xrarr;</div>
-          <div class="arch-box highlight">
-            <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-image.svg" alt="">
-            skillctl pack
-          </div>
-          <div class="arch-arrow">&xrarr;</div>
-          <div class="arch-box">
-            <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/storage.svg" alt="">
-            OCI Layout
-          </div>
-        </div>
-        <div class="arch-arrow-down">&darr;</div>
-        <div class="arch-row">
-          <div class="arch-box">
-            <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/storage.svg" alt="">
-            OCI Layout
-          </div>
-          <div class="arch-arrow">&xrarr;</div>
-          <div class="arch-box highlight">
-            <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/upload.svg" alt="">
-            skillctl push
-          </div>
-          <div class="arch-arrow">&xrarr;</div>
-          <div class="arch-box">
-            <img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-registry.svg" alt="">
-            quay.io/docsclaw/skill-*
-          </div>
-        </div>
-      </div>
-      <div class="two-col animate-in" style="margin-top: 32px; max-width: 1000px;">
-        <div>
-          <h3 style="color: var(--text-primary);">What goes into the artifact</h3>
-          <ul class="feature-list">
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/paper-lined.svg" alt=""> <span>SKILL.md &mdash; instructions</span></li>
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/checklist.svg" alt=""> <span>skill.yaml &mdash; SkillCard metadata</span></li>
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/paper-stack-lined.svg" alt=""> <span>Any supporting files in the directory</span></li>
-          </ul>
-        </div>
-        <div>
-          <h3 style="color: var(--text-primary);">What the registry provides</h3>
-          <ul class="feature-list">
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/pricetag.svg" alt=""> <span>Immutable digest + mutable tags</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/padlock-locked.svg" alt=""> <span>RBAC &amp; pull secrets</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/fingerprint.svg" alt=""> <span>Cosign / sigstore signatures</span></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 7: THE WORKFLOW                                         -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="The --as-image flag produces an OCI image (with rootfs layer) instead of an OCI artifact. This is required for Kubernetes image volumes, which expect a proper container image that the kubelet can pull via the container runtime.<br><br>Credential resolution is automatic: skillctl reads podman/docker auth configs, so if you've done 'podman login quay.io', push/pull just works.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/command-line.svg" alt=""> Demo</div>
-      <h2 class="animate-in">The Workflow: <span class="accent">Pack, Push, Mount</span></h2>
-      <div class="code-block animate-in">
-        <span class="comment"># Pack skill into a local OCI layout</span><br>
-        <span class="cmd">$ skillctl pack</span> <span class="arg">examples/skills/resume-screener</span><br>
-        <span style="color: var(--text-muted);">Packed skill &rarr; oci-layout &middot; sha256:65af81ce... &middot; 1226 bytes</span><br><br>
-
-        <span class="comment"># Push to registry (uses podman/docker credentials)</span><br>
-        <span class="cmd">$ skillctl push</span> <span class="arg">examples/skills/resume-screener \<br>&ensp;&ensp;quay.io/docsclaw/skill-resume-screener:1.0.0</span><br>
-        <span style="color: var(--text-muted);">Pushed &rarr; quay.io/docsclaw/skill-resume-screener:1.0.0</span><br><br>
-
-        <span class="comment"># Push as mountable image (for image volumes)</span><br>
-        <span class="cmd">$ skillctl push --as-image</span> <span class="arg">examples/skills/resume-screener \<br>&ensp;&ensp;quay.io/docsclaw/skill-resume-screener:1.0.0-image</span><br><br>
-
-        <span class="comment"># Inspect remotely (no download needed)</span><br>
-        <span class="cmd">$ skillctl inspect</span> <span class="arg">quay.io/docsclaw/skill-resume-screener:1.0.0</span><br>
-        <span style="color: var(--text-muted);">Name: resume-screener &middot; Version: 1.0.0 &middot; Tools: [read_file]</span>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 8: SKILLCARD — INSPECT & CATALOG                        -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>SkillCard schema:</strong> docsclaw.io/v1alpha1 kind: SkillCard. The metadata travels inside the OCI manifest annotations, so 'skill inspect' reads it without pulling the full layer.<br><br>Future vision: a Skill Catalog UI that queries registries, reads SkillCard metadata, and presents a searchable, browsable catalog of available skills &mdash; like a curated app store for agent capabilities. Teams can discover skills by category, see resource requirements, check signing status, and deploy with one click.<br><br>The SkillCard schema is intentionally extensible: additional fields (compatibility matrix, test results, usage metrics) can be added without breaking existing skills.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/catalog.svg" alt=""> SkillCard</div>
-      <h2 class="animate-in">Every Skill Has a <span class="accent">Machine-Readable Identity</span></h2>
-      <div class="two-col animate-in">
-        <div>
-          <p class="body-text">The <strong style="color: var(--text-primary);">SkillCard</strong> (<code style="font-family: var(--font-mono); background: var(--bg-surface); padding: 2px 8px; border-radius: 3px;">skill.yaml</code>) carries structured metadata alongside the skill instructions. Inspect it remotely without pulling the full content:</p>
-          <div class="code-block" style="margin-top: 16px; max-width: 100%;">
-            <span class="cmd">$ skillctl inspect</span> <span class="arg">\<br>&ensp;&ensp;quay.io/docsclaw/skill-resume-screener:1.0.0</span><br><br>
-            <span style="color: #6ec8f5;">Name:</span>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;resume-screener<br>
-            <span style="color: #6ec8f5;">Namespace:</span>&ensp;&ensp;&ensp;official<br>
-            <span style="color: #6ec8f5;">Version:</span>&ensp;&ensp;&ensp;&ensp;&ensp;1.0.0<br>
-            <span style="color: #6ec8f5;">Description:</span>&ensp;Screen resumes against<br>
-            &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;a job description...<br>
-            <span style="color: #6ec8f5;">Author:</span>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;Red Hat ET<br>
-            <span style="color: #6ec8f5;">License:</span>&ensp;&ensp;&ensp;&ensp;&ensp;Apache-2.0<br>
-            <span style="color: #6ec8f5;">Tools:</span>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[read_file]<br>
-            <span style="color: #6ec8f5;">Memory:</span>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;32Mi<br>
-            <span style="color: #6ec8f5;">CPU:</span>&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;100m
-          </div>
-        </div>
-        <div>
-          <h3 style="color: var(--text-primary); margin-bottom: 16px;">What SkillCard enables</h3>
-          <ul class="feature-list">
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/magnifying-glass.svg" alt=""> <span><strong>Discovery</strong> &mdash; search skills by name, namespace, category, author</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/scalable.svg" alt=""> <span><strong>Resource planning</strong> &mdash; CPU and memory hints before deployment</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/interoperability.svg" alt=""> <span><strong>Compatibility</strong> &mdash; required tools, dependencies, min agent version</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/certification.svg" alt=""> <span><strong>Governance</strong> &mdash; license, author, namespace for org-level trust policies</span></li>
-          </ul>
-          <div class="card" style="margin-top: 24px; border-color: var(--accent); background: rgba(238,0,0,0.05);">
-            <h3><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/catalog.svg" alt=""> Future: Skill Catalog</h3>
-            <p>A UI that queries registries, reads SkillCards, and presents a searchable catalog &mdash; browse by category, check signing status, deploy with one click.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 9: IMAGE VOLUMES (was 8)                                 -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>Image Volumes (KEP-4639):</strong> GA in Kubernetes 1.33 / OpenShift 4.20.<br><br>The kubelet pulls the image via the container runtime and mounts it read-only into the pod. No init container, no PVC, no emptyDir. The image is cached in the node's container image store &mdash; subsequent pods that use the same skill image don't need to pull again.<br><br>This is the exact same mechanism used for container images, so existing image pull policies (IfNotPresent, Always), pull secrets, and registry mirrors all work.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/kubernetes-pod.svg" alt=""> Preferred Method</div>
-      <h2 class="animate-in">Image Volumes: Mount Skills <span class="accent">Directly</span></h2>
-      <div class="two-col animate-in">
-        <div>
-          <p class="body-text">On OpenShift 4.20+ / Kubernetes 1.33+, the kubelet can mount an OCI image as a <strong style="color: var(--text-primary);">read-only volume</strong> &mdash; no init container needed.</p>
-          <ul class="feature-list" style="margin-top: 24px;">
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/container-image.svg" alt=""> <span>Kubelet pulls and caches skill images</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/padlock-locked.svg" alt=""> <span>Read-only mount &mdash; immutable at runtime</span></li>
-            <li><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/scalable.svg" alt=""> <span>No emptyDir, no node storage consumed</span></li>
-          </ul>
-        </div>
-        <div class="yaml-block">
-          <span class="key">volumes:</span><br>
-          &ensp;&ensp;- <span class="key">name:</span> <span class="val">skill-resume-screener</span><br>
-          &ensp;&ensp;&ensp;&ensp;<span class="key">image:</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="key">reference:</span> <span class="val" style="color: var(--accent-light);">quay.io/docsclaw/</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="val" style="color: var(--accent-light);">skill-resume-screener:1.0.0</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="key">pullPolicy:</span> <span class="val">IfNotPresent</span><br>
-          <br>
-          <span class="key">containers:</span><br>
-          &ensp;&ensp;- <span class="key">name:</span> <span class="val">docsclaw</span><br>
-          &ensp;&ensp;&ensp;&ensp;<span class="key">volumeMounts:</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="key">name:</span> <span class="val">skill-resume-screener</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="key">mountPath:</span> <span class="val">/skills/resume-screener</span>
-        </div>
-      </div>
-      <div class="source">KEP-4639 &middot; Kubernetes 1.33+ &middot; OpenShift 4.20+</div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 10: INIT CONTAINER FALLBACK                              -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="For older clusters, the init container approach uses skillctl to pull skills from the registry before the main container starts. Use a PVC (not emptyDir) to persist the skill cache across pod restarts and avoid filling node ephemeral storage.<br><br>Signature verification happens at pull time: --verify + --key flags enforce cosign verification before extracting the skill.">
-      <div class="slide-label animate-in"><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/server-stack.svg" alt=""> Universal Fallback</div>
-      <h2 class="animate-in">Init Container for <span class="accent">Older Clusters</span></h2>
-      <div class="two-col animate-in">
-        <div>
-          <p class="body-text">For Kubernetes &lt; 1.33 or OpenShift &lt; 4.20, use skillctl as an init container to pull skills before the agent starts.</p>
-          <ul class="feature-list" style="margin-top: 24px;">
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/download.svg" alt=""> <span>Pull at pod startup, verify signatures</span></li>
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/storage.svg" alt=""> <span>Cache on a PVC across restarts</span></li>
-            <li><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/share.svg" alt=""> <span>Share the volume with the main container</span></li>
-          </ul>
-        </div>
-        <div class="yaml-block">
-          <span class="key">initContainers:</span><br>
-          &ensp;&ensp;- <span class="key">name:</span> <span class="val">skill-puller</span><br>
-          &ensp;&ensp;&ensp;&ensp;<span class="key">image:</span> <span class="val">ghcr.io/redhat-et/</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="val">skillctl:latest</span><br>
-          &ensp;&ensp;&ensp;&ensp;<span class="key">command:</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val">"skillctl"</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val">"pull"</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val">"--verify"</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val">"-o"</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val">"/skills"</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;- <span class="val" style="color: var(--accent-light);">quay.io/docsclaw/</span><br>
-          &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;<span class="val" style="color: var(--accent-light);">skill-resume-screener:1.0.0</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 11: COMPARISON                                          -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="The before/after contrast highlights what OCI distribution adds to the picture. All the &quot;after&quot; properties come for free from the OCI ecosystem &mdash; registries, sigstore, RBAC, pull policies &mdash; we're just reusing existing infrastructure.">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/scalable.svg" alt=""> Comparison</div>
-      <h2 class="animate-in">From Ad-Hoc to <span class="accent">Supply Chain</span></h2>
-      <div class="two-col animate-in">
-        <div class="compare-col before">
-          <h3><img class="rh-icon small" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/padlock-unlocked.svg" alt=""> Before</h3>
-          <ul class="compare-list">
-            <li>git clone or manual copy</li>
-            <li>No versioning beyond branch/tag</li>
-            <li>No cryptographic signing</li>
-            <li>No audit trail for downloads</li>
-            <li>Auth at repo level only</li>
-            <li>ConfigMap size limits (1 MiB)</li>
-            <li>Mutable at runtime</li>
-          </ul>
-        </div>
-        <div class="compare-col after">
-          <h3><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/padlock-locked.svg" alt=""> After (OCI)</h3>
-          <ul class="compare-list">
-            <li>Push/pull with standard tooling</li>
-            <li>Semver tags + immutable digests</li>
-            <li>Cosign / sigstore signing</li>
-            <li>Registry access logs</li>
-            <li>Per-namespace RBAC + pull secrets</li>
-            <li>No size limits</li>
-            <li>Read-only image volume mount</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 12: NEXT STEPS / CTA                                    -->
-    <!-- ============================================================ -->
-    <div class="slide" data-notes="<strong>Resources:</strong><br>- PR #21: <a href='https://github.com/redhat-et/docsclaw/pull/21'>github.com/redhat-et/docsclaw/pull/21</a><br>- Design spec: docs/dev/2026-04-12-oci-skill-distribution-design.md<br>- OCI skills guide: docs/oci-skills-guide.md<br>- Agent Skills OCI Spec: <a href='https://github.com/ThomasVitale/agents-skills-oci-artifacts-spec'>github.com/ThomasVitale/agents-skills-oci-artifacts-spec</a><br>- ORAS project: <a href='https://oras.land'>oras.land</a><br>- Zot registry: <a href='https://zotregistry.dev'>zotregistry.dev</a>">
-      <div class="slide-label animate-in"><img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/rocket.svg" alt=""> Next Steps</div>
-      <h2 class="animate-in">Try It <span class="accent">Today</span></h2>
-      <ul class="feature-list animate-in">
-        <li>
-          <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/command-line.svg" alt="">
-          <span><strong>Hands-on:</strong> spin up a local Zot registry, pack a skill, push, inspect, pull &mdash; 5 minutes end to end</span>
-        </li>
-        <li>
-          <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/code-branch.svg" alt="">
-          <span><strong>Review the PR:</strong> design decisions, media types, and annotation schema are documented in the design spec &mdash; feedback welcome</span>
-        </li>
-        <li>
-          <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/collaboration.svg" alt="">
-          <span><strong>Community:</strong> should we propose SkillCard alignment to the Agent Skills OCI Artifacts Specification?</span>
-        </li>
-        <li>
-          <img class="rh-icon small accent" src="https://cdn.jsdelivr.net/npm/@rhds/icons@2.1.0/standard/fingerprint.svg" alt="">
-          <span><strong>Next milestone:</strong> full sigstore integration for keyless skill signing and verification</span>
-        </li>
-      </ul>
-      <div class="tags animate-in" style="margin-top: 32px;">
-        <span class="tag accent">github.com/redhat-et/docsclaw</span>
-      </div>
-    </div>
-
-    <!-- ============================================================ -->
-    <!-- SLIDE 13: THANK YOU                                           -->
-    <!-- ============================================================ -->
-    <div class="slide thank-you-slide" data-notes="Thank you for your time. Questions and feedback welcome.">
-      <h1 class="animate-in">Thank <span class="accent">You</span></h1>
-      <div class="attribution animate-in">Pavel Anni &middot; Office of CTO &middot; Red Hat</div>
-      <div class="logo-footer animate-in">
-        <svg class="rh-logo large" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 613 145" role="img" aria-label="Red Hat"><title>Red Hat</title><path d="M127.47,83.49c12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42l-7.45-32.36c-1.72-7.12-3.23-10.35-15.73-16.6C124.89,8.69,103.76.5,97.51.5,91.69.5,90,8,83.06,8c-6.68,0-11.64-5.6-17.89-5.6-6,0-9.91,4.09-12.93,12.5,0,0-8.41,23.72-9.49,27.16A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33C22.27,52,.5,55,.5,74.22c0,31.48,74.59,70.28,133.65,70.28,45.28,0,56.7-20.48,56.7-36.65,0-12.72-11-27.16-30.83-35.78" fill="#e00"/><path d="M160,72.07c1.73,8.19,1.73,9.05,1.73,10.13,0,14-15.74,21.77-36.43,21.77C78.54,104,37.58,76.6,37.58,58.49a18.45,18.45,0,0,1,1.51-7.33l3.66-9.06A6.43,6.43,0,0,0,42.53,44c0,9.22,36.3,39.45,84.94,39.45,12.51,0,30.61-2.58,30.61-17.46a14,14,0,0,0-.31-3.42Z"/><path d="M579.74,92.8c0,11.89,7.15,17.67,20.19,17.67a52.11,52.11,0,0,0,11.89-1.68V95a24.84,24.84,0,0,1-7.68,1.16c-5.37,0-7.36-1.68-7.36-6.73V68.3h15.56V54.1H596.78v-18l-17,3.68V54.1H568.49V68.3h11.25Zm-53,.32c0-3.68,3.69-5.47,9.26-5.47a43.12,43.12,0,0,1,10.1,1.26v7.15a21.51,21.51,0,0,1-10.63,2.63c-5.46,0-8.73-2.1-8.73-5.57m5.2,17.56c6,0,10.84-1.26,15.36-4.31v3.37h16.82V74.08c0-13.56-9.14-21-24.39-21-8.52,0-16.94,2-26,6.1l6.1,12.52c6.52-2.74,12-4.42,16.83-4.42,7,0,10.62,2.73,10.62,8.31v2.73a49.53,49.53,0,0,0-12.62-1.58c-14.31,0-22.93,6-22.93,16.73,0,9.78,7.78,17.24,20.19,17.24m-92.44-.94h18.09V80.92h30.29v28.82H506V36.12H487.93V64.41H457.64V36.12H439.55ZM370.62,81.87c0-8,6.31-14.1,14.62-14.1A17.22,17.22,0,0,1,397,72.09V91.54A16.36,16.36,0,0,1,385.24,96c-8.2,0-14.62-6.1-14.62-14.09m26.61,27.87h16.83V32.44l-17,3.68V57.05a28.3,28.3,0,0,0-14.2-3.68c-16.19,0-28.92,12.51-28.92,28.5a28.25,28.25,0,0,0,28.4,28.6,25.12,25.12,0,0,0,14.93-4.83ZM320,67c5.36,0,9.88,3.47,11.67,8.83H308.47C310.15,70.3,314.36,67,320,67M291.33,82c0,16.2,13.25,28.82,30.28,28.82,9.36,0,16.2-2.53,23.25-8.42l-11.26-10c-2.63,2.74-6.52,4.21-11.14,4.21a14.39,14.39,0,0,1-13.68-8.83h39.65V83.55c0-17.67-11.88-30.39-28.08-30.39a28.57,28.57,0,0,0-29,28.81M262,51.58c6,0,9.36,3.78,9.36,8.31S268,68.2,262,68.2H244.11V51.58Zm-36,58.16h18.09V82.92h13.77l13.89,26.82H292l-16.2-29.45a22.27,22.27,0,0,0,13.88-20.72c0-13.25-10.41-23.45-26-23.45H226Z" fill="#fff"/></svg>
-      </div>
-    </div>
-
-  </div>
-
-  <!-- CONTROLS -->
-  <div class="controls">
-    <div class="nav-hint">&larr; &rarr; or click to navigate &middot; N for additional context</div>
-    <div class="progress"><span class="current">1</span> / <span class="total">13</span></div>
-  </div>
-
-  <!-- NOTES PANEL -->
-  <div class="notes-panel"></div>
-
-  <script>
-    (function() {
-      const slides = document.querySelectorAll('.slide');
-      const currentEl = document.querySelector('.current');
-      const totalEl = document.querySelector('.total');
-      const notesPanel = document.querySelector('.notes-panel');
-      let idx = 0;
-      let notesVisible = false;
-
-      totalEl.textContent = slides.length;
-
-      function pauseAllMedia() {
-        document.querySelectorAll('.slide:not(.active) video').forEach(v => v.pause());
-        document.querySelectorAll('.slide:not(.active) iframe').forEach(f => {
-          f.contentWindow.postMessage('{"event":"command","func":"pauseVideo","args":""}', '*');
-          f.contentWindow.postMessage('{"method":"pause"}', '*');
-        });
-      }
-
-      function playActiveMedia() {
-        document.querySelectorAll('.slide.active video').forEach(v => v.play());
-        document.querySelectorAll('.slide.active iframe').forEach(f => {
-          f.contentWindow.postMessage('{"event":"command","func":"playVideo","args":""}', '*');
-          f.contentWindow.postMessage('{"method":"play"}', '*');
-        });
-      }
-
-      function show(i) {
-        slides.forEach((s, j) => {
-          s.classList.toggle('active', j === i);
-          s.style.display = j === i ? 'flex' : 'none';
-        });
-        currentEl.textContent = i + 1;
-        pauseAllMedia();
-        playActiveMedia();
-        if (notesVisible && notesPanel) {
-          const note = slides[i].dataset.notes || '';
-          notesPanel.innerHTML = note;
-        }
-      }
-
-      function next() { if (idx < slides.length - 1) { idx++; show(idx); } }
-      function prev() { if (idx > 0) { idx--; show(idx); } }
-
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); next(); }
-        if (e.key === 'ArrowLeft') { prev(); }
-        if (e.key === 'n' || e.key === 'N') {
-          notesVisible = !notesVisible;
-          if (notesPanel) notesPanel.classList.toggle('visible', notesVisible);
-          show(idx);
-        }
-      });
-
-      document.addEventListener('click', (e) => {
-        if (e.target.closest('.controls') || e.target.closest('.notes-panel') || e.target.closest('.video-container') || e.target.closest('.media-container')) return;
-        const x = e.clientX / window.innerWidth;
-        x > 0.5 ? next() : prev();
-      });
-
-      let touchStartX = 0;
-      document.addEventListener('touchstart', (e) => { touchStartX = e.touches[0].clientX; });
-      document.addEventListener('touchend', (e) => {
-        const diff = e.changedTouches[0].clientX - touchStartX;
-        if (Math.abs(diff) > 50) { diff < 0 ? next() : prev(); }
-      });
-
-      show(0);
-    })();
-  </script>
-</body>
-</html>
+Signature verification happens at pull time: --verify + --key flags enforce cosign
+verification before extracting the skill.</p></div><div class="bespoke-marp-note" data-index="10" tabindex="0"><p>The before/after contrast highlights what OCI distribution adds to the picture. All the
+&quot;after&quot; properties come for free from the OCI ecosystem — registries, sigstore, RBAC,
+pull policies — we're just reusing existing infrastructure.</p></div><div class="bespoke-marp-note" data-index="11" tabindex="0"><p>Resources:
+- PR #21: github.com/redhat-et/docsclaw/pull/21
+- Design spec: docs/dev/2026-04-12-oci-skill-distribution-design.md
+- OCI skills guide: docs/oci-skills-guide.md
+- Agent Skills OCI Spec: github.com/ThomasVitale/agents-skills-oci-artifacts-spec
+- ORAS project: oras.land
+- Zot registry: zotregistry.dev</p></div><div class="bespoke-marp-note" data-index="12" tabindex="0"><p>Thank you for your time. Questions and feedback welcome.</p></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
+!function(){"use strict";function e(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var t,n,r=(n||(n=1,t={from:function(e,t){var n,r=1===(e.parent||e).nodeType?e.parent||e:document.querySelector(e.parent||e),o=[].filter.call("string"==typeof e.slides?r.querySelectorAll(e.slides):e.slides||r.children,function(e){return"SCRIPT"!==e.nodeName}),i={},a=function(e,t){return(t=t||{}).index=o.indexOf(e),t.slide=e,t},s=function(e,t){i[e]=(i[e]||[]).filter(function(e){return e!==t})},l=function(e,t){return(i[e]||[]).reduce(function(e,n){return e&&!1!==n(t)},!0)},c=function(e,t){o[e]&&(n&&l("deactivate",a(n,t)),n=o[e],l("activate",a(n,t)))},d=function(e,t){var r=o.indexOf(n)+e;l(e>0?"next":"prev",a(n,t))&&c(r,t)},u={off:s,on:function(e,t){return(i[e]||(i[e]=[])).push(t),s.bind(null,e,t)},fire:l,slide:function(e,t){if(!arguments.length)return o.indexOf(n);l("slide",a(o[e],t))&&c(e,t)},next:d.bind(null,1),prev:d.bind(null,-1),parent:r,slides:o,destroy:function(e){l("destroy",a(n,e)),i={}}};return(t||[]).forEach(function(e){e(u)}),n||c(0),u}}),t),o=e(r);const i=document.body,a=(...e)=>history.replaceState(...e),s="",l="presenter",c="next",d="overview",u=["",l,d,c],f="bespoke-marp-",m=`data-${f}`,g=(e,{protocol:t,host:n,pathname:r,hash:o}=location)=>{const i=e.toString();return`${t}//${n}${r}${i?"?":""}${i}${o}`},p=()=>i.dataset.bespokeView,v=e=>new URLSearchParams(location.search).get(e),h=(e,t={})=>{const n={location,setter:a,...t},r=new URLSearchParams(n.location.search);for(const t of Object.keys(e)){const n=e[t];"string"==typeof n?r.set(t,n):r.delete(t)}try{n.setter({...window.history.state??{}},"",g(r,n.location))}catch(e){console.error(e)}},w=(()=>{const e="bespoke-marp";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch{return!1}})(),y=e=>{try{return localStorage.getItem(e)}catch{return null}},b=(e,t)=>{try{return localStorage.setItem(e,t),!0}catch{return!1}},k=e=>{try{return localStorage.removeItem(e),!0}catch{return!1}},x=(e,t)=>{const n="aria-hidden";t?e.setAttribute(n,"true"):e.removeAttribute(n)},E=e=>{e.parent.classList.add(`${f}parent`),e.slides.forEach(e=>e.classList.add(`${f}slide`)),e.on("activate",t=>{const n=`${f}active`,r=t.slide,o=r.classList,i=!o.contains(n);if(e.slides.forEach(e=>{e.classList.remove(n),x(e,!0)}),o.add(n),x(r,!1),i){const e=`${n}-ready`;o.add(e),document.body.clientHeight,o.remove(e)}})},$=e=>{let t=0,n=0;Object.defineProperty(e,"fragments",{enumerable:!0,value:e.slides.map(e=>[null,...e.querySelectorAll("[data-marpit-fragment]")])});const r=r=>void 0!==e.fragments[t][n+r],o=(r,o)=>{t=r,n=o,e.fragments.forEach((e,t)=>{e.forEach((e,n)=>{if(null==e)return;const i=t<r||t===r&&n<=o;e.setAttribute(`${m}fragment`,(i?"":"in")+"active");const a=`${m}current-fragment`;t===r&&n===o?e.setAttribute(a,"current"):e.removeAttribute(a)})}),e.fragmentIndex=o;const i={slide:e.slides[r],index:r,fragments:e.fragments[r],fragmentIndex:o};e.fire("fragment",i)};e.on("next",({fragment:i=!0})=>{if(i){if(r(1))return o(t,n+1),!1;const i=t+1;e.fragments[i]&&o(i,0)}else{const r=e.fragments[t].length;if(n+1<r)return o(t,r-1),!1;const i=e.fragments[t+1];i&&o(t+1,i.length-1)}}),e.on("prev",({fragment:i=!0})=>{if(r(-1)&&i)return o(t,n-1),!1;const a=t-1;e.fragments[a]&&o(a,e.fragments[a].length-1)}),e.on("slide",({index:t,fragment:n})=>{let r=0;if(void 0!==n){const o=e.fragments[t];if(o){const{length:e}=o;r=-1===n?e-1:Math.min(Math.max(n,0),e-1)}}o(t,r)}),o(0,0)},L=document,S=()=>!(!L.fullscreenEnabled&&!L.webkitFullscreenEnabled),P=()=>!(!L.fullscreenElement&&!L.webkitFullscreenElement),_=e=>{e.fullscreen=()=>{S()&&(async()=>{P()?(L.exitFullscreen||L.webkitExitFullscreen)?.call(L):((e=L.body)=>{(e.requestFullscreen||e.webkitRequestFullscreen)?.call(e)})()})()},document.addEventListener("keydown",t=>{"f"!==t.key&&"F11"!==t.key||t.altKey||t.ctrlKey||t.metaKey||!S()||(e.fullscreen(),t.preventDefault())})},O=`${f}inactive`,T=(e=2e3)=>({parent:t,fire:n})=>{const r=t.classList,o=e=>n(`marp-${e?"":"in"}active`);let i;const a=()=>{i&&clearTimeout(i),i=setTimeout(()=>{r.add(O),o()},e),r.contains(O)&&(r.remove(O),o(!0))};for(const e of["mousedown","mousemove","touchend"])document.addEventListener(e,a);setTimeout(a,0)},I=["AUDIO","BUTTON","INPUT","SELECT","TEXTAREA","VIDEO"],M=e=>{e.parent.addEventListener("keydown",e=>{if(!e.target)return;const t=e.target;(I.includes(t.nodeName)||"true"===t.contentEditable)&&e.stopPropagation()})},A=e=>{window.addEventListener("load",()=>{for(const t of e.slides){const e=t.querySelector("marp-auto-scaling, [data-auto-scaling], [data-marp-fitting]");t.setAttribute(`${m}load`,e?"":"hideable")}})},C=({interval:e=250}={})=>t=>{document.addEventListener("keydown",e=>{if(" "===e.key&&e.shiftKey)t.prev();else if("ArrowLeft"===e.key||"ArrowUp"===e.key||"PageUp"===e.key)t.prev({fragment:!e.shiftKey});else if(" "!==e.key||e.shiftKey)if("ArrowRight"===e.key||"ArrowDown"===e.key||"PageDown"===e.key)t.next({fragment:!e.shiftKey});else if("End"===e.key)t.slide(t.slides.length-1,{fragment:-1});else{if("Home"!==e.key)return;t.slide(0)}else t.next();e.preventDefault()});let n,r,o=0;t.parent.addEventListener("wheel",i=>{let a=!1;const s=(e,t)=>{e&&(a=a||((e,t)=>((e,t)=>{const n="X"===t?"Width":"Height";return e[`client${n}`]<e[`scroll${n}`]})(e,t)&&((e,t)=>{const{overflow:n}=e,r=e[`overflow${t}`];return"auto"===n||"scroll"===n||"auto"===r||"scroll"===r})(getComputedStyle(e),t))(e,t)),e?.parentElement&&s(e.parentElement,t)};if(0!==i.deltaX&&s(i.target,"X"),0!==i.deltaY&&s(i.target,"Y"),a)return;i.preventDefault();const l=Math.sqrt(i.deltaX**2+i.deltaY**2);if(void 0!==i.wheelDelta){if(void 0===i.webkitForce&&Math.abs(i.wheelDelta)<40)return;if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<4)return}else if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<12)return;r&&clearTimeout(r),r=setTimeout(()=>{n=0},e);const c=Date.now()-o<e,d=l<=n;if(n=l,c||d)return;let u;(i.deltaX>0||i.deltaY>0)&&(u="next"),(i.deltaX<0||i.deltaY<0)&&(u="prev"),u&&(t[u](),o=Date.now())})},D=(e=`.${f}osc`)=>{const t=document.querySelector(e);if(!t)return()=>{};const n=(e,n)=>{t.querySelectorAll(`[${m}osc=${JSON.stringify(e)}]`).forEach(n)};if(S()||n("fullscreen",e=>e.style.display="none"),!w){const e=(e,t)=>{e.disabled=!0,e.title=`${t} is disabled due to restricted localStorage.`};n("presenter",t=>e(t,"Presenter view")),n("overview",t=>e(t,"Overview view"))}return e=>{t.addEventListener("click",t=>{if(t.target instanceof HTMLElement){const{bespokeMarpOsc:n}=t.target.dataset;n&&t.target.blur();const r={fragment:!t.shiftKey};"next"===n?e.next(r):"prev"===n?e.prev(r):"fullscreen"===n?e?.fullscreen():"presenter"===n?e.openPresenterView():"overview"===n&&e.toggleOverviewView()}}),e.parent.appendChild(t),e.on("activate",({index:t})=>{n("page",n=>n.textContent=`Page ${t+1} of ${e.slides.length}`)}),e.on("fragment",({index:t,fragments:r,fragmentIndex:o})=>{n("prev",e=>e.disabled=0===t&&0===o),n("next",n=>n.disabled=t===e.slides.length-1&&o===r.length-1)}),e.on("marp-active",()=>x(t,!1)),e.on("marp-inactive",()=>x(t,!0)),S()&&(e=>{for(const t of["","webkit"])L.addEventListener(t+"fullscreenchange",e)})(()=>n("fullscreen",e=>e.classList.toggle("exit",S()&&P())))}},N=e=>{if(e.syncKey&&"string"==typeof e.syncKey)return!0;throw new Error("The current instance of Bespoke.js is incompatible with Marp bespoke sync plugin.")},B=(e={})=>{const t=e.key||window.history.state?.marpBespokeSyncKey||Math.random().toString(36).slice(2),n=`bespoke-marp-sync-${t}`;var r;r={marpBespokeSyncKey:t},h({},{setter:(e,...t)=>a({...e,...r},...t)});const o=()=>{const e=y(n);return e?JSON.parse(e):Object.create(null)},i=e=>{const t=o(),r={...t,...e(t)};return b(n,JSON.stringify(r)),r},s=()=>{window.removeEventListener("pageshow",s),i(e=>({reference:(e.reference||0)+1}))};return e=>{s(),Object.defineProperty(e,"syncKey",{value:t,enumerable:!0});let r=!0;setTimeout(()=>{e.on("fragment",e=>{r&&i(()=>({index:e.index,fragmentIndex:e.fragmentIndex}))})},0),window.addEventListener("storage",t=>{if(t.key===n&&t.oldValue&&t.newValue){const n=JSON.parse(t.oldValue),o=JSON.parse(t.newValue);if(n.index!==o.index||n.fragmentIndex!==o.fragmentIndex)try{r=!1,e.slide(o.index,{fragment:o.fragmentIndex,forSync:!0})}finally{r=!0}}});const a=()=>{const{reference:e}=o();void 0===e||e<=1?k(n):i(()=>({reference:e-1}))};window.addEventListener("pagehide",e=>{e.persisted&&window.addEventListener("pageshow",s),a()}),e.on("destroy",a)}},K=e=>{w&&document.addEventListener("keydown",t=>{("o"!==t.key||t.altKey||t.ctrlKey||t.metaKey)&&"Escape"!==t.key||(t.preventDefault(),e())})};let q=null;const V=({closeOnSelect:e=!0}={})=>t=>{N(t);const n=n=>{const r=(()=>{if(!q||!q.isConnected){q=document.createElement("div"),q.className=`${f}overview`,q.inert=!0;const n=document.createElement("iframe");n.src=(()=>{const n=new URLSearchParams(location.search);return n.set("view","overview"),n.set("sync",t.syncKey),e&&n.set("closeOnSelect","1"),g(n)})(),q.append(n),document.body.append(q)}return q})(),o=n??!r.dataset.open;setTimeout(()=>{if(r.dataset.open=o?"1":"",r.inert=!o,t.skipTransition=o,o){const e=r.querySelector("iframe");try{e?.contentWindow?.focus()}catch{e?.focus()}}else window.focus()},0)};Object.defineProperties(t,{toggleOverviewView:{enumerable:!0,value:n}}),window.addEventListener("message",e=>{e.origin===window.origin&&"closeOverview"===e.data&&n(!1)}),K(n)},j=e=>{const{title:t}=document;document.title="[Overview]"+(t?` - ${t}`:"");const n=!!v("closeOnSelect"),r=()=>{window.parent.postMessage("closeOverview","null"===window.origin?"*":window.origin)};if(e.slides.forEach((t,o)=>{t.tabIndex=0;const i=()=>{e.slide(o,{fragment:-1}),n&&r()};t.addEventListener("click",i),t.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),i())})}),window.addEventListener("keydown",t=>{const n=e.slide(),r=t=>{const r=t=>{const n=e.slides[t].getBoundingClientRect();return[Math.round((n.left+n.right)/2),Math.round((n.top+n.bottom)/2)]};let o=null,i=n;do{const e=r(i);if(o){if(Math.abs(e[0]-o[0])<2)return i}else o=e;i+=t}while(i>=0&&i<e.slides.length);return n};if("ArrowLeft"===t.key)e.slide(Math.max(n-1,0),{fragment:-1});else if("ArrowRight"===t.key)e.slide(Math.min(n+1,e.slides.length-1),{fragment:-1});else if("ArrowUp"===t.key)e.slide(r(-1),{fragment:-1});else if("ArrowDown"===t.key)e.slide(r(1),{fragment:-1});else if("End"===t.key)e.slide(e.slides.length-1,{fragment:-1});else{if("Home"!==t.key)return;e.slide(0,{fragment:-1})}t.preventDefault();const o=e.slide();e.slides[o]?.focus?.(),e.slides[o]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),e.on("slide",({index:t})=>{e.slides[t]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),window.parent!==window){K(r);const e=document.createElement("header");e.className=`${f}overview-header`;const t=document.createElement("button");t.className=`${f}overview-close`,t.type="button",t.title="Close overview",t.textContent=t.title,t.addEventListener("click",r),e.append(t),document.body.prepend(e)}},F=()=>{const e=p();return{[s]:V(),[l]:V({closeOnSelect:!1}),[d]:j}[e]},U=e=>{window.addEventListener("message",t=>{if(t.origin!==window.origin)return;const[n,r]=t.data.split(":");if("navigate"===n){const[t,n]=r.split(",");let o=Number.parseInt(t,10),i=Number.parseInt(n,10)+1;i>=e.fragments[o].length&&(o+=1,i=0),e.slide(o,{fragment:i})}})};var R,X,H,W,J,Y,z,G={exports:{}},Q=(R||(R=1,G.exports=(X=["area","base","br","col","command","embed","hr","img","input","keygen","link","meta","param","source","track","wbr"],H=function(e){return String(e).replace(/[&<>"']/g,function(e){return"&"+W[e]+";"})},W={"&":"amp","<":"lt",">":"gt",'"':"quot","'":"apos"},J="dangerouslySetInnerHTML",Y={className:"class",htmlFor:"for"},z={},function(e,t){var n=[],r="";t=t||{};for(var o=arguments.length;o-- >2;)n.push(arguments[o]);if("function"==typeof e)return t.children=n.reverse(),e(t);if(e){if(r+="<"+e,t)for(var i in t)!1!==t[i]&&null!=t[i]&&i!==J&&(r+=" "+(Y[i]?Y[i]:H(i))+'="'+H(t[i])+'"');r+=">"}if(-1===X.indexOf(e)){if(t[J])r+=t[J].__html;else for(;n.length;){var a=n.pop();if(a)if(a.pop)for(var s=a.length;s--;)n.push(a[s]);else r+=!0===z[a]?a:H(a)}r+=e?"</"+e+">":""}return z[r]=!0,r})),G.exports),Z=e(Q);const ee=({children:e})=>Z(null,null,...e),te=`${f}presenter-`,ne={container:`${te}container`,dragbar:`${te}dragbar-container`,next:`${te}next`,nextContainer:`${te}next-container`,noteContainer:`${te}note-container`,noteWrapper:`${te}note-wrapper`,noteButtons:`${te}note-buttons`,infoContainer:`${te}info-container`,infoPageArea:`${te}info-page-area`,infoPage:`${te}info-page`,infoPagePrev:`${te}info-page-prev`,infoPageNext:`${te}info-page-next`,noteButtonsBigger:`${te}note-bigger`,noteButtonsSmaller:`${te}note-smaller`,infoTime:`${te}info-time`,infoTimer:`${te}info-timer`},re=e=>{const{title:t}=document;document.title="[Presenter view]"+(t?` - ${t}`:"");const n={},r=e=>(n[e]=n[e]||document.querySelector(`.${e}`),n[e]);document.body.appendChild((e=>{const t=document.createElement("div");return t.className=ne.container,t.appendChild(e),t.insertAdjacentHTML("beforeend",Z(ee,null,Z("div",{class:ne.nextContainer},Z("iframe",{class:ne.next,src:"?view=next"})),Z("div",{class:ne.dragbar}),Z("div",{class:ne.noteContainer},Z("div",{class:ne.noteWrapper}),Z("div",{class:ne.noteButtons},Z("button",{class:ne.noteButtonsSmaller,tabindex:"-1",title:"Smaller notes font size"},"Smaller notes font size"),Z("button",{class:ne.noteButtonsBigger,tabindex:"-1",title:"Bigger notes font size"},"Bigger notes font size"))),Z("div",{class:ne.infoContainer},Z("div",{class:ne.infoPageArea},Z("button",{class:ne.infoPagePrev,tabindex:"-1",title:"Previous"},"Previous"),Z("button",{class:ne.infoPage}),Z("button",{class:ne.infoPageNext,tabindex:"-1",title:"Next"},"Next")),Z("time",{class:ne.infoTime,title:"Current time"}),Z("time",{class:ne.infoTimer,title:"Timer"})))),t})(e.parent)),(e=>{let t=!1;r(ne.dragbar).addEventListener("mousedown",()=>{t=!0,r(ne.dragbar).classList.add("active")}),window.addEventListener("mouseup",()=>{t=!1,r(ne.dragbar).classList.remove("active")}),window.addEventListener("mousemove",e=>{if(!t)return;const n=e.clientX/document.documentElement.clientWidth*100;r(ne.container).style.setProperty("--bespoke-marp-presenter-split-ratio",`${Math.max(0,Math.min(100,n))}%`)}),r(ne.nextContainer).addEventListener("click",()=>e.next());const n=r(ne.next),o=(i=n,(e,t)=>i.contentWindow?.postMessage(`navigate:${e},${t}`,"null"===window.origin?"*":window.origin));var i;n.addEventListener("load",()=>{r(ne.nextContainer).classList.add("active"),o(e.slide(),e.fragmentIndex),e.on("fragment",({index:e,fragmentIndex:t})=>o(e,t))});const a=document.querySelectorAll(".bespoke-marp-note");a.forEach(e=>{e.addEventListener("keydown",e=>e.stopPropagation()),r(ne.noteWrapper).appendChild(e)}),e.on("activate",()=>a.forEach(t=>t.classList.toggle("active",t.dataset.index==e.slide())));let s=0;const l=e=>{s=Math.max(-5,s+e),r(ne.noteContainer).style.setProperty("--bespoke-marp-note-font-scale",(1.2**s).toFixed(4))},c=()=>l(1),d=()=>l(-1),u=r(ne.noteButtonsBigger),f=r(ne.noteButtonsSmaller);u.addEventListener("click",()=>{u.blur(),c()}),f.addEventListener("click",()=>{f.blur(),d()}),document.addEventListener("keydown",e=>{"+"===e.key&&c(),"-"===e.key&&d()},!0);const m=r(ne.infoPage);e.on("activate",({index:t})=>{m.textContent=`${t+1} / ${e.slides.length}`}),m.addEventListener("click",()=>{m.blur(),e.toggleOverviewView()});const g=r(ne.infoPagePrev),p=r(ne.infoPageNext);g.addEventListener("click",t=>{g.blur(),e.prev({fragment:!t.shiftKey})}),p.addEventListener("click",t=>{p.blur(),e.next({fragment:!t.shiftKey})}),e.on("fragment",({index:t,fragments:n,fragmentIndex:r})=>{g.disabled=0===t&&0===r,p.disabled=t===e.slides.length-1&&r===n.length-1});let v=new Date;const h=()=>{const e=new Date,t=e=>`${Math.floor(e)}`.padStart(2,"0"),n=e.getTime()-v.getTime(),o=t(n/1e3%60),i=t(n/1e3/60%60),a=t(n/36e5%24);r(ne.infoTime).textContent=e.toLocaleTimeString(),r(ne.infoTimer).textContent=`${a}:${i}:${o}`};h(),setInterval(h,250),r(ne.infoTimer).addEventListener("click",()=>{v=new Date})})(e)},oe=e=>{N(e),Object.defineProperties(e,{openPresenterView:{enumerable:!0,value:ie},presenterUrl:{enumerable:!0,get:ae}}),w&&document.addEventListener("keydown",t=>{"p"!==t.key||t.altKey||t.ctrlKey||t.metaKey||(t.preventDefault(),e.openPresenterView())})};function ie(){const{max:e,floor:t}=Math,n=e(t(.85*window.innerWidth),640),r=e(t(.85*window.innerHeight),360);return window.open(this.presenterUrl,te+this.syncKey,`width=${n},height=${r},menubar=no,toolbar=no`)}function ae(){const e=new URLSearchParams(location.search);return e.set("view","presenter"),e.set("sync",this.syncKey),g(e)}const se=e=>{const t=p();return t===c&&e.appendChild(document.createElement("span")),{[s]:oe,[l]:re,[c]:U}[t]},le=e=>{e.on("activate",t=>{document.querySelectorAll(".bespoke-progress-parent > .bespoke-progress-bar").forEach(n=>{n.style.flexBasis=100*t.index/(e.slides.length-1)+"%"})})},ce=e=>{const t=Number.parseInt(e,10);return Number.isNaN(t)?null:t},de=(e={})=>{const t={history:!0,...e};return e=>{let n=!0;const r=e=>{const t=n;try{return n=!0,e()}finally{n=t}},o=(t={fragment:!0})=>{let n=t.fragment?ce(v("f")||""):null;((t,n)=>{const{min:r,max:o}=Math,{fragments:i,slides:a}=e,s=o(0,r(t,a.length-1)),l=o(0,r(n||0,i[s].length-1));s===e.slide()&&l===e.fragmentIndex||e.slide(s,{fragment:l})})((()=>{if(location.hash){const[t]=location.hash.slice(1).split(":~:");if(/^\d+$/.test(t))return(ce(t)??1)-1;const r=document.getElementById(t)||document.querySelector(`a[name="${CSS.escape(t)}"]`);if(r){const{length:t}=e.slides;for(let o=0;o<t;o+=1)if(e.slides[o].contains(r)){const t=e.fragments?.[o],i=r.closest("[data-marpit-fragment]");if(t&&i){const e=t.indexOf(i);e>=0&&(n=e)}return o}}}return 0})(),n)};e.on("fragment",({index:e,fragmentIndex:r})=>{n||h({f:0===r||r.toString()},{location:{...location,hash:`#${e+1}`},setter:(...e)=>t.history?history.pushState(...e):history.replaceState(...e)})}),setTimeout(()=>{o(),window.addEventListener("hashchange",()=>r(()=>{o({fragment:!1}),h({f:void 0})})),window.addEventListener("popstate",()=>{n||r(()=>o())}),n=!1},0)}},{PI:ue,abs:fe,sqrt:me,atan2:ge}=Math,pe={passive:!0},ve=({slope:e=-.7,swipeThreshold:t=30}={})=>n=>{let r;const o=n.parent,i=e=>{const t=o.getBoundingClientRect();return{x:e.pageX-(t.left+t.right)/2,y:e.pageY-(t.top+t.bottom)/2}};o.addEventListener("touchstart",({touches:e})=>{r=1===e.length?i(e[0]):void 0},pe),o.addEventListener("touchmove",e=>{if(r)if(1===e.touches.length){e.preventDefault();const t=i(e.touches[0]),n=t.x-r.x,o=t.y-r.y;r.delta=me(fe(n)**2+fe(o)**2),r.radian=ge(n,o)}else r=void 0}),o.addEventListener("touchend",o=>{if(r){if(r.delta&&r.delta>=t&&r.radian){const t=(r.radian-e+ue)%(2*ue)-ue;n[t<0?"next":"prev"](),o.stopPropagation()}r=void 0}},pe)},he=new Map;he.clear(),he.set("none",{backward:{both:void 0,incoming:void 0,outgoing:void 0},forward:{both:void 0,incoming:void 0,outgoing:void 0}});const we={both:"",outgoing:"outgoing-",incoming:"incoming-"},ye={forward:"",backward:"-backward"},be=e=>`--marp-bespoke-transition-animation-${e}`,ke=e=>`--marp-transition-${e}`,xe=be("name"),Ee=be("duration"),$e=e=>new Promise(t=>{const n={},r=document.createElement("div"),o=e=>{r.remove(),t(e)};r.addEventListener("animationstart",()=>o(n)),Object.assign(r.style,{animationName:e,animationDuration:"1s",animationFillMode:"both",animationPlayState:"paused",position:"absolute",pointerEvents:"none"}),document.body.appendChild(r);const i=getComputedStyle(r).getPropertyValue(ke("duration"));i&&Number.parseFloat(i)>=0&&(n.defaultDuration=i),((e,t)=>{requestAnimationFrame(()=>{e.style.animationPlayState="running",requestAnimationFrame(()=>t(void 0))})})(r,o)}),Le=async e=>he.has(e)?he.get(e):(e=>{const t={},n=[];for(const[r,o]of Object.entries(we))for(const[i,a]of Object.entries(ye)){const s=`marp-${o}transition${a}-${e}`;n.push($e(s).then(e=>{t[i]=t[i]||{},t[i][r]=e?{...e,name:s}:void 0}))}return Promise.all(n).then(()=>t)})(e).then(t=>(he.set(e,t),t)),Se=e=>Object.values(e).flatMap(Object.values).every(e=>!e),Pe=(e,{type:t,backward:n})=>{const r=e[n?"backward":"forward"],o=(()=>{const e=r[t],n=e=>({[xe]:e.name});if(e)return n(e);if(r.both){const e=n(r.both);return"incoming"===t&&(e[be("direction")]="reverse"),e}})();return!o&&n?Pe(e,{type:t,backward:!1}):o||{[xe]:"__bespoke_marp_transition_no_animation__"}},_e=e=>{if(e)try{const t=JSON.parse(e);if((e=>{if("object"!=typeof e)return!1;const t=e;return"string"==typeof t.name&&(void 0===t.duration||"string"==typeof t.duration)})(t))return t}catch{}},Oe="_tSId",Te="_tA",Ie="bespoke-marp-transition-warming-up",Me=window.matchMedia("(prefers-reduced-motion: reduce)"),Ae="__bespoke_marp_transition_reduced_outgoing__",Ce="__bespoke_marp_transition_reduced_incoming__",De={forward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}},backward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}}},Ne=e=>{if(!document.startViewTransition)return;const t=t=>(void 0!==t&&(e._tD=t),e._tD);let n;t(!1),((...e)=>{CSS.registerProperty({name:ke("duration"),syntax:"<time>",inherits:!0,initialValue:"-1s"});const t=[...new Set(e).values()];return Promise.all(t.map(e=>Le(e))).then()})(...Array.from(document.querySelectorAll("section[data-transition], section[data-transition-back]")).flatMap(e=>[e.dataset.transition,e.dataset.transitionBack].flatMap(e=>{const t=_e(e);return[t?.name,t?.builtinFallback?`__builtin__${t.name}`:void 0]}).filter(e=>!!e))).then(()=>{document.querySelectorAll("style").forEach(e=>{e.innerHTML=e.innerHTML.replace(/--marp-transition-duration:[^;}]*[;}]/g,e=>e.slice(0,-1)+"!important"+e.slice(-1))})});const r=(n,{back:r,cond:o})=>i=>{const a=t();if(a)return!!i[Te]||!("object"!=typeof a||(a.skipTransition(),!i.forSync));if(e.skipTransition)return!0;if(!o(i))return!0;const s=e.slides[e.slide()],l=()=>i.back??r,c="data-transition"+(l()?"-back":""),d=s.querySelector(`section[${c}]`);if(!d)return!0;const u=_e(d.getAttribute(c)??void 0);return!u||((async(e,{builtinFallback:t=!0}={})=>{let n=await Le(e);if(Se(n)){if(!t)return;return n=await Le(`__builtin__${e}`),Se(n)?void 0:n}return n})(u.name,{builtinFallback:u.builtinFallback}).then(e=>{if(!e){t(!0);try{n(i)}finally{t(!1)}return}let r=e;Me.matches&&(console.warn("Use a constant animation to transition because preferring reduced motion by viewer has detected."),r=De);const o=document.getElementById(Oe);o&&o.remove();const a=document.createElement("style");a.id=Oe,document.head.appendChild(a),((e,t)=>{const n=[`:root{${ke("direction")}:${t.backward?-1:1};}`,":root:has(.bespoke-marp-inactive){cursor:none;}"],r=t=>{const n=e[t].both?.defaultDuration||e[t].outgoing?.defaultDuration||e[t].incoming?.defaultDuration;return"forward"===t?n:n||r("forward")},o=t.duration||r(t.backward?"backward":"forward");void 0!==o&&n.push(`::view-transition-group(*){${Ee}:${o};}`);const i=e=>Object.entries(e).map(([e,t])=>`${e}:${t};`).join("");return n.push(`::view-transition-old(root){${i(Pe(e,{...t,type:"outgoing"}))}}`,`::view-transition-new(root){${i(Pe(e,{...t,type:"incoming"}))}}`),n})(r,{backward:l(),duration:u.duration}).forEach(e=>a.sheet?.insertRule(e));const s=document.documentElement.classList;s.add(Ie);let c=!1;const d=()=>{c||(n(i),c=!0,s.remove(Ie))},f=()=>{t(!1),a.remove(),s.remove(Ie)};try{t(!0);const e=document.startViewTransition(d);t(e),e.finished.finally(f)}catch(e){console.error(e),d(),f()}}),!1)};e.on("prev",r(t=>e.prev({...t,[Te]:!0}),{back:!0,cond:e=>e.index>0&&!((e.fragment??1)&&n.fragmentIndex>0)})),e.on("next",r(t=>e.next({...t,[Te]:!0}),{cond:t=>t.index+1<e.slides.length&&!(n.fragmentIndex+1<n.fragments.length)})),setTimeout(()=>{e.on("slide",r(t=>e.slide(t.index,{...t,[Te]:!0}),{cond:t=>{const n=e.slide();return t.index!==n&&(t.back=t.index<n,!0)}}))},0),e.on("fragment",e=>{n=e})};let Be;const Ke=()=>(void 0===Be&&(Be="wakeLock"in navigator&&navigator.wakeLock),Be),qe=async()=>{const e=Ke();if(e)try{return await e.request("screen")}catch(e){console.warn(e)}return null},Ve=async()=>{if(!Ke())return;let e;const t=()=>{e&&"visible"===document.visibilityState&&qe()};for(const e of["visibilitychange","fullscreenchange"])document.addEventListener(e,t);return e=await qe(),e};((e=document.getElementById(":$p"))=>{(()=>{const e=v("view");i.dataset.bespokeView=u.some(t=>t&&t===e)?e:""})();const t=(e=>{const t=v(e);return h({[e]:void 0}),t})("sync")||void 0;o.from(e,((...e)=>{const t=u.findIndex(e=>p()===e);return e.map(([e,n])=>e[t]&&n).filter(e=>e)})([[1,1,1,0],B({key:t})],[[1,1,0,1],se(e)],[[1,1,0,0],M],[[1,1,1,1],E],[[1,0,0,0],T()],[[1,1,1,1],A],[[1,1,1,1],de({history:!1})],[[1,1,0,0],C()],[[1,1,1,0],_],[[1,0,0,0],le],[[1,1,0,0],ve()],[[1,0,0,0],D()],[[1,1,1,0],F()],[[1,0,0,0],Ne],[[1,1,1,1],$],[[1,1,1,0],Ve]))})()}();</script></body></html>

--- a/docs/slides/oci-skill-distribution-deck.md
+++ b/docs/slides/oci-skill-distribution-deck.md
@@ -1,0 +1,525 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 16:9
+title: OCI-Based Skill Distribution
+author: Pavel Anni
+class: invert
+style: |
+  @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&family=Red+Hat+Text:wght@400;500;700&family=Red+Hat+Mono:wght@400;700&display=swap');
+  :root {
+    --color-background: #000000;
+    --color-foreground: #ffffff;
+    --color-highlight: #ee0000;
+    --color-dimmed: #a3a3a3;
+  }
+  section {
+    font-family: 'Red Hat Text', sans-serif;
+    background: #000000;
+    color: #ffffff;
+  }
+  section::after {
+    color: #a3a3a3;
+    font-family: 'Red Hat Mono', monospace;
+    font-size: 0.7em;
+  }
+  h1, h2, h3 {
+    font-family: 'Red Hat Display', sans-serif;
+    color: #ffffff;
+  }
+  h1 { font-weight: 900; }
+  h2 { font-weight: 700; }
+  code {
+    font-family: 'Red Hat Mono', monospace;
+    background: #292929;
+    border-radius: 3px;
+  }
+  pre {
+    background: #1f1f1f;
+    border: 1px solid #383838;
+    border-radius: 3px;
+  }
+  a { color: #f56e6e; }
+  strong { color: #ffffff; }
+  em { color: #c7c7c7; }
+  .accent { color: #ee0000; }
+  .tag {
+    display: inline-block;
+    padding: 2px 14px;
+    border: 1px solid #383838;
+    border-radius: 64px;
+    font-family: 'Red Hat Mono', monospace;
+    font-size: 0.7em;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #c7c7c7;
+    margin: 2px;
+  }
+  .tag-accent {
+    display: inline-block;
+    padding: 2px 14px;
+    border: 1px solid #ee0000;
+    border-radius: 64px;
+    font-family: 'Red Hat Mono', monospace;
+    font-size: 0.7em;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #ee0000;
+    margin: 2px;
+  }
+  .muted { color: #a3a3a3; }
+  .small { font-size: 0.75em; }
+  section.lead h1 { font-size: 2.8em; }
+  section.lead .subtitle {
+    color: #a3a3a3;
+    font-size: 1.1em;
+    max-width: 680px;
+  }
+  table {
+    font-size: 0.85em;
+    background: transparent;
+  }
+  th {
+    background: #1f1f1f;
+    border-color: #383838;
+  }
+  td {
+    border-color: #383838;
+  }
+  section.thankyou h1 {
+    font-size: 5em;
+    text-align: center;
+  }
+  section.thankyou {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+---
+
+<!-- _class: lead -->
+
+# Distributing AI Skills at <span class="accent">Enterprise Scale</span>
+
+Package, sign, and distribute agent skills as OCI artifacts — using the same registries and trust chains you already run for container images.
+
+<span class="tag-accent">OCI Artifacts</span> <span class="tag">ORAS</span> <span class="tag">Sigstore</span> <span class="tag">Image Volumes</span>
+
+<span class="muted small">Pavel Anni · Office of CTO · Red Hat</span>
+
+<!--
+Tips: Arrow keys or click to navigate. Press N to toggle notes.
+Context: This feature was implemented in PR #21 on redhat-et/docsclaw.
+The design spec is at docs/dev/2026-04-12-oci-skill-distribution-design.md.
+-->
+
+---
+
+## Your Agent Is Only as Good as Its <span class="accent">Skills</span>
+
+Skills are the unit of specialization. Each skill lives in its own subdirectory and gives the agent domain expertise.
+
+- **SKILL.md** — instructions in Agent Skills spec format
+- **skill.yaml** — metadata: tools, resources, versioning
+
+```
+skills/
+├── resume-screener/
+│   ├── SKILL.md
+│   └── skill.yaml
+├── policy-comparator/
+│   ├── SKILL.md
+│   └── skill.yaml
+└── checklist-auditor/
+    ├── SKILL.md
+    └── skill.yaml
+```
+
+<span class="muted small">Agent Skills Specification — agentskills.io</span>
+
+<!--
+Agent Skills Specification: agentskills.io/specification
+
+Skills are the unit of specialization for an agent. Each skill is a self-contained
+directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
+discovers and loads them at startup.
+
+Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.
+-->
+
+---
+
+## Today's Skill Distribution Is <span class="accent">Ad-Hoc</span>
+
+| Method | How it works | Drawback |
+| ------ | ------------ | -------- |
+| **Copy from a Friend** | Slack messages, email, shared drives | No versioning. No provenance. No audit trail. |
+| **Clone from GitHub** | git clone the repo, copy the directory | No signing. No atomic versioning. Auth is coarse-grained. |
+| **Mount a ConfigMap** | Embed skill text in a K8s ConfigMap | 1 MiB limit. No versioning. Mixes config with content. |
+
+These get you started, but none provide the **versioning, signing, and auditability** that enterprise deployments require.
+
+<!--
+Each of these methods gets progressively closer to enterprise readiness —
+ConfigMaps are already Kubernetes-native — but all three lack the supply chain
+guarantees (signing, versioning, audit) that regulated environments require.
+
+ConfigMaps have a 1 MiB size limit (etcd constraint), so larger skills with
+examples or data files won't fit.
+-->
+
+---
+
+## Enterprise Deployments Need <span class="accent">Trust Infrastructure</span>
+
+- 🔒 **Signing** — Cryptographic proof of who published a skill and that it hasn't been tampered with
+- 📋 **Auditability** — Registry logs show who pulled what, when, and where it was deployed
+- 🔄 **Versioning** — Immutable tags, semantic versions, rollback to a known-good skill set
+- 📌 **Reproducibility** — Pin skills by digest (sha256) for byte-identical deployments across environments
+- 🔑 **Access control** — Registry RBAC, pull secrets, org-scoped namespaces — the same policies you use for images
+
+<!--
+This is the core motivation. When you deploy AI agents in a regulated enterprise,
+you need the same supply chain guarantees you have for container images: signed
+artifacts, vulnerability scanning, access control, and audit logs.
+
+Reproducibility matters because you need to prove which exact skill version
+produced an agent's output — especially in regulated industries (finance,
+healthcare, government).
+-->
+
+---
+
+## OCI Is Not Just for <span class="accent">Container Images</span>
+
+The OCI Distribution Specification is **content-agnostic**. Any blob + a manifest + a media type = a valid OCI artifact.
+
+The **ORAS** project (OCI Registry As Storage) makes this practical: push any content to any OCI registry with standard tooling.
+
+<span class="tag">Helm Charts</span> <span class="tag">WASM Modules</span> <span class="tag">ML Models</span> <span class="tag">Policy Bundles</span> <span class="tag-accent">Agent Skills</span>
+
+```
+┌────────────────────────────────────────────────────┐
+│      OCI Registry (Quay / GHCR / Harbor / Zot)     │
+└────────────────────────────────────────────────────┘
+    ↓  Same protocol, same auth, same RBAC  ↓
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│  Container   │  │    Helm      │  │    Agent     │
+│   Images     │  │   Charts     │  │   Skills ★   │
+└──────────────┘  └──────────────┘  └──────────────┘
+```
+
+<span class="muted small">ORAS — oras.land · OCI Distribution Spec</span>
+
+<!--
+ORAS (OCI Registry As Storage): oras.land
+
+The OCI Distribution Specification was designed to be content-agnostic. Media types
+let registries and tools distinguish content without special handling. Helm charts
+have been distributed as OCI artifacts since Helm 3.8 (2022). WASM modules, ML models,
+and policy bundles are also distributed this way.
+
+Key insight: your Quay/Harbor/GHCR registry can already store and serve non-image content.
+No infrastructure changes needed.
+-->
+
+---
+
+## A Skill Becomes an <span class="accent">OCI Artifact</span>
+
+```
+Skill Directory  →  skillctl pack  →  OCI Layout  →  skillctl push  →  Registry
+```
+
+**What goes into the artifact:**
+- `SKILL.md` — instructions
+- `skill.yaml` — SkillCard metadata
+- Any supporting files in the directory
+
+**What the registry provides:**
+- Immutable digest + mutable tags
+- RBAC & pull secrets
+- Cosign / sigstore signatures
+
+<!--
+Community alignment: This implementation aligns with the Agent Skills OCI Artifacts
+Specification by Thomas Vitale.
+
+Media types used:
+- application/vnd.oci.image.layer.v1.tar+gzip (skill content layer)
+- application/vnd.oci.image.config.v1+json (config with SkillCard metadata)
+
+The custom annotations (io.docsclaw.skill.*) carry SkillCard metadata in the manifest
+for fast inspection without pulling the full layer.
+-->
+
+---
+
+## The Workflow: <span class="accent">Pack, Push, Mount</span>
+
+```bash
+# Pack skill into a local OCI layout
+$ skillctl pack examples/skills/resume-screener
+Packed skill → oci-layout · sha256:65af81ce... · 1226 bytes
+
+# Push to registry (uses podman/docker credentials)
+$ skillctl push examples/skills/resume-screener \
+    quay.io/docsclaw/skill-resume-screener:1.0.0
+Pushed → quay.io/docsclaw/skill-resume-screener:1.0.0
+
+# Push as mountable image (for image volumes)
+$ skillctl push --as-image examples/skills/resume-screener \
+    quay.io/docsclaw/skill-resume-screener:1.0.0-image
+
+# Inspect remotely (no download needed)
+$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
+Name: resume-screener · Version: 1.0.0 · Tools: [read_file]
+```
+
+<!--
+The --as-image flag produces an OCI image (with rootfs layer) instead of an OCI artifact.
+This is required for Kubernetes image volumes, which expect a proper container image that
+the kubelet can pull via the container runtime.
+
+Credential resolution is automatic: skillctl reads podman/docker auth configs, so if you've
+done 'podman login quay.io', push/pull just works.
+-->
+
+---
+
+## Every Skill Has a <span class="accent">Machine-Readable Identity</span>
+
+```
+$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
+
+Name:          resume-screener
+Namespace:     official
+Version:       1.0.0
+Description:   Screen resumes against a job description...
+Author:        Red Hat ET
+License:       Apache-2.0
+Tools:         [read_file]
+Memory:        32Mi
+CPU:           100m
+```
+
+**What SkillCard enables:**
+- 🔍 **Discovery** — search by name, namespace, category, author
+- 📐 **Resource planning** — CPU and memory hints before deployment
+- 🔗 **Compatibility** — required tools, dependencies, min agent version
+- ✅ **Governance** — license, author, namespace for org-level trust policies
+
+> **Future: Skill Catalog** — A UI that queries registries, reads SkillCards, and presents a searchable catalog — browse by category, check signing status, deploy with one click.
+
+<!--
+SkillCard schema: docsclaw.io/v1alpha1 kind: SkillCard. The metadata travels inside the
+OCI manifest annotations, so 'skill inspect' reads it without pulling the full layer.
+
+Future vision: a Skill Catalog UI that queries registries, reads SkillCard metadata, and
+presents a searchable, browsable catalog of available skills — like a curated app store
+for agent capabilities.
+
+The SkillCard schema is intentionally extensible: additional fields (compatibility matrix,
+test results, usage metrics) can be added without breaking existing skills.
+-->
+
+---
+
+## Image Volumes: Mount Skills <span class="accent">Directly</span>
+
+On OpenShift 4.20+ / Kubernetes 1.33+, the kubelet can mount an OCI image as a **read-only volume** — no init container needed.
+
+- Kubelet pulls and caches skill images
+- Read-only mount — immutable at runtime
+- No emptyDir, no node storage consumed
+
+```yaml
+volumes:
+  - name: skill-resume-screener
+    image:
+      reference: quay.io/docsclaw/skill-resume-screener:1.0.0
+      pullPolicy: IfNotPresent
+
+containers:
+  - name: docsclaw
+    volumeMounts:
+      - name: skill-resume-screener
+        mountPath: /skills/resume-screener
+```
+
+<span class="muted small">KEP-4639 · Kubernetes 1.33+ · OpenShift 4.20+</span>
+
+<!--
+Image Volumes (KEP-4639): GA in Kubernetes 1.33 / OpenShift 4.20.
+
+The kubelet pulls the image via the container runtime and mounts it read-only into the pod.
+No init container, no PVC, no emptyDir. The image is cached in the node's container image
+store — subsequent pods that use the same skill image don't need to pull again.
+
+This is the exact same mechanism used for container images, so existing image pull policies
+(IfNotPresent, Always), pull secrets, and registry mirrors all work.
+-->
+
+---
+
+## Init Container for <span class="accent">Older Clusters</span>
+
+For Kubernetes < 1.33 or OpenShift < 4.20, use skillctl as an init container to pull skills before the agent starts.
+
+- Pull at pod startup, verify signatures
+- Cache on a PVC across restarts
+- Share the volume with the main container
+
+```yaml
+initContainers:
+  - name: skill-puller
+    image: ghcr.io/redhat-et/skillctl:latest
+    command:
+      - "skillctl"
+      - "pull"
+      - "--verify"
+      - "-o"
+      - "/skills"
+      - "quay.io/docsclaw/skill-resume-screener:1.0.0"
+```
+
+<!--
+For older clusters, the init container approach uses skillctl to pull skills from the
+registry before the main container starts. Use a PVC (not emptyDir) to persist the skill
+cache across pod restarts and avoid filling node ephemeral storage.
+
+Signature verification happens at pull time: --verify + --key flags enforce cosign
+verification before extracting the skill.
+-->
+
+---
+
+## From Ad-Hoc to <span class="accent">Supply Chain</span>
+
+| | Before | After (OCI) |
+| --- | ------ | ----------- |
+| **Distribution** | git clone or manual copy | Push/pull with standard tooling |
+| **Versioning** | Branch/tag only | Semver tags + immutable digests |
+| **Signing** | None | Cosign / sigstore signing |
+| **Audit** | No trail | Registry access logs |
+| **Auth** | Repo level only | Per-namespace RBAC + pull secrets |
+| **Size** | ConfigMap 1 MiB limit | No limits |
+| **Runtime** | Mutable | Read-only image volume mount |
+
+<!--
+The before/after contrast highlights what OCI distribution adds to the picture. All the
+"after" properties come for free from the OCI ecosystem — registries, sigstore, RBAC,
+pull policies — we're just reusing existing infrastructure.
+-->
+
+---
+
+## Disconnected and <span class="accent">Air-Gapped</span> Environments
+
+Many enterprise OpenShift clusters operate in restricted networks with no external registry access. Skills must reach these environments reliably.
+
+**oc-mirror** can mirror skill images alongside operator bundles to an internal registry — if the skill uses a recognizable MIME type.
+
+```text
+Connected                              Disconnected
+┌──────────┐   oc-mirror   ┌──────────────────────────┐
+│ Quay.io  │ ───────────── │ Internal OCP Registry    │
+│          │   (mirrored)  │ image-registry.svc:5000  │
+└──────────┘               └──────────────────────────┘
+  Skills +                   Skills + Operators +
+  Operators                  Signatures preserved
+```
+
+- **OLM integration** — skills as related images in operator bundles, mirrored automatically
+- **Internal registry** — pull from the cluster's built-in image registry, no external access needed
+- **Signature preservation** — cosign signatures survive the mirror, verified at admission
+
+<!--
+OCPSTRAT-3122 covers this from the platform side. The oc-mirror tool needs a
+recognizable MIME type (application/vnd.redhat.agentskill.layer.v1+tar) to
+identify skill artifacts for mirroring. skillctl supports this as an optional
+media type alongside the standard OCI types.
+
+For air-gapped clusters, the internal OpenShift registry
+(image-registry.openshift-image-registry.svc:5000) serves the same role as
+Quay.io — skillctl pull works the same way.
+
+OLM integration: operators can declare skills as related images in their
+ClusterServiceVersion. When oc-mirror processes the operator catalog, it
+automatically includes the skill images.
+-->
+
+---
+
+## Multiple <span class="accent">Consumption</span> Paths
+
+Not every consumer can mount OCI images. skillctl supports multiple ways to get skills where they need to go.
+
+| Method | Command | Best for |
+| ------ | ------- | -------- |
+| **Image volume** | Pod spec `volumes.image` | OpenShift 4.20+ / K8s 1.33+ |
+| **Init container** | `skillctl pull -o /skills` | Older clusters |
+| **CLI pull** | `skillctl pull -o ~/.claude/skills` | Developer workstations |
+| **Container extract** | `podman create` + `podman cp` | No skillctl installed |
+| **Zip download** | Artifact repo or registry | Non-OCI-aware tools |
+
+```bash
+# No skillctl? Use podman to extract skill files directly:
+$ podman create --name tmp quay.io/skills/resume-screener:1.0.0
+$ podman cp tmp:/skills/resume-screener ./skills/
+$ podman rm tmp
+```
+
+<!--
+The podman/docker extraction path is important for users who don't want to install
+skillctl. Since skills are standard OCI images, any container runtime can pull and
+extract the content.
+
+Zip format: skillctl can bundle a .zip alongside the OCI image for consumers that
+can't work with OCI natively (e.g. some coding assistants). Low implementation
+effort — just create a zip of the skill directory and push as an additional layer
+or separate artifact.
+
+Ann Marie Fred (OpenShift AI) noted that coding assistants can't natively load OCI
+artifacts yet. Multiple consumption paths lower the barrier to adoption.
+-->
+
+---
+
+## Try It <span class="accent">Today</span>
+
+- 💻 **Hands-on:** spin up a local Zot registry, pack a skill, push, inspect, pull — 5 minutes end to end
+- 🔀 **Review the PR:** design decisions, media types, and annotation schema are documented in the design spec — feedback welcome
+- 🤝 **Community:** should we propose SkillCard alignment to the Agent Skills OCI Artifacts Specification?
+- 🔏 **Next milestone:** full sigstore integration for keyless skill signing and verification
+- 🏢 **OpenShift alignment:** OCPSTRAT-3122 is building platform-side support — oc-mirror, OLM integration, admission control
+
+<span class="tag-accent">github.com/redhat-et/docsclaw</span>
+
+<!--
+Resources:
+- OCPSTRAT-3122: Agent skill packaging for OpenShift (Jira)
+- OCPSTRAT-3118: Shipping Agent skills for OLM-managed operators
+- OCPSTRAT-3119: Automatic agent skill discovery and registration
+- PR #21: github.com/redhat-et/docsclaw/pull/21
+- Design spec: docs/dev/2026-04-12-oci-skill-distribution-design.md
+- OCI skills guide: docs/oci-skills-guide.md
+- Agent Skills OCI Spec: github.com/ThomasVitale/agents-skills-oci-artifacts-spec
+- ORAS project: oras.land
+- Zot registry: zotregistry.dev
+-->
+
+---
+
+<!-- _class: thankyou -->
+
+# Thank <span class="accent">You</span>
+
+Pavel Anni · Office of CTO · Red Hat
+
+<!--
+Thank you for your time. Questions and feedback welcome.
+-->

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -10,25 +10,30 @@ import (
 
 func newPackCmd() *cobra.Command {
 	var tag string
+	var mediaType string
 	cmd := &cobra.Command{
 		Use:   "pack <dir>",
 		Short: "Pack a skill directory into a local OCI image",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPack(cmd, args[0], tag)
+			return runPack(cmd, args[0], tag, mediaType)
 		},
 	}
 	cmd.Flags().StringVar(&tag, "tag", "", "override the image tag (default: <version>-draft)")
+	cmd.Flags().StringVar(&mediaType, "media-type", "", `media type profile: "standard" (default) or "redhat" (for oc-mirror)`)
 	return cmd
 }
 
-func runPack(cmd *cobra.Command, dir string, tag string) error {
+func runPack(cmd *cobra.Command, dir, tag, mediaType string) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err
 	}
 
-	desc, err := client.Pack(context.Background(), dir, oci.PackOptions{Tag: tag})
+	desc, err := client.Pack(context.Background(), dir, oci.PackOptions{
+		Tag:       tag,
+		MediaType: oci.MediaTypeProfile(mediaType),
+	})
 	if err != nil {
 		return fmt.Errorf("packing %s: %w", dir, err)
 	}

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -25,6 +25,11 @@ func newPackCmd() *cobra.Command {
 }
 
 func runPack(cmd *cobra.Command, dir, tag, mediaType string) error {
+	profile, err := oci.ParseMediaTypeProfile(mediaType)
+	if err != nil {
+		return err
+	}
+
 	client, err := defaultClient()
 	if err != nil {
 		return err
@@ -32,7 +37,7 @@ func runPack(cmd *cobra.Command, dir, tag, mediaType string) error {
 
 	desc, err := client.Pack(context.Background(), dir, oci.PackOptions{
 		Tag:       tag,
-		MediaType: oci.MediaTypeProfile(mediaType),
+		MediaType: profile,
 	})
 	if err != nil {
 		return fmt.Errorf("packing %s: %w", dir, err)

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -69,7 +69,9 @@ type InspectResult struct {
 	WordCount     string
 	Digest        string
 	Created       string
-	MediaType     string
-	Size          int64
-	LayerCount    int
+	MediaType      string
+	ConfigMediaType string
+	LayerMediaType  string
+	Size           int64
+	LayerCount     int
 }

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -27,6 +27,9 @@ func NewClient(storePath string) (*Client, error) {
 type PackOptions struct {
 	// Tag overrides the default tag. If empty, defaults to <version>-draft.
 	Tag string
+	// MediaType selects the media type profile. Empty or "standard" uses
+	// standard OCI types; "redhat" uses Red Hat-specific types for oc-mirror.
+	MediaType MediaTypeProfile
 }
 
 // PushOptions configures the Push operation.

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -76,21 +76,28 @@ func inspect(ctx context.Context, store inspectableStore, ref string) (*InspectR
 		totalSize += layer.Size
 	}
 
+	var layerMediaType string
+	if len(manifest.Layers) > 0 {
+		layerMediaType = manifest.Layers[0].MediaType
+	}
+
 	return &InspectResult{
-		Name:          name,
-		DisplayName:   displayName,
-		Version:       version,
-		Status:        status,
-		Description:   description,
-		Authors:       authors,
-		License:       license,
-		Tags:          tags,
-		Compatibility: compatibility,
-		WordCount:     wordCount,
-		Digest:        desc.Digest.String(),
-		Created:       created,
-		MediaType:     desc.MediaType,
-		Size:          totalSize,
-		LayerCount:    len(manifest.Layers),
+		Name:            name,
+		DisplayName:     displayName,
+		Version:         version,
+		Status:          status,
+		Description:     description,
+		Authors:         authors,
+		License:         license,
+		Tags:            tags,
+		Compatibility:   compatibility,
+		WordCount:       wordCount,
+		Digest:          desc.Digest.String(),
+		Created:         created,
+		MediaType:       desc.MediaType,
+		ConfigMediaType: manifest.Config.MediaType,
+		LayerMediaType:  layerMediaType,
+		Size:            totalSize,
+		LayerCount:      len(manifest.Layers),
 	}, nil
 }

--- a/pkg/oci/mediatype.go
+++ b/pkg/oci/mediatype.go
@@ -3,6 +3,8 @@ package oci
 import (
 	"fmt"
 	"strings"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // MediaTypeProfile selects which set of OCI media types to use when packing
@@ -17,7 +19,7 @@ const (
 )
 
 const (
-	RedHatMediaTypeSkillLayer  = "application/vnd.redhat.agentskill.layer.v1+tar"
+	RedHatMediaTypeSkillLayer  = "application/vnd.redhat.agentskill.layer.v1.tar+gzip"
 	RedHatMediaTypeSkillConfig = "application/vnd.redhat.agentskill.config.v1+json"
 )
 
@@ -41,7 +43,6 @@ func resolveMediaTypes(profile MediaTypeProfile) (layer, config string) {
 	case MediaTypeRedHat:
 		return RedHatMediaTypeSkillLayer, RedHatMediaTypeSkillConfig
 	default:
-		return "application/vnd.oci.image.layer.v1.tar+gzip",
-			"application/vnd.oci.image.config.v1+json"
+		return ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageConfig
 	}
 }

--- a/pkg/oci/mediatype.go
+++ b/pkg/oci/mediatype.go
@@ -1,6 +1,9 @@
 package oci
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // MediaTypeProfile selects which set of OCI media types to use when packing
 // skill images. The default (empty string or "standard") uses standard OCI
@@ -18,19 +21,27 @@ const (
 	RedHatMediaTypeSkillConfig = "application/vnd.redhat.agentskill.config.v1+json"
 )
 
+// ParseMediaTypeProfile validates and normalizes a media type profile string.
+func ParseMediaTypeProfile(s string) (MediaTypeProfile, error) {
+	p := MediaTypeProfile(strings.TrimSpace(strings.ToLower(s)))
+	switch p {
+	case "", MediaTypeStandard:
+		return MediaTypeStandard, nil
+	case MediaTypeRedHat:
+		return MediaTypeRedHat, nil
+	default:
+		return "", fmt.Errorf("unknown media type profile: %q (valid: standard, redhat)", s)
+	}
+}
+
 // resolveMediaTypes returns the layer and config media types for the given
 // profile. An empty profile defaults to standard OCI types.
-func resolveMediaTypes(profile MediaTypeProfile) (layer, config string, err error) {
+func resolveMediaTypes(profile MediaTypeProfile) (layer, config string) {
 	switch profile {
-	case "", MediaTypeStandard:
-		return "application/vnd.oci.image.layer.v1.tar+gzip",
-			"application/vnd.oci.image.config.v1+json",
-			nil
 	case MediaTypeRedHat:
-		return RedHatMediaTypeSkillLayer,
-			RedHatMediaTypeSkillConfig,
-			nil
+		return RedHatMediaTypeSkillLayer, RedHatMediaTypeSkillConfig
 	default:
-		return "", "", fmt.Errorf("unknown media type profile: %q (valid: standard, redhat)", profile)
+		return "application/vnd.oci.image.layer.v1.tar+gzip",
+			"application/vnd.oci.image.config.v1+json"
 	}
 }

--- a/pkg/oci/mediatype.go
+++ b/pkg/oci/mediatype.go
@@ -1,0 +1,36 @@
+package oci
+
+import "fmt"
+
+// MediaTypeProfile selects which set of OCI media types to use when packing
+// skill images. The default (empty string or "standard") uses standard OCI
+// image media types. The "redhat" profile uses Red Hat-specific types that
+// enable oc-mirror to identify skill artifacts for disconnected mirroring.
+type MediaTypeProfile string
+
+const (
+	MediaTypeStandard MediaTypeProfile = "standard"
+	MediaTypeRedHat   MediaTypeProfile = "redhat"
+)
+
+const (
+	RedHatMediaTypeSkillLayer  = "application/vnd.redhat.agentskill.layer.v1+tar"
+	RedHatMediaTypeSkillConfig = "application/vnd.redhat.agentskill.config.v1+json"
+)
+
+// resolveMediaTypes returns the layer and config media types for the given
+// profile. An empty profile defaults to standard OCI types.
+func resolveMediaTypes(profile MediaTypeProfile) (layer, config string, err error) {
+	switch profile {
+	case "", MediaTypeStandard:
+		return "application/vnd.oci.image.layer.v1.tar+gzip",
+			"application/vnd.oci.image.config.v1+json",
+			nil
+	case MediaTypeRedHat:
+		return RedHatMediaTypeSkillLayer,
+			RedHatMediaTypeSkillConfig,
+			nil
+	default:
+		return "", "", fmt.Errorf("unknown media type profile: %q (valid: standard, redhat)", profile)
+	}
+}

--- a/pkg/oci/mediatype_test.go
+++ b/pkg/oci/mediatype_test.go
@@ -3,6 +3,8 @@ package oci
 import (
 	"strings"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestParseMediaTypeProfile(t *testing.T) {
@@ -53,14 +55,14 @@ func TestResolveMediaTypes(t *testing.T) {
 		{
 			name:       "default",
 			profile:    "",
-			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
-			wantConfig: "application/vnd.oci.image.config.v1+json",
+			wantLayer:  ocispec.MediaTypeImageLayerGzip,
+			wantConfig: ocispec.MediaTypeImageConfig,
 		},
 		{
 			name:       "standard",
 			profile:    MediaTypeStandard,
-			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
-			wantConfig: "application/vnd.oci.image.config.v1+json",
+			wantLayer:  ocispec.MediaTypeImageLayerGzip,
+			wantConfig: ocispec.MediaTypeImageConfig,
 		},
 		{
 			name:       "redhat",

--- a/pkg/oci/mediatype_test.go
+++ b/pkg/oci/mediatype_test.go
@@ -1,0 +1,53 @@
+package oci
+
+import "testing"
+
+func TestResolveMediaTypes(t *testing.T) {
+	tests := []struct {
+		profile    MediaTypeProfile
+		wantLayer  string
+		wantConfig string
+		wantErr    bool
+	}{
+		{
+			profile:    "",
+			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
+			wantConfig: "application/vnd.oci.image.config.v1+json",
+		},
+		{
+			profile:    MediaTypeStandard,
+			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
+			wantConfig: "application/vnd.oci.image.config.v1+json",
+		},
+		{
+			profile:    MediaTypeRedHat,
+			wantLayer:  RedHatMediaTypeSkillLayer,
+			wantConfig: RedHatMediaTypeSkillConfig,
+		},
+		{
+			profile: "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.profile), func(t *testing.T) {
+			layer, config, err := resolveMediaTypes(tt.profile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if layer != tt.wantLayer {
+				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
+			}
+			if config != tt.wantConfig {
+				t.Errorf("config = %q, want %q", config, tt.wantConfig)
+			}
+		})
+	}
+}

--- a/pkg/oci/mediatype_test.go
+++ b/pkg/oci/mediatype_test.go
@@ -1,47 +1,78 @@
 package oci
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestResolveMediaTypes(t *testing.T) {
+func TestParseMediaTypeProfile(t *testing.T) {
 	tests := []struct {
-		profile    MediaTypeProfile
-		wantLayer  string
-		wantConfig string
-		wantErr    bool
+		name    string
+		input   string
+		want    MediaTypeProfile
+		wantErr bool
 	}{
-		{
-			profile:    "",
-			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
-			wantConfig: "application/vnd.oci.image.config.v1+json",
-		},
-		{
-			profile:    MediaTypeStandard,
-			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
-			wantConfig: "application/vnd.oci.image.config.v1+json",
-		},
-		{
-			profile:    MediaTypeRedHat,
-			wantLayer:  RedHatMediaTypeSkillLayer,
-			wantConfig: RedHatMediaTypeSkillConfig,
-		},
-		{
-			profile: "invalid",
-			wantErr: true,
-		},
+		{name: "empty", input: "", want: MediaTypeStandard},
+		{name: "standard", input: "standard", want: MediaTypeStandard},
+		{name: "redhat", input: "redhat", want: MediaTypeRedHat},
+		{name: "uppercase", input: "RedHat", want: MediaTypeRedHat},
+		{name: "trailing space", input: "redhat ", want: MediaTypeRedHat},
+		{name: "leading space", input: " standard", want: MediaTypeStandard},
+		{name: "invalid", input: "bogus", wantErr: true},
 	}
 
 	for _, tt := range tests {
-		t.Run(string(tt.profile), func(t *testing.T) {
-			layer, config, err := resolveMediaTypes(tt.profile)
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMediaTypeProfile(tt.input)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), "unknown media type profile") {
+					t.Errorf("error = %q, want it to mention unknown profile", err)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMediaTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		profile    MediaTypeProfile
+		wantLayer  string
+		wantConfig string
+	}{
+		{
+			name:       "default",
+			profile:    "",
+			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
+			wantConfig: "application/vnd.oci.image.config.v1+json",
+		},
+		{
+			name:       "standard",
+			profile:    MediaTypeStandard,
+			wantLayer:  "application/vnd.oci.image.layer.v1.tar+gzip",
+			wantConfig: "application/vnd.oci.image.config.v1+json",
+		},
+		{
+			name:       "redhat",
+			profile:    MediaTypeRedHat,
+			wantLayer:  RedHatMediaTypeSkillLayer,
+			wantConfig: RedHatMediaTypeSkillConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layer, config := resolveMediaTypes(tt.profile)
 			if layer != tt.wantLayer {
 				t.Errorf("layer = %q, want %q", layer, tt.wantLayer)
 			}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -477,6 +477,54 @@ func TestTag(t *testing.T) {
 	}
 }
 
+func TestPackRedHatMediaType(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	desc, err := client.Pack(ctx, skillDir, oci.PackOptions{
+		MediaType: oci.MediaTypeRedHat,
+	})
+	if err != nil {
+		t.Fatalf("Pack with redhat media type: %v", err)
+	}
+	if desc.Digest.String() == "" {
+		t.Error("expected non-empty digest")
+	}
+
+	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if result.MediaType != "application/vnd.oci.image.manifest.v1+json" {
+		t.Errorf("manifest media type = %q, want standard OCI manifest type", result.MediaType)
+	}
+}
+
+func TestPackInvalidMediaType(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.Pack(context.Background(), skillDir, oci.PackOptions{
+		MediaType: "bogus",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid media type profile")
+	}
+}
+
 func TestAnnotationsEmptySKILLmd(t *testing.T) {
 	skillDir := t.TempDir()
 	skillYAML := []byte(`apiVersion: skillimage.io/v1alpha1

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -507,19 +507,8 @@ func TestPackRedHatMediaType(t *testing.T) {
 	}
 }
 
-func TestPackInvalidMediaType(t *testing.T) {
-	skillDir := t.TempDir()
-	writeTestSkill(t, skillDir)
-
-	storeDir := t.TempDir()
-	client, err := oci.NewClient(storeDir)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-
-	_, err = client.Pack(context.Background(), skillDir, oci.PackOptions{
-		MediaType: "bogus",
-	})
+func TestParseMediaTypeProfileRejectsInvalid(t *testing.T) {
+	_, err := oci.ParseMediaTypeProfile("bogus")
 	if err == nil {
 		t.Fatal("expected error for invalid media type profile")
 	}

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -505,6 +505,12 @@ func TestPackRedHatMediaType(t *testing.T) {
 	if result.MediaType != "application/vnd.oci.image.manifest.v1+json" {
 		t.Errorf("manifest media type = %q, want standard OCI manifest type", result.MediaType)
 	}
+	if result.ConfigMediaType != oci.RedHatMediaTypeSkillConfig {
+		t.Errorf("config media type = %q, want %q", result.ConfigMediaType, oci.RedHatMediaTypeSkillConfig)
+	}
+	if result.LayerMediaType != oci.RedHatMediaTypeSkillLayer {
+		t.Errorf("layer media type = %q, want %q", result.LayerMediaType, oci.RedHatMediaTypeSkillLayer)
+	}
 }
 
 func TestParseMediaTypeProfileRejectsInvalid(t *testing.T) {

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -60,10 +60,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 	}
 
 	// 3. Resolve media types for the selected profile.
-	layerMediaType, configMediaType, err := resolveMediaTypes(opts.MediaType)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
+	layerMediaType, configMediaType := resolveMediaTypes(opts.MediaType)
 
 	// 4. Create a tar.gz layer of all files in the directory.
 	layerBuf, uncompressedDigest, err := createLayer(skillDir)

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -59,17 +59,23 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		wordCount = len(strings.Fields(stripFrontmatter(string(data))))
 	}
 
-	// 3. Create a tar.gz layer of all files in the directory.
+	// 3. Resolve media types for the selected profile.
+	layerMediaType, configMediaType, err := resolveMediaTypes(opts.MediaType)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	// 4. Create a tar.gz layer of all files in the directory.
 	layerBuf, uncompressedDigest, err := createLayer(skillDir)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("creating layer: %w", err)
 	}
 
-	// 4. Push the layer blob to the store.
+	// 5. Push the layer blob to the store.
 	layerBytes := layerBuf.Bytes()
 	layerDigest := godigest.FromBytes(layerBytes)
 	layerDesc := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageLayerGzip,
+		MediaType: layerMediaType,
 		Digest:    layerDigest,
 		Size:      int64(len(layerBytes)),
 	}
@@ -77,14 +83,14 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		return ocispec.Descriptor{}, fmt.Errorf("pushing layer: %w", err)
 	}
 
-	// 5. Create and push the OCI image config.
+	// 6. Create and push the OCI image config.
 	configBytes, err := buildImageConfig(uncompressedDigest)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("building image config: %w", err)
 	}
 	configDigest := godigest.FromBytes(configBytes)
 	configDesc := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageConfig,
+		MediaType: configMediaType,
 		Digest:    configDigest,
 		Size:      int64(len(configBytes)),
 	}
@@ -92,10 +98,10 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		return ocispec.Descriptor{}, fmt.Errorf("pushing config: %w", err)
 	}
 
-	// 6. Build annotations from SkillCard.
+	// 7. Build annotations from SkillCard.
 	annotations := buildAnnotations(sc, wordCount)
 
-	// 7. Create and push the OCI manifest.
+	// 8. Create and push the OCI manifest.
 	manifest := ocispec.Manifest{
 		Versioned: specs.Versioned{SchemaVersion: 2},
 		MediaType: ocispec.MediaTypeImageManifest,
@@ -121,7 +127,7 @@ func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (o
 		return ocispec.Descriptor{}, fmt.Errorf("pushing manifest: %w", err)
 	}
 
-	// 8. Tag as namespace/name:tag.
+	// 9. Tag as namespace/name:tag.
 	tag := opts.Tag
 	if tag == "" {
 		tag = lifecycle.TagForState(sc.Metadata.Version, lifecycle.Draft)


### PR DESCRIPTION
## Summary

- Add `--media-type` flag to `skillctl pack` with two profiles: `standard` (default) and `redhat`
- The `redhat` profile uses `application/vnd.redhat.agentskill.layer.v1+tar` and `application/vnd.redhat.agentskill.config.v1+json` media types, enabling `oc-mirror` to identify skill artifacts for disconnected/air-gapped mirroring
- Standard OCI types remain the default — no behavior change for existing users
- Manifest media type stays `application/vnd.oci.image.manifest.v1+json` in both profiles so kubelet image volumes and registry tooling work regardless

Ref: OCPSTRAT-3122 (Agent skill packaging for OpenShift)

## Test plan

- [x] `TestResolveMediaTypes` — covers standard, redhat, empty, and invalid profiles
- [x] `TestPackRedHatMediaType` — full pack with redhat profile, verifies manifest type stays standard
- [x] `TestPackInvalidMediaType` — rejects unknown profile names
- [x] All existing tests pass (no behavior change for default profile)
- [x] `make lint` — 0 issues
- [ ] Manual: `skillctl pack --media-type redhat examples/skills/resume-screener` and inspect the OCI layout to verify layer/config media types


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--media-type` CLI flag to select media type profiles (standard or Red Hat) when packing skills.

* **Documentation**
  * New presentation deck introducing OCI-Based Skill Distribution, covering the skill model, distribution workflows, deployment strategies, and consumption paths.

* **Tests**
  * Added comprehensive test coverage for media type profile parsing and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->