### PR TITLE
fix: split Dockerfile for GoReleaser and local builds

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,3 +1,10 @@
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /skillctl ./cmd/skillctl
+
 FROM alpine:3.21 AS base
 RUN apk add --no-cache ca-certificates \
  && mkdir -p /home/skillctl/.local/share \
@@ -7,7 +14,7 @@ RUN apk add --no-cache ca-certificates \
 FROM scratch
 COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=base /home/skillctl /home/skillctl
-COPY --chmod=0755 skillctl /usr/local/bin/skillctl
+COPY --from=build /skillctl /usr/local/bin/skillctl
 ENV HOME=/home/skillctl
 USER 65534
 ENTRYPOINT ["skillctl"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt clean
+.PHONY: build test lint fmt clean image
 
 BINARY := skillctl
 BINDIR := bin
@@ -14,6 +14,9 @@ lint:
 
 fmt:
 	gofumpt -l -w .
+
+image:
+	podman -c rhel build -f Dockerfile.local -t ghcr.io/redhat-et/skillctl:latest .
 
 clean:
 	rm -rf $(BINDIR)


### PR DESCRIPTION
## Summary

- Restore `Dockerfile` to expect a pre-built binary (GoReleaser passes only `Dockerfile` + binary into the Docker context)
- Move full build-from-source Dockerfile to `Dockerfile.local` for local dev
- Add `make image` target that builds via `podman -c rhel` using `Dockerfile.local`

Fixes the v0.2.0 release build failure where GoReleaser could not find `go.mod` in the Docker context.

## Test plan

- [ ] `make image` builds successfully via podman
- [ ] GoReleaser release build passes (retag after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)