### PR TITLE
feat: add Homebrew, container image, and install script distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   release:
@@ -20,9 +21,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,3 +47,41 @@ release:
   github:
     owner: redhat-et
     name: skillimage
+
+brews:
+  - name: skillctl
+    repository:
+      owner: pavelanni
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/redhat-et/skillimage
+    description: Pack, push, pull, and inspect AI agent skills as OCI images
+    license: Apache-2.0
+    install: |
+      bin.install "skillctl"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - image_templates:
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-arm64"
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "ghcr.io/redhat-et/skillctl:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-amd64"
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/redhat-et/skillctl:latest"
+    image_templates:
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-amd64"
+      - "ghcr.io/redhat-et/skillctl:{{ .Version }}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.21 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY skillctl /usr/local/bin/skillctl
+ENTRYPOINT ["skillctl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ RUN apk add --no-cache ca-certificates
 
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY skillctl /usr/local/bin/skillctl
+COPY --chmod=0755 skillctl /usr/local/bin/skillctl
+USER 65534
 ENTRYPOINT ["skillctl"]

--- a/README.md
+++ b/README.md
@@ -20,13 +20,52 @@ ORAS artifacts. This means:
 - Standard registries (Quay, GHCR, Zot) index and serve them normally
 - Signing and verification via cosign/sigstore (planned)
 
-## Quick start
+## Install
 
-### Build
+### Homebrew (macOS / Linux)
 
 ```bash
-make build
+brew install pavelanni/tap/skillctl
 ```
+
+### Install script
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/redhat-et/skillimage/main/install.sh | sh
+```
+
+To install a specific version or to a custom directory:
+
+```bash
+VERSION=0.1.0 INSTALL_DIR=~/.local/bin curl -fsSL \
+  https://raw.githubusercontent.com/redhat-et/skillimage/main/install.sh | sh
+```
+
+### Go install
+
+```bash
+go install github.com/redhat-et/skillimage/cmd/skillctl@latest
+```
+
+### Container image
+
+```bash
+podman run --rm ghcr.io/redhat-et/skillctl:latest version
+```
+
+### From source
+
+```bash
+make build    # produces bin/skillctl
+```
+
+### GitHub releases
+
+Pre-built binaries for Linux, macOS, and Windows (amd64/arm64)
+are available on the
+[releases page](https://github.com/redhat-et/skillimage/releases).
+
+## Quick start
 
 ### Create a skill
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ curl -fsSL https://raw.githubusercontent.com/redhat-et/skillimage/main/install.s
 To install a specific version or to a custom directory:
 
 ```bash
-VERSION=0.1.0 INSTALL_DIR=~/.local/bin curl -fsSL \
-  https://raw.githubusercontent.com/redhat-et/skillimage/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/redhat-et/skillimage/main/install.sh \
+  | VERSION=0.1.0 INSTALL_DIR=~/.local/bin sh
 ```
 
 ### Go install

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,34 @@ INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
+
 echo "Downloading ${BINARY} ${VERSION} for ${OS}/${ARCH}..."
 curl -fsSL -o "${TMPDIR}/${ARCHIVE}" "$URL"
+curl -fsSL -o "${TMPDIR}/checksums.txt" "$CHECKSUMS_URL"
+
+echo "Verifying checksum..."
+EXPECTED=$(grep "${ARCHIVE}" "${TMPDIR}/checksums.txt" | awk '{print $1}')
+if [ -z "$EXPECTED" ]; then
+  echo "Error: no checksum found for ${ARCHIVE}" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL=$(sha256sum "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL=$(shasum -a 256 "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')
+else
+  echo "Error: no sha256sum or shasum found" >&2
+  exit 1
+fi
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "Error: checksum mismatch" >&2
+  echo "  expected: $EXPECTED" >&2
+  echo "  actual:   $ACTUAL" >&2
+  exit 1
+fi
 
 echo "Extracting..."
 tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
@@ -53,11 +79,11 @@ tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
 echo "Installing to ${INSTALL_DIR}/${BINARY}..."
 if [ -w "$INSTALL_DIR" ]; then
   mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  chmod +x "${INSTALL_DIR}/${BINARY}"
 else
   sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  sudo chmod +x "${INSTALL_DIR}/${BINARY}"
 fi
-
-chmod +x "${INSTALL_DIR}/${BINARY}"
 
 echo "Installed ${BINARY} ${VERSION} to ${INSTALL_DIR}/${BINARY}"
 "${INSTALL_DIR}/${BINARY}" version 2>/dev/null || true

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+REPO="redhat-et/skillimage"
+BINARY="skillctl"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  linux)  OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64)  ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)             echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Determine version
+if [ -n "${VERSION:-}" ]; then
+  TAG="v${VERSION#v}"
+else
+  TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+fi
+
+if [ -z "$TAG" ]; then
+  echo "Error: could not determine latest release version." >&2
+  echo "Set VERSION=x.y.z to install a specific version." >&2
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+ARCHIVE="${BINARY}_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+
+# Determine install directory
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${BINARY} ${VERSION} for ${OS}/${ARCH}..."
+curl -fsSL -o "${TMPDIR}/${ARCHIVE}" "$URL"
+
+echo "Extracting..."
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+
+echo "Installing to ${INSTALL_DIR}/${BINARY}..."
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+  sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+echo "Installed ${BINARY} ${VERSION} to ${INSTALL_DIR}/${BINARY}"
+"${INSTALL_DIR}/${BINARY}" version 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add Homebrew formula via GoReleaser, auto-updated to `pavelanni/homebrew-tap` on each release
- Add multi-arch container image (`ghcr.io/redhat-et/skillctl`) built from a minimal scratch-based Dockerfile
- Add `install.sh` — a curl-based installer that detects OS/arch and downloads from GitHub Releases
- Update release workflow with GHCR login and Homebrew tap token passthrough
- Update README with install section covering all five distribution methods

## Setup required before first release

1. Create `pavelanni/homebrew-tap` repo on GitHub (empty, public)
2. Create a GitHub PAT with `repo` scope for that repo
3. Add it as `HOMEBREW_TAP_TOKEN` secret in `redhat-et/skillimage` settings

## Test plan

- [x] `goreleaser check` validates config
- [x] `make test` and `make lint` pass
- [ ] Manual: `goreleaser release --snapshot --clean` to verify archives, Docker images, and formula generation
- [ ] Manual: verify install.sh works after first release
- [ ] Manual: verify `brew install pavelanni/tap/skillctl` works after first release


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew formula for easy installation.
  * New curl-based installation script for streamlined setup across platforms.
  * Multi-architecture Docker images now available on GitHub Container Registry (amd64 and arm64).

* **Documentation**
  * Expanded README with comprehensive installation guide covering multiple methods: Homebrew, curl script, Go install, container, and pre-built binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->