### PR TITLE
refactor: rename pack command to build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ make fmt         # Format code
 | `internal/store/` | Storage interface + SQLite |
 | `internal/server/` | Router, middleware |
 | `pkg/skillcard/` | SkillCard parse, validate, serialize |
-| `pkg/oci/` | Pack/push/pull/inspect (oras-go) |
+| `pkg/oci/` | Build/push/pull/inspect (oras-go) |
 | `pkg/verify/` | Sigstore signature verification |
 | `pkg/lifecycle/` | State machine, semver rules |
 | `pkg/diff/` | Version comparison |
@@ -40,7 +40,7 @@ make fmt         # Format code
 ## Architecture
 
 Library-first: core logic in `pkg/`, CLI and server are thin
-consumers. Two operating modes: standalone CLI (pack/push/pull
+consumers. Two operating modes: standalone CLI (build/push/pull
 against OCI registries, no server needed) and server mode
 (lifecycle management, search, UI support via REST API).
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,14 @@ The `namespace` field groups skills locally. When you run
 within the skill card and is independent of the remote registry
 path.
 
-### Validate, pack, and inspect
+### Validate, build, and inspect
 
 ```bash
 # Validate the SkillCard against the JSON Schema
 bin/skillctl validate examples/hello-world/
 
-# Pack into a local OCI image (tagged as 1.0.0-draft)
-bin/skillctl pack examples/hello-world/
+# Build into a local OCI image (tagged as 1.0.0-draft)
+bin/skillctl build examples/hello-world/
 
 # List local images
 bin/skillctl list
@@ -266,7 +266,7 @@ make fmt         # Format code
 | `cmd/skillctl/` | CLI entry point |
 | `internal/cli/` | Cobra commands |
 | `pkg/skillcard/` | SkillCard parse, validate, serialize |
-| `pkg/oci/` | OCI image pack/push/pull/inspect/promote |
+| `pkg/oci/` | OCI image build/push/pull/inspect/promote |
 | `pkg/lifecycle/` | State machine, tag rules |
 | `schemas/` | JSON Schema for SkillCard |
 | `examples/` | Sample skills |
@@ -283,7 +283,7 @@ consumers: skillctl CLI, agent runtimes, CI/CD
       |
   pkg/ (public Go API)
   +-- skillcard/  parse, validate, serialize
-  +-- oci/        pack, push, pull, inspect, promote
+  +-- oci/        build, push, pull, inspect, promote
   +-- lifecycle/  state machine, tag rules
       |
   OCI registries (quay.io, ghcr.io, Zot)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,7 +41,7 @@ Start a local registry (e.g. [zot](https://zotregistry.dev)):
 podman run -d -p 5000:5000 ghcr.io/project-zot/zot-linux-amd64:latest
 
 # Push skills to it
-bin/skillctl pack examples/document-reviewer
+bin/skillctl build examples/document-reviewer
 bin/skillctl push test/document-reviewer:1.0.0-draft localhost:5000/test/document-reviewer:1.0.0-draft --tls-verify=false
 
 # Serve — local registries support /v2/_catalog, so no --repositories needed

--- a/docs/index.html
+++ b/docs/index.html
@@ -383,12 +383,12 @@
 
   <!-- WORKFLOW -->
   <section>
-    <h2>The Workflow: <span class="accent">Pack, Push, Mount</span></h2>
+    <h2>The Workflow: <span class="accent">Build, Push, Mount</span></h2>
     <div class="code-section">
       <div class="code-block">
-        <span class="comment"># Pack a skill directory into a local OCI image</span><br>
-        <span class="cmd">$ skillctl pack</span> examples/skills/resume-screener<br>
-        <span class="output">Packed &rarr; oci-layout &middot; sha256:65af81ce... &middot; 1226 bytes</span><br><br>
+        <span class="comment"># Build a skill directory into a local OCI image</span><br>
+        <span class="cmd">$ skillctl build</span> examples/skills/resume-screener<br>
+        <span class="output">Built &rarr; oci-layout &middot; sha256:65af81ce... &middot; 1226 bytes</span><br><br>
 
         <span class="comment"># Push to any OCI registry</span><br>
         <span class="cmd">$ skillctl push</span> quay.io/myorg/skill-resume-screener:1.0.0<br>

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -8,32 +8,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPackCmd() *cobra.Command {
+func newBuildCmd() *cobra.Command {
 	var tag string
 	var mediaType string
 	var bundle bool
 	cmd := &cobra.Command{
-		Use:   "pack <dir>",
-		Short: "Pack a skill directory into a local OCI image",
-		Long: `Pack a skill directory into a local OCI image.
+		Use:   "build <dir>",
+		Short: "Build a skill directory into a local OCI image",
+		Long: `Build a skill directory into a local OCI image.
 
-Use --bundle to pack a directory containing multiple skill
+Use --bundle to build a directory containing multiple skill
 subdirectories into a single OCI image.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if bundle {
-				return runPackBundle(cmd, args[0], tag, mediaType)
+				return runBuildBundle(cmd, args[0], tag, mediaType)
 			}
-			return runPack(cmd, args[0], tag, mediaType)
+			return runBuild(cmd, args[0], tag, mediaType)
 		},
 	}
 	cmd.Flags().StringVar(&tag, "tag", "", "override the image tag (default: <version>-draft)")
 	cmd.Flags().StringVar(&mediaType, "media-type", "", `media type profile: "standard" (default) or "redhat" (for oc-mirror)`)
-	cmd.Flags().BoolVar(&bundle, "bundle", false, "pack multiple skill subdirectories as a single image")
+	cmd.Flags().BoolVar(&bundle, "bundle", false, "build multiple skill subdirectories as a single image")
 	return cmd
 }
 
-func runPack(cmd *cobra.Command, dir, tag, mediaType string) error {
+func runBuild(cmd *cobra.Command, dir, tag, mediaType string) error {
 	profile, err := oci.ParseMediaTypeProfile(mediaType)
 	if err != nil {
 		return err
@@ -44,19 +44,19 @@ func runPack(cmd *cobra.Command, dir, tag, mediaType string) error {
 		return err
 	}
 
-	desc, err := client.Pack(context.Background(), dir, oci.PackOptions{
+	desc, err := client.Build(context.Background(), dir, oci.BuildOptions{
 		Tag:       tag,
 		MediaType: profile,
 	})
 	if err != nil {
-		return fmt.Errorf("packing %s: %w", dir, err)
+		return fmt.Errorf("building %s: %w", dir, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Packed %s\nDigest: %s\n", dir, desc.Digest)
+	fmt.Fprintf(cmd.OutOrStdout(), "Built %s\nDigest: %s\n", dir, desc.Digest)
 	return nil
 }
 
-func runPackBundle(cmd *cobra.Command, dir, tag, mediaType string) error {
+func runBuildBundle(cmd *cobra.Command, dir, tag, mediaType string) error {
 	profile, err := oci.ParseMediaTypeProfile(mediaType)
 	if err != nil {
 		return err
@@ -67,14 +67,14 @@ func runPackBundle(cmd *cobra.Command, dir, tag, mediaType string) error {
 		return err
 	}
 
-	desc, err := client.PackBundle(context.Background(), dir, oci.BundlePackOptions{
+	desc, err := client.BuildBundle(context.Background(), dir, oci.BundleBuildOptions{
 		Tag:       tag,
 		MediaType: profile,
 	})
 	if err != nil {
-		return fmt.Errorf("packing bundle %s: %w", dir, err)
+		return fmt.Errorf("building bundle %s: %w", dir, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Packed bundle %s\nDigest: %s\n", dir, desc.Digest)
+	fmt.Fprintf(cmd.OutOrStdout(), "Built bundle %s\nDigest: %s\n", dir, desc.Digest)
 	return nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,14 +8,14 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "skillctl",
 		Short:   "Manage AI agent skills as OCI images",
-		Long:    "skillctl packs, pushes, pulls, and manages the lifecycle of AI agent skills stored as OCI images.",
+		Long:    "skillctl builds, pushes, pulls, and manages the lifecycle of AI agent skills stored as OCI images.",
 		Version: version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 
 	cmd.AddCommand(newValidateCmd())
-	cmd.AddCommand(newPackCmd())
+	cmd.AddCommand(newBuildCmd())
 	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newListCmd())

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -23,9 +23,9 @@ import (
 	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
-// Pack reads a skill directory, validates the SkillCard, creates an OCI image,
+// Build reads a skill directory, validates the SkillCard, creates an OCI image,
 // and stores it in the local OCI layout. It returns the manifest descriptor.
-func (c *Client) Pack(ctx context.Context, skillDir string, opts PackOptions) (ocispec.Descriptor, error) {
+func (c *Client) Build(ctx context.Context, skillDir string, opts BuildOptions) (ocispec.Descriptor, error) {
 	// 1. Read and parse skill.yaml.
 	skillPath := filepath.Join(skillDir, "skill.yaml")
 	f, err := os.Open(skillPath)

--- a/pkg/oci/bundle.go
+++ b/pkg/oci/bundle.go
@@ -20,16 +20,16 @@ import (
 	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
-// BundlePackOptions configures the PackBundle operation.
-type BundlePackOptions struct {
+// BundleBuildOptions configures the BuildBundle operation.
+type BundleBuildOptions struct {
 	Tag       string
 	MediaType MediaTypeProfile
 }
 
-// PackBundle reads a directory containing multiple skill subdirectories,
+// BuildBundle reads a directory containing multiple skill subdirectories,
 // validates each SkillCard, creates a single OCI image with all skills,
 // and stores it in the local OCI layout.
-func (c *Client) PackBundle(ctx context.Context, bundleDir string, opts BundlePackOptions) (ocispec.Descriptor, error) {
+func (c *Client) BuildBundle(ctx context.Context, bundleDir string, opts BundleBuildOptions) (ocispec.Descriptor, error) {
 	if opts.Tag == "" {
 		return ocispec.Descriptor{}, fmt.Errorf("--tag is required for bundles")
 	}

--- a/pkg/oci/bundle_test.go
+++ b/pkg/oci/bundle_test.go
@@ -37,7 +37,7 @@ spec:
 	}
 }
 
-func TestPackBundle(t *testing.T) {
+func TestBuildBundle(t *testing.T) {
 	bundleDir := t.TempDir()
 	writeTestBundle(t, bundleDir)
 
@@ -48,11 +48,11 @@ func TestPackBundle(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	desc, err := client.PackBundle(ctx, bundleDir, oci.BundlePackOptions{
+	desc, err := client.BuildBundle(ctx, bundleDir, oci.BundleBuildOptions{
 		Tag: "1.0.0-draft",
 	})
 	if err != nil {
-		t.Fatalf("PackBundle: %v", err)
+		t.Fatalf("BuildBundle: %v", err)
 	}
 	if desc.Digest.String() == "" {
 		t.Error("expected non-empty digest")
@@ -63,7 +63,7 @@ func TestPackBundle(t *testing.T) {
 		t.Fatalf("ListLocal: %v", err)
 	}
 	if len(images) == 0 {
-		t.Fatal("expected at least 1 image after PackBundle")
+		t.Fatal("expected at least 1 image after BuildBundle")
 	}
 
 	found := false
@@ -78,7 +78,7 @@ func TestPackBundle(t *testing.T) {
 	}
 }
 
-func TestPackBundleRequiresTag(t *testing.T) {
+func TestBuildBundleRequiresTag(t *testing.T) {
 	bundleDir := t.TempDir()
 	writeTestBundle(t, bundleDir)
 
@@ -88,13 +88,13 @@ func TestPackBundleRequiresTag(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.PackBundle(context.Background(), bundleDir, oci.BundlePackOptions{})
+	_, err = client.BuildBundle(context.Background(), bundleDir, oci.BundleBuildOptions{})
 	if err == nil {
 		t.Fatal("expected error when tag is empty")
 	}
 }
 
-func TestPackBundleEmptyDir(t *testing.T) {
+func TestBuildBundleEmptyDir(t *testing.T) {
 	emptyDir := t.TempDir()
 
 	storeDir := t.TempDir()
@@ -103,7 +103,7 @@ func TestPackBundleEmptyDir(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.PackBundle(context.Background(), emptyDir, oci.BundlePackOptions{
+	_, err = client.BuildBundle(context.Background(), emptyDir, oci.BundleBuildOptions{
 		Tag: "1.0.0-draft",
 	})
 	if err == nil {
@@ -111,7 +111,7 @@ func TestPackBundleEmptyDir(t *testing.T) {
 	}
 }
 
-func TestPackBundleInvalidSkill(t *testing.T) {
+func TestBuildBundleInvalidSkill(t *testing.T) {
 	bundleDir := t.TempDir()
 	skillDir := filepath.Join(bundleDir, "bad-skill")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -135,7 +135,7 @@ metadata:
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.PackBundle(context.Background(), bundleDir, oci.BundlePackOptions{
+	_, err = client.BuildBundle(context.Background(), bundleDir, oci.BundleBuildOptions{
 		Tag: "1.0.0-draft",
 	})
 	if err == nil {
@@ -143,7 +143,7 @@ metadata:
 	}
 }
 
-func TestPackBundleNamespaceMismatch(t *testing.T) {
+func TestBuildBundleNamespaceMismatch(t *testing.T) {
 	bundleDir := t.TempDir()
 
 	for _, tc := range []struct {
@@ -181,7 +181,7 @@ spec:
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.PackBundle(context.Background(), bundleDir, oci.BundlePackOptions{
+	_, err = client.BuildBundle(context.Background(), bundleDir, oci.BundleBuildOptions{
 		Tag: "1.0.0-draft",
 	})
 	if err == nil {
@@ -192,7 +192,7 @@ spec:
 	}
 }
 
-func TestPackBundleAnnotations(t *testing.T) {
+func TestBuildBundleAnnotations(t *testing.T) {
 	bundleDir := t.TempDir()
 	writeTestBundle(t, bundleDir)
 
@@ -203,11 +203,11 @@ func TestPackBundleAnnotations(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.PackBundle(ctx, bundleDir, oci.BundlePackOptions{
+	_, err = client.BuildBundle(ctx, bundleDir, oci.BundleBuildOptions{
 		Tag: "1.0.0-draft",
 	})
 	if err != nil {
-		t.Fatalf("PackBundle: %v", err)
+		t.Fatalf("BuildBundle: %v", err)
 	}
 
 	images, err := client.ListLocal()

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -23,8 +23,8 @@ func NewClient(storePath string) (*Client, error) {
 	}, nil
 }
 
-// PackOptions configures the Pack operation.
-type PackOptions struct {
+// BuildOptions configures the Build operation.
+type BuildOptions struct {
 	// Tag overrides the default tag. If empty, defaults to <version>-draft.
 	Tag string
 	// MediaType selects the media type profile. Empty or "standard" uses

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -33,7 +33,7 @@ spec:
 	}
 }
 
-func TestPackAndListLocal(t *testing.T) {
+func TestBuildAndListLocal(t *testing.T) {
 	skillDir := t.TempDir()
 	writeTestSkill(t, skillDir)
 
@@ -44,9 +44,9 @@ func TestPackAndListLocal(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	desc, err := client.Pack(ctx, skillDir, oci.PackOptions{})
+	desc, err := client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 	if desc.Digest.String() == "" {
 		t.Error("expected non-empty digest")
@@ -70,7 +70,7 @@ func TestPackAndListLocal(t *testing.T) {
 	}
 }
 
-func TestPackValidatesSkillCard(t *testing.T) {
+func TestBuildValidatesSkillCard(t *testing.T) {
 	skillDir := t.TempDir()
 	badYAML := []byte(`apiVersion: wrong/v1
 kind: SkillCard
@@ -90,13 +90,13 @@ metadata:
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.Pack(context.Background(), skillDir, oci.PackOptions{})
+	_, err = client.Build(context.Background(), skillDir, oci.BuildOptions{})
 	if err == nil {
 		t.Fatal("expected error for invalid SkillCard")
 	}
 }
 
-func TestPackMissingSkillYAML(t *testing.T) {
+func TestBuildMissingSkillYAML(t *testing.T) {
 	emptyDir := t.TempDir()
 
 	storeDir := t.TempDir()
@@ -105,14 +105,14 @@ func TestPackMissingSkillYAML(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	_, err = client.Pack(context.Background(), emptyDir, oci.PackOptions{})
+	_, err = client.Build(context.Background(), emptyDir, oci.BuildOptions{})
 	if err == nil {
 		t.Fatal("expected error for missing skill.yaml")
 	}
 }
 
 func TestCopyToAndBack(t *testing.T) {
-	// Pack into source store
+	// Build into source store
 	skillDir := t.TempDir()
 	writeTestSkill(t, skillDir)
 
@@ -123,9 +123,9 @@ func TestCopyToAndBack(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = srcClient.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = srcClient.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	// Copy to destination store
@@ -162,9 +162,9 @@ func TestUnpack(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	// Unpack to output directory
@@ -197,9 +197,9 @@ func TestInspect(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	result, err := client.Inspect(ctx, "test/test-skill:1.0.0-draft")
@@ -231,9 +231,9 @@ func TestPromoteLocal(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	// Promote draft -> testing
@@ -306,9 +306,9 @@ spec:
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	result, err := client.Inspect(ctx, "test/annotated-skill:2.0.0-draft")
@@ -361,9 +361,9 @@ These five words are counted.
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	result, err := client.Inspect(ctx, "test/frontmatter-skill:1.0.0-draft")
@@ -387,9 +387,9 @@ func TestPromoteInvalidTransition(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	// Try invalid transition: draft -> published
@@ -422,9 +422,9 @@ spec:
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	result, err := client.Inspect(ctx, "test/minimal-skill:1.0.0-draft")
@@ -454,9 +454,9 @@ func TestTag(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	err = client.Tag(ctx, "test/test-skill:1.0.0-draft", "quay.io/myorg/test-skill:1.0.0-draft")
@@ -477,7 +477,7 @@ func TestTag(t *testing.T) {
 	}
 }
 
-func TestPackRedHatMediaType(t *testing.T) {
+func TestBuildRedHatMediaType(t *testing.T) {
 	skillDir := t.TempDir()
 	writeTestSkill(t, skillDir)
 
@@ -488,7 +488,7 @@ func TestPackRedHatMediaType(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	desc, err := client.Pack(ctx, skillDir, oci.PackOptions{
+	desc, err := client.Build(ctx, skillDir, oci.BuildOptions{
 		MediaType: oci.MediaTypeRedHat,
 	})
 	if err != nil {
@@ -546,9 +546,9 @@ spec:
 	}
 
 	ctx := context.Background()
-	_, err = client.Pack(ctx, skillDir, oci.PackOptions{})
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
 	if err != nil {
-		t.Fatalf("Pack: %v", err)
+		t.Fatalf("Build: %v", err)
 	}
 
 	result, err := client.Inspect(ctx, "test/empty-md-skill:1.0.0-draft")

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -492,7 +492,7 @@ func TestBuildRedHatMediaType(t *testing.T) {
 		MediaType: oci.MediaTypeRedHat,
 	})
 	if err != nil {
-		t.Fatalf("Pack with redhat media type: %v", err)
+		t.Fatalf("Build with redhat media type: %v", err)
 	}
 	if desc.Digest.String() == "" {
 		t.Error("expected non-empty digest")


### PR DESCRIPTION
## Summary

- Rename `skillctl pack` to `skillctl build` to align with Docker/Podman conventions (`build`, `push`, `pull`, `inspect`)
- Rename all internal types: `PackOptions` → `BuildOptions`, `PackBundle` → `BuildBundle`, etc.
- Update user-facing docs (README, CLAUDE.md, deploy/README, landing page)
- Design docs and historical plans left unchanged as records

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all pass
- [x] `make lint` zero issues
- [ ] Verify `bin/skillctl build examples/hello-world/` works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed CLI subcommand from `pack` to `build` for skill container operations
  * Updated OCI API methods and configuration types: Pack/PackOptions → Build/BuildOptions, PackBundle/BundlePackOptions → BuildBundle/BundleBuildOptions

* **Documentation**
  * Updated terminology and examples from "pack" to "build" across all documentation files and deployment guides

* **Tests**
  * Updated test names and assertions to reflect new "build" terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->