### PR TITLE
feat: support running skillctl in OpenShift containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM alpine:3.21 AS certs
-RUN apk add --no-cache ca-certificates
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /skillctl ./cmd/skillctl
+
+FROM alpine:3.21 AS base
+RUN apk add --no-cache ca-certificates \
+ && mkdir -p /home/skillctl/.local/share \
+ && chown -R 65534:0 /home/skillctl \
+ && chmod -R g+rwX /home/skillctl
 
 FROM scratch
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --chmod=0755 skillctl /usr/local/bin/skillctl
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=base /home/skillctl /home/skillctl
+COPY --from=build /skillctl /usr/local/bin/skillctl
+ENV HOME=/home/skillctl
 USER 65534
 ENTRYPOINT ["skillctl"]

--- a/README.md
+++ b/README.md
@@ -180,14 +180,15 @@ oc create secret docker-registry skillctl-auth \
 Then run skillctl as a pod with the secret mounted:
 
 ```bash
-oc run skillctl --rm --restart=Never \
+oc run skillctl --rm -i --restart=Never \
   --image=ghcr.io/redhat-et/skillctl:latest \
   --overrides='{"spec":{"containers":[{"name":"skillctl","image":"ghcr.io/redhat-et/skillctl:latest","args":["inspect","--tls-verify=false","image-registry.openshift-image-registry.svc:5000/NAMESPACE/SKILL@sha256:DIGEST"],"volumeMounts":[{"name":"auth","mountPath":"/home/skillctl/.docker"}]}],"volumes":[{"name":"auth","secret":{"secretName":"skillctl-auth","items":[{"key":".dockerconfigjson","path":"config.json"}]}}]}}'
 ```
 
 Use `--tls-verify=false` for the internal registry (self-signed
-certificate). The token from `oc whoami -t` is short-lived;
-recreate the secret when it expires.
+certificate). The `-i` flag ensures `--rm` cleans up the pod
+after it completes. The token from `oc whoami -t` is typically
+valid for 24 hours; recreate the secret when it expires.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ spec:
   prompt: SKILL.md
 ```
 
+The `namespace` field groups skills locally. When you run
+`skillctl list`, skills display as `namespace/name` (e.g.,
+`examples/hello-world`). The namespace is a logical grouping
+within the skill card and is independent of the remote registry
+path.
+
 ### Validate, pack, and inspect
 
 ```bash
@@ -125,6 +131,12 @@ bin/skillctl push quay.io/myorg/hello-world:1.0.0-draft
 bin/skillctl pull quay.io/myorg/hello-world:1.0.0 -o ./skills/
 ```
 
+We recommend aligning the remote registry path with the skill's
+`namespace` field. For example, a skill with `namespace: business`
+would push to `quay.io/myorg/business/hello-world:1.0.0-draft`.
+This is a convention, not enforced by skillctl, but it makes it
+easier to find skills in both local and remote listings.
+
 Authentication uses your existing `~/.docker/config.json` or
 Podman's `auth.json` -- no separate login needed.
 
@@ -151,6 +163,31 @@ skopeo inspect docker://quay.io/myorg/hello-world:1.0.0 \
 This works because all skill metadata is stored in OCI manifest
 annotations, not inside the image layers. A catalog UI or CI
 pipeline can read skill metadata with a single manifest fetch.
+
+### Running skillctl on OpenShift
+
+You can run skillctl directly on an OpenShift cluster to inspect
+images in the internal registry. First, create a secret with your
+registry credentials:
+
+```bash
+oc create secret docker-registry skillctl-auth \
+  --docker-server=image-registry.openshift-image-registry.svc:5000 \
+  --docker-username=unused \
+  --docker-password="$(oc whoami -t)"
+```
+
+Then run skillctl as a pod with the secret mounted:
+
+```bash
+oc run skillctl --rm --restart=Never \
+  --image=ghcr.io/redhat-et/skillctl:latest \
+  --overrides='{"spec":{"containers":[{"name":"skillctl","image":"ghcr.io/redhat-et/skillctl:latest","args":["inspect","--tls-verify=false","image-registry.openshift-image-registry.svc:5000/NAMESPACE/SKILL@sha256:DIGEST"],"volumeMounts":[{"name":"auth","mountPath":"/home/skillctl/.docker"}]}],"volumes":[{"name":"auth","secret":{"secretName":"skillctl-auth","items":[{"key":".dockerconfigjson","path":"config.json"}]}}]}}'
+```
+
+Use `--tls-verify=false` for the internal registry (self-signed
+certificate). The token from `oc whoami -t` is short-lived;
+recreate the secret when it expires.
 
 ## Testing
 

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
 )
 
 func newInspectCmd() *cobra.Command {
@@ -34,7 +36,7 @@ func runInspect(cmd *cobra.Command, ref string, skipTLSVerify bool) error {
 	result, localErr := client.Inspect(ctx, ref)
 	if localErr != nil {
 		var remoteErr error
-		result, remoteErr = client.InspectRemote(ctx, ref, skipTLSVerify)
+		result, remoteErr = client.InspectRemote(ctx, ref, oci.InspectOptions{SkipTLSVerify: skipTLSVerify})
 		if remoteErr != nil {
 			return fmt.Errorf("inspecting %s: %w", ref, errors.Join(localErr, remoteErr))
 		}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -9,17 +9,20 @@ import (
 )
 
 func newInspectCmd() *cobra.Command {
-	return &cobra.Command{
+	var tlsVerify bool
+	cmd := &cobra.Command{
 		Use:   "inspect <ref>",
 		Short: "Show SkillCard metadata and OCI image details",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInspect(cmd, args[0])
+			return runInspect(cmd, args[0], !tlsVerify)
 		},
 	}
+	cmd.Flags().BoolVar(&tlsVerify, "tls-verify", true, "require HTTPS and verify certificates")
+	return cmd
 }
 
-func runInspect(cmd *cobra.Command, ref string) error {
+func runInspect(cmd *cobra.Command, ref string, skipTLSVerify bool) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err
@@ -31,7 +34,7 @@ func runInspect(cmd *cobra.Command, ref string) error {
 	result, localErr := client.Inspect(ctx, ref)
 	if localErr != nil {
 		var remoteErr error
-		result, remoteErr = client.InspectRemote(ctx, ref)
+		result, remoteErr = client.InspectRemote(ctx, ref, skipTLSVerify)
 		if remoteErr != nil {
 			return fmt.Errorf("inspecting %s: %w", ref, errors.Join(localErr, remoteErr))
 		}

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -13,6 +13,7 @@ import (
 func newPromoteCmd() *cobra.Command {
 	var toState string
 	var local bool
+	var tlsVerify bool
 	cmd := &cobra.Command{
 		Use:   "promote <ref>",
 		Short: "Promote a skill to the next lifecycle state",
@@ -28,16 +29,17 @@ Examples:
   skillctl promote test/test-skill:1.0.0-draft --to testing --local`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPromote(cmd, args[0], toState, local)
+			return runPromote(cmd, args[0], toState, local, !tlsVerify)
 		},
 	}
 	cmd.Flags().StringVar(&toState, "to", "", "target lifecycle state (required)")
 	_ = cmd.MarkFlagRequired("to")
 	cmd.Flags().BoolVar(&local, "local", false, "promote in local store instead of remote registry")
+	cmd.Flags().BoolVar(&tlsVerify, "tls-verify", true, "require HTTPS and verify certificates")
 	return cmd
 }
 
-func runPromote(cmd *cobra.Command, ref, toState string, local bool) error {
+func runPromote(cmd *cobra.Command, ref, toState string, local bool, skipTLSVerify bool) error {
 	to, err := lifecycle.ParseState(toState)
 	if err != nil {
 		return fmt.Errorf("invalid target state: %w", err)
@@ -55,7 +57,7 @@ func runPromote(cmd *cobra.Command, ref, toState string, local bool) error {
 			return fmt.Errorf("promoting %s: %w", ref, err)
 		}
 	} else {
-		if err := client.Promote(ctx, ref, to, oci.PromoteOptions{}); err != nil {
+		if err := client.Promote(ctx, ref, to, oci.PromoteOptions{SkipTLSVerify: skipTLSVerify}); err != nil {
 			return fmt.Errorf("promoting %s: %w", ref, err)
 		}
 	}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -11,6 +11,7 @@ import (
 
 func newPullCmd() *cobra.Command {
 	var outputDir string
+	var tlsVerify bool
 	cmd := &cobra.Command{
 		Use:   "pull <ref>",
 		Short: "Pull a skill image from a remote registry",
@@ -25,10 +26,11 @@ Examples:
   skillctl pull quay.io/acme/hr-onboarding:1.0.0 -o ./skills/`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPull(cmd, args[0], outputDir)
+			return runPull(cmd, args[0], outputDir, !tlsVerify)
 		},
 	}
 	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "unpack skill files to directory")
+	cmd.Flags().BoolVar(&tlsVerify, "tls-verify", true, "require HTTPS and verify certificates")
 	return cmd
 }
 
@@ -36,7 +38,7 @@ func looksLocal(ref string) bool {
 	return !strings.Contains(ref, "/")
 }
 
-func runPull(cmd *cobra.Command, ref string, outputDir string) error {
+func runPull(cmd *cobra.Command, ref string, outputDir string, skipTLSVerify bool) error {
 	if looksLocal(ref) {
 		return fmt.Errorf("%s looks like a local reference, not a remote registry\n\nTo install from the local store, use:\n  skillctl install %s --target <agent>\n  skillctl install %s -o <directory>", ref, ref, ref)
 	}
@@ -47,7 +49,8 @@ func runPull(cmd *cobra.Command, ref string, outputDir string) error {
 	}
 
 	desc, err := client.Pull(context.Background(), ref, oci.PullOptions{
-		OutputDir: outputDir,
+		OutputDir:     outputDir,
+		SkipTLSVerify: skipTLSVerify,
 	})
 	if err != nil {
 		return fmt.Errorf("pulling: %w", err)

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -9,7 +9,8 @@ import (
 )
 
 func newPushCmd() *cobra.Command {
-	return &cobra.Command{
+	var tlsVerify bool
+	cmd := &cobra.Command{
 		Use:   "push <ref>",
 		Short: "Push a skill image from local store to a remote registry",
 		Long: `Push a skill image to a remote OCI registry.
@@ -18,18 +19,20 @@ The ref should be a full OCI reference: registry/namespace/name:tag
 Example: quay.io/acme/hr-onboarding:1.0.0-draft`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPush(cmd, args[0])
+			return runPush(cmd, args[0], !tlsVerify)
 		},
 	}
+	cmd.Flags().BoolVar(&tlsVerify, "tls-verify", true, "require HTTPS and verify certificates")
+	return cmd
 }
 
-func runPush(cmd *cobra.Command, ref string) error {
+func runPush(cmd *cobra.Command, ref string, skipTLSVerify bool) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err
 	}
 
-	if err := client.Push(context.Background(), ref, oci.PushOptions{}); err != nil {
+	if err := client.Push(context.Background(), ref, oci.PushOptions{SkipTLSVerify: skipTLSVerify}); err != nil {
 		return fmt.Errorf("pushing: %w", err)
 	}
 

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -66,6 +66,13 @@ type PromoteOptions struct {
 	SkipTLSVerify bool
 }
 
+// InspectOptions configures the InspectRemote operation.
+type InspectOptions struct {
+	// SkipTLSVerify disables TLS certificate verification for the
+	// remote registry (equivalent to --tls-verify=false).
+	SkipTLSVerify bool
+}
+
 // InspectResult holds detailed metadata for a skill image.
 type InspectResult struct {
 	Name          string

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -33,13 +33,20 @@ type PackOptions struct {
 }
 
 // PushOptions configures the Push operation.
-type PushOptions struct{}
+type PushOptions struct {
+	// SkipTLSVerify disables TLS certificate verification for the
+	// remote registry (equivalent to --tls-verify=false).
+	SkipTLSVerify bool
+}
 
 // PullOptions configures the Pull operation.
 type PullOptions struct {
 	// OutputDir, if set, causes the pulled image to be unpacked into this
 	// directory after storing it locally.
 	OutputDir string
+	// SkipTLSVerify disables TLS certificate verification for the
+	// remote registry (equivalent to --tls-verify=false).
+	SkipTLSVerify bool
 }
 
 // LocalImage holds metadata for an image stored in the local OCI layout.
@@ -53,7 +60,11 @@ type LocalImage struct {
 }
 
 // PromoteOptions configures the Promote operation.
-type PromoteOptions struct{}
+type PromoteOptions struct {
+	// SkipTLSVerify disables TLS certificate verification for the
+	// remote registry (equivalent to --tls-verify=false).
+	SkipTLSVerify bool
+}
 
 // InspectResult holds detailed metadata for a skill image.
 type InspectResult struct {

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -23,8 +23,8 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 }
 
 // InspectRemote retrieves detailed metadata for a skill image on a remote registry.
-func (c *Client) InspectRemote(ctx context.Context, ref string, skipTLSVerify bool) (*InspectResult, error) {
-	repo, err := newRemoteRepository(ref, skipTLSVerify)
+func (c *Client) InspectRemote(ctx context.Context, ref string, opts InspectOptions) (*InspectResult, error) {
+	repo, err := newRemoteRepository(ref, opts.SkipTLSVerify)
 	if err != nil {
 		return nil, fmt.Errorf("creating remote repository: %w", err)
 	}

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -23,8 +23,8 @@ func (c *Client) Inspect(ctx context.Context, ref string) (*InspectResult, error
 }
 
 // InspectRemote retrieves detailed metadata for a skill image on a remote registry.
-func (c *Client) InspectRemote(ctx context.Context, ref string) (*InspectResult, error) {
-	repo, err := newRemoteRepository(ref)
+func (c *Client) InspectRemote(ctx context.Context, ref string, skipTLSVerify bool) (*InspectResult, error) {
+	repo, err := newRemoteRepository(ref, skipTLSVerify)
 	if err != nil {
 		return nil, fmt.Errorf("creating remote repository: %w", err)
 	}

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -212,6 +212,9 @@ func (c *Client) imageFromManifest(ctx context.Context, tag string, desc ocispec
 // parseNameFromTag extracts the "namespace/name" portion from a tag reference
 // like "namespace/name:tag".
 func parseNameFromTag(ref string) string {
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		return ref[:idx]
+	}
 	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
 		return ref[:idx]
 	}

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -194,10 +194,7 @@ func (c *Client) imageFromManifest(ctx context.Context, tag string, desc ocispec
 	}
 
 	name := parseNameFromTag(tag)
-	tagPart := ""
-	if idx := strings.LastIndex(tag, ":"); idx >= 0 {
-		tagPart = tag[idx+1:]
-	}
+	_, tagPart := splitRefTag(tag)
 
 	return &LocalImage{
 		Name:    name,

--- a/pkg/oci/promote.go
+++ b/pkg/oci/promote.go
@@ -34,8 +34,8 @@ func (c *Client) PromoteLocal(ctx context.Context, ref string, to lifecycle.Stat
 
 // Promote promotes a skill on a remote registry by transitioning it
 // from its current lifecycle state to the target state.
-func (c *Client) Promote(ctx context.Context, ref string, to lifecycle.State, _ PromoteOptions) error {
-	repo, err := newRemoteRepository(ref)
+func (c *Client) Promote(ctx context.Context, ref string, to lifecycle.State, opts PromoteOptions) error {
+	repo, err := newRemoteRepository(ref, opts.SkipTLSVerify)
 	if err != nil {
 		return fmt.Errorf("creating remote repository: %w", err)
 	}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -86,12 +86,12 @@ func (c *Client) Unpack(ctx context.Context, ref string, outputDir string) error
 // skillNameFromRef extracts the skill name from a reference like
 // "namespace/name:tag" -- it returns "name".
 func skillNameFromRef(ref string) string {
-	// Strip tag.
 	name := ref
-	if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		name = ref[:idx]
+	} else if idx := strings.LastIndex(ref, ":"); idx >= 0 {
 		name = ref[:idx]
 	}
-	// Take the last path segment.
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {
 		name = name[idx+1:]
 	}

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -18,7 +18,7 @@ import (
 // Pull copies an image from a remote registry into the local store.
 // If opts.OutputDir is set, the image is also unpacked into that directory.
 func (c *Client) Pull(ctx context.Context, ref string, opts PullOptions) (ocispec.Descriptor, error) {
-	repo, err := newRemoteRepository(ref)
+	repo, err := newRemoteRepository(ref, opts.SkipTLSVerify)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("creating remote repository: %w", err)
 	}

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -2,7 +2,9 @@ package oci
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,8 +16,8 @@ import (
 )
 
 // Push copies an image from the local OCI store to a remote registry.
-func (c *Client) Push(ctx context.Context, ref string, _ PushOptions) error {
-	repo, err := newRemoteRepository(ref)
+func (c *Client) Push(ctx context.Context, ref string, opts PushOptions) error {
+	repo, err := newRemoteRepository(ref, opts.SkipTLSVerify)
 	if err != nil {
 		return fmt.Errorf("creating remote repository: %w", err)
 	}
@@ -44,7 +46,7 @@ func (c *Client) CopyTo(ctx context.Context, ref string, dst *Client) error {
 // newRemoteRepository creates a remote.Repository from a full reference string
 // like "registry.example.com/namespace/name:tag", configured with credentials
 // from Docker and Podman auth files.
-func newRemoteRepository(ref string) (*remote.Repository, error) {
+func newRemoteRepository(ref string, skipTLSVerify bool) (*remote.Repository, error) {
 	repoRef, _ := splitRefTag(ref)
 	repo, err := remote.NewRepository(repoRef)
 	if err != nil {
@@ -56,9 +58,17 @@ func newRemoteRepository(ref string) (*remote.Repository, error) {
 		return nil, fmt.Errorf("loading credentials: %w", err)
 	}
 
-	repo.Client = &auth.Client{
+	authClient := &auth.Client{
 		Credential: credentials.Credential(store),
 	}
+	if skipTLSVerify {
+		authClient.Client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-requested via --tls-verify=false
+			},
+		}
+	}
+	repo.Client = authClient
 
 	return repo, nil
 }
@@ -100,21 +110,29 @@ func podmanAuthPath() string {
 	return filepath.Join(home, ".config", "containers", "auth.json")
 }
 
-// splitRefTag splits an OCI reference into repository and tag.
+// splitRefTag splits an OCI reference into repository and tag/digest.
 // Handles registry ports correctly: localhost:5000/ns/name:tag splits
 // at the tag colon (after the last /), not the port colon.
+// Digest references (name@sha256:abc) split at the @ and return the
+// full digest (sha256:abc) as the tag.
 func splitRefTag(ref string) (repo, tag string) {
-	// Find the last slash to isolate the name:tag portion.
+	// Find the last slash to isolate the name portion.
 	lastSlash := strings.LastIndex(ref, "/")
 	if lastSlash < 0 {
-		// No slash: the whole ref might be name:tag.
+		if idx := strings.Index(ref, "@"); idx >= 0 {
+			return ref[:idx], ref[idx+1:]
+		}
 		if idx := strings.LastIndex(ref, ":"); idx >= 0 {
 			return ref[:idx], ref[idx+1:]
 		}
 		return ref, ""
 	}
-	// Look for a colon only after the last slash.
 	tail := ref[lastSlash+1:]
+	// Digest reference: name@sha256:abc...
+	if idx := strings.Index(tail, "@"); idx >= 0 {
+		return ref[:lastSlash+1+idx], tail[idx+1:]
+	}
+	// Tag reference: name:tag
 	if idx := strings.LastIndex(tail, ":"); idx >= 0 {
 		return ref[:lastSlash+1+idx], tail[idx+1:]
 	}

--- a/pkg/oci/push.go
+++ b/pkg/oci/push.go
@@ -64,7 +64,7 @@ func newRemoteRepository(ref string, skipTLSVerify bool) (*remote.Repository, er
 	if skipTLSVerify {
 		authClient.Client = &http.Client{
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // user-requested via --tls-verify=false
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // user-requested via --tls-verify=false
 			},
 		}
 	}

--- a/pkg/oci/ref_test.go
+++ b/pkg/oci/ref_test.go
@@ -18,11 +18,13 @@ func TestSplitRefTag(t *testing.T) {
 		{"name", "name", ""},
 	}
 	for _, tt := range tests {
-		repo, tag := splitRefTag(tt.ref)
-		if repo != tt.wantRepo || tag != tt.wantTag {
-			t.Errorf("splitRefTag(%q) = (%q, %q), want (%q, %q)",
-				tt.ref, repo, tag, tt.wantRepo, tt.wantTag)
-		}
+		t.Run(tt.ref, func(t *testing.T) {
+			repo, tag := splitRefTag(tt.ref)
+			if repo != tt.wantRepo || tag != tt.wantTag {
+				t.Errorf("splitRefTag(%q) = (%q, %q), want (%q, %q)",
+					tt.ref, repo, tag, tt.wantRepo, tt.wantTag)
+			}
+		})
 	}
 }
 
@@ -38,10 +40,12 @@ func TestParseNameFromTag(t *testing.T) {
 		{"name", "name"},
 	}
 	for _, tt := range tests {
-		got := parseNameFromTag(tt.ref)
-		if got != tt.want {
-			t.Errorf("parseNameFromTag(%q) = %q, want %q", tt.ref, got, tt.want)
-		}
+		t.Run(tt.ref, func(t *testing.T) {
+			got := parseNameFromTag(tt.ref)
+			if got != tt.want {
+				t.Errorf("parseNameFromTag(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -58,9 +62,11 @@ func TestSkillNameFromRef(t *testing.T) {
 		{"name", "name"},
 	}
 	for _, tt := range tests {
-		got := skillNameFromRef(tt.ref)
-		if got != tt.want {
-			t.Errorf("skillNameFromRef(%q) = %q, want %q", tt.ref, got, tt.want)
-		}
+		t.Run(tt.ref, func(t *testing.T) {
+			got := skillNameFromRef(tt.ref)
+			if got != tt.want {
+				t.Errorf("skillNameFromRef(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/oci/ref_test.go
+++ b/pkg/oci/ref_test.go
@@ -1,0 +1,66 @@
+package oci
+
+import "testing"
+
+func TestSplitRefTag(t *testing.T) {
+	tests := []struct {
+		ref      string
+		wantRepo string
+		wantTag  string
+	}{
+		{"ns/name:1.0.0", "ns/name", "1.0.0"},
+		{"ns/name@sha256:abc123", "ns/name", "sha256:abc123"},
+		{"localhost:5000/ns/name:tag", "localhost:5000/ns/name", "tag"},
+		{"localhost:5000/ns/name@sha256:abc", "localhost:5000/ns/name", "sha256:abc"},
+		{"registry.svc:5000/team1/skill@sha256:ffa608d3", "registry.svc:5000/team1/skill", "sha256:ffa608d3"},
+		{"name:tag", "name", "tag"},
+		{"name@sha256:abc", "name", "sha256:abc"},
+		{"name", "name", ""},
+	}
+	for _, tt := range tests {
+		repo, tag := splitRefTag(tt.ref)
+		if repo != tt.wantRepo || tag != tt.wantTag {
+			t.Errorf("splitRefTag(%q) = (%q, %q), want (%q, %q)",
+				tt.ref, repo, tag, tt.wantRepo, tt.wantTag)
+		}
+	}
+}
+
+func TestParseNameFromTag(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"ns/name:1.0.0", "ns/name"},
+		{"ns/name@sha256:abc123", "ns/name"},
+		{"registry:5000/ns/name:tag", "registry:5000/ns/name"},
+		{"registry:5000/ns/name@sha256:abc", "registry:5000/ns/name"},
+		{"name", "name"},
+	}
+	for _, tt := range tests {
+		got := parseNameFromTag(tt.ref)
+		if got != tt.want {
+			t.Errorf("parseNameFromTag(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestSkillNameFromRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"ns/name:1.0.0", "name"},
+		{"ns/name@sha256:abc123", "name"},
+		{"registry:5000/ns/skill@sha256:ffa608d3", "skill"},
+		{"registry:5000/ns/skill:1.0.0-draft", "skill"},
+		{"name:tag", "name"},
+		{"name", "name"},
+	}
+	for _, tt := range tests {
+		got := skillNameFromRef(tt.ref)
+		if got != tt.want {
+			t.Errorf("skillNameFromRef(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Dockerfile**: multi-stage build compiles Go binary inside the container; creates OpenShift-compatible home directory (GID 0 writable) so skillctl works with arbitrary UIDs
- **`--tls-verify` flag**: added to `inspect`, `push`, `pull`, and `promote` for registries with self-signed certificates (e.g. OpenShift internal registry)
- **Digest reference support**: `splitRefTag` and `parseNameFromTag` now handle `@sha256:...` references correctly
- **README**: documents namespace field, remote naming convention, and OpenShift usage with `oc run` + mounted auth secrets

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Verified `splitRefTag` parses digest refs, tag refs, and port-based registry refs correctly
- [x] Built container image via `podman build` on RHEL x86_64
- [x] Successfully ran `skillctl inspect --tls-verify=false` against OpenShift internal registry from a pod with mounted auth secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--tls-verify` flag to `inspect`, `promote`, `pull`, and `push` commands to control TLS certificate verification when accessing remote registries.

* **Documentation**
  * Documented `namespace` field semantics and registry path conventions.
  * Added OpenShift workflow guide for in-cluster image inspection.

* **Chores**
  * Improved container image: multi-stage build with non-root user and CA certificate support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->