### PR TITLE
feat: build skill images from remote Git repositories

### DIFF
--- a/docs/superpowers/plans/2026-04-29-remote-git-sources.md
+++ b/docs/superpowers/plans/2026-04-29-remote-git-sources.md
@@ -1,0 +1,1698 @@
+# Remote Git sources implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build OCI skill images directly from Git repository URLs,
+with SKILL.md-based discovery and SkillCard generation from
+frontmatter.
+
+**Architecture:** New `pkg/source` package with five files: URL
+parsing, git cloning (with sparse checkout), skill discovery by
+SKILL.md, SkillCard generation from frontmatter, and a top-level
+resolver. The CLI build command gains URL detection and loops over
+discovered skills. `pkg/oci.Build()` accepts an optional pre-built
+SkillCard.
+
+**Tech Stack:** Go stdlib `os/exec` for git, `gopkg.in/yaml.v3`
+for frontmatter parsing, `filepath.Match` for glob filtering.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-remote-git-sources-design.md`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+| ---- | ------ | -------------- |
+| `pkg/source/giturl.go` | Create | `GitSource` struct, `ParseGitURL()` |
+| `pkg/source/giturl_test.go` | Create | URL parsing tests |
+| `pkg/source/clone.go` | Create | `CheckGit()`, `Clone()` with sparse checkout |
+| `pkg/source/clone_test.go` | Create | Clone tests (against real git repos on disk) |
+| `pkg/source/discover.go` | Create | `Discover()` — walk for SKILL.md, glob filter |
+| `pkg/source/discover_test.go` | Create | Discovery tests |
+| `pkg/source/generate.go` | Create | `ParseFrontmatter()`, `GenerateSkillCard()` |
+| `pkg/source/generate_test.go` | Create | SkillCard generation tests |
+| `pkg/source/source.go` | Create | `IsRemote()`, `Resolve()` orchestrator |
+| `pkg/source/source_test.go` | Create | Orchestrator tests |
+| `pkg/oci/client.go` | Modify | Add `SkillCard` field to `BuildOptions` |
+| `pkg/oci/build.go` | Modify | Use pre-built SkillCard when provided |
+| `pkg/oci/oci_test.go` | Modify | Test Build with pre-built SkillCard |
+| `internal/cli/build.go` | Modify | Add `--ref`, `--filter` flags, remote path |
+| `internal/cli/build_test.go` | Create | CLI integration tests |
+
+---
+
+## Task 1: URL parsing
+
+**Files:**
+
+- Create: `pkg/source/giturl.go`
+- Create: `pkg/source/giturl_test.go`
+
+- [ ] **Step 1: Write failing tests for ParseGitURL**
+
+```go
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    source.GitSource
+		wantErr bool
+	}{
+		{
+			name: "github repo root",
+			raw:  "https://github.com/anthropics/skills",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name: "github with ref and subpath",
+			raw:  "https://github.com/anthropics/skills/tree/main/skills",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "main",
+				SubPath:  "skills",
+			},
+		},
+		{
+			name: "github with tag ref and deep subpath",
+			raw:  "https://github.com/anthropics/skills/tree/v1.0/skills/internal-comms",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "v1.0",
+				SubPath:  "skills/internal-comms",
+			},
+		},
+		{
+			name: "gitlab with tree path",
+			raw:  "https://gitlab.com/org/repo/-/tree/main/path/to/skill",
+			want: source.GitSource{
+				CloneURL: "https://gitlab.com/org/repo.git",
+				Ref:      "main",
+				SubPath:  "path/to/skill",
+			},
+		},
+		{
+			name: "unknown host plain URL",
+			raw:  "https://unknown-host.com/org/repo",
+			want: source.GitSource{
+				CloneURL: "https://unknown-host.com/org/repo",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name: "github repo with .git suffix",
+			raw:  "https://github.com/anthropics/skills.git",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name:    "not a URL",
+			raw:     "/some/local/path",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := source.ParseGitURL(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseGitURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseGitURL() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/source/ -run TestParseGitURL -v`
+Expected: FAIL — package does not exist yet.
+
+- [ ] **Step 3: Implement GitSource and ParseGitURL**
+
+```go
+package source
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type GitSource struct {
+	CloneURL string
+	Ref      string
+	SubPath  string
+}
+
+func ParseGitURL(raw string) (GitSource, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return GitSource{}, fmt.Errorf("not a valid URL: %s", raw)
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return GitSource{}, fmt.Errorf("URL must contain at least org/repo: %s", raw)
+	}
+
+	host := u.Host
+
+	switch {
+	case host == "github.com":
+		return parseGitHub(u, parts)
+	case host == "gitlab.com" || containsGitLab(parts):
+		return parseGitLab(u, parts)
+	default:
+		return parseGeneric(u, parts)
+	}
+}
+
+func parseGitHub(u *url.URL, parts []string) (GitSource, error) {
+	org := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", u.Host, org, repo)
+
+	var ref, subPath string
+	if len(parts) > 3 && parts[2] == "tree" {
+		ref = parts[3]
+		if len(parts) > 4 {
+			subPath = strings.Join(parts[4:], "/")
+		}
+	}
+
+	return GitSource{CloneURL: cloneURL, Ref: ref, SubPath: subPath}, nil
+}
+
+func parseGitLab(u *url.URL, parts []string) (GitSource, error) {
+	org := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", u.Host, org, repo)
+
+	var ref, subPath string
+	// GitLab: /-/tree/<ref>/path
+	for i, p := range parts {
+		if p == "-" && i+2 < len(parts) && parts[i+1] == "tree" {
+			ref = parts[i+2]
+			if i+3 < len(parts) {
+				subPath = strings.Join(parts[i+3:], "/")
+			}
+			break
+		}
+	}
+
+	return GitSource{CloneURL: cloneURL, Ref: ref, SubPath: subPath}, nil
+}
+
+func parseGeneric(u *url.URL, parts []string) (GitSource, error) {
+	return GitSource{
+		CloneURL: u.String(),
+		Ref:      "",
+		SubPath:  "",
+	}, nil
+}
+
+func containsGitLab(parts []string) bool {
+	for _, p := range parts {
+		if p == "-" {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/source/ -run TestParseGitURL -v`
+Expected: PASS — all 7 cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/source/giturl.go pkg/source/giturl_test.go
+git commit -s -m "feat(source): add Git URL parser for GitHub, GitLab, and generic hosts"
+```
+
+---
+
+## Task 2: Git availability check and clone
+
+**Files:**
+
+- Create: `pkg/source/clone.go`
+- Create: `pkg/source/clone_test.go`
+
+- [ ] **Step 1: Write failing tests for CheckGit and Clone**
+
+```go
+package source_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestCheckGit(t *testing.T) {
+	err := source.CheckGit()
+	if err != nil {
+		t.Skipf("git not available in test environment: %v", err)
+	}
+}
+
+func TestCloneShallow(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a local bare repo to clone from.
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	// Initialize a bare repo with a SKILL.md.
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	skillDir := filepath.Join(workDir, "skills", "hello")
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: hello\n---\nHello skill."), 0o644)
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+		Ref:      "",
+		SubPath:  "skills/hello",
+	}
+
+	ctx := context.Background()
+	result, err := source.Clone(ctx, src, source.CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer result.Cleanup()
+
+	// Verify SKILL.md exists at resolved path.
+	if _, err := os.Stat(filepath.Join(result.Dir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not found in cloned directory: %v", err)
+	}
+
+	if result.CommitSHA == "" {
+		t.Error("expected non-empty CommitSHA")
+	}
+}
+
+func TestCloneBadURL(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	src := source.GitSource{
+		CloneURL: "https://example.com/nonexistent/repo.git",
+	}
+
+	ctx := context.Background()
+	_, err := source.Clone(ctx, src, source.CloneOptions{})
+	if err == nil {
+		t.Fatal("expected error for bad clone URL")
+	}
+}
+
+func TestCloneSubPathNotFound(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Create a minimal repo with no subdirectories.
+	workDir := t.TempDir()
+	bareDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(workDir, "README.md"), []byte("hi"), 0o644)
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+		SubPath:  "nonexistent/path",
+	}
+
+	ctx := context.Background()
+	_, err := source.Clone(ctx, src, source.CloneOptions{})
+	if err == nil {
+		t.Fatal("expected error for nonexistent subpath")
+	}
+}
+
+func TestCloneRefOverride(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	workDir := t.TempDir()
+	bareDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("v1"), 0o644)
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "v1")
+	run(workDir, "tag", "v1.0")
+	os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("v2"), 0o644)
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "v2")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+	}
+
+	ctx := context.Background()
+	result, err := source.Clone(ctx, src, source.CloneOptions{RefOverride: "v1.0"})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer result.Cleanup()
+
+	data, err := os.ReadFile(filepath.Join(result.Dir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading SKILL.md: %v", err)
+	}
+	if string(data) != "v1" {
+		t.Errorf("SKILL.md content = %q, want %q (tag v1.0)", string(data), "v1")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/source/ -run "TestCheck|TestClone" -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement CheckGit, CloneResult, and Clone**
+
+```go
+package source
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type CloneOptions struct {
+	RefOverride string
+}
+
+type CloneResult struct {
+	Dir       string
+	CommitSHA string
+	Cleanup   func()
+}
+
+func CheckGit() error {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		return fmt.Errorf("git is required for remote sources — install it from https://git-scm.com")
+	}
+	return nil
+}
+
+func Clone(ctx context.Context, src GitSource, opts CloneOptions) (*CloneResult, error) {
+	if err := CheckGit(); err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "skillctl-clone-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(tmpDir) }
+
+	ref := opts.RefOverride
+	if ref == "" {
+		ref = src.Ref
+	}
+
+	if err := cloneRepo(ctx, src.CloneURL, ref, src.SubPath, tmpDir); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	resolvedDir := tmpDir
+	if src.SubPath != "" {
+		resolvedDir = filepath.Join(tmpDir, src.SubPath)
+		if _, err := os.Stat(resolvedDir); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("path %q not found in repository %s", src.SubPath, src.CloneURL)
+		}
+	}
+
+	sha, err := commitSHA(ctx, tmpDir)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("reading commit SHA: %w", err)
+	}
+
+	return &CloneResult{Dir: resolvedDir, CommitSHA: sha, Cleanup: cleanup}, nil
+}
+
+func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+	if subPath != "" {
+		if err := sparseClone(ctx, cloneURL, ref, subPath, destDir); err == nil {
+			return nil
+		}
+	}
+
+	return shallowClone(ctx, cloneURL, ref, destDir)
+}
+
+func sparseClone(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+	args := []string{"clone", "--depth", "1", "--filter=blob:none", "--sparse"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, cloneURL, destDir)
+
+	if err := runGit(ctx, "", args...); err != nil {
+		return err
+	}
+
+	return runGit(ctx, destDir, "sparse-checkout", "set", subPath)
+}
+
+func shallowClone(ctx context.Context, cloneURL, ref, destDir string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, cloneURL, destDir)
+
+	return runGit(ctx, "", args...)
+}
+
+func commitSHA(ctx context.Context, repoDir string) (string, error) {
+	var stdout bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
+	cmd.Dir = repoDir
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %v: %s", args, stderr.String())
+	}
+	return nil
+}
+```
+
+Note: add `"strings"` to the import block (needed by `commitSHA`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/source/ -run "TestCheck|TestClone" -v`
+Expected: PASS — all 4 tests (TestCloneBadURL may take a few
+seconds due to network timeout).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/source/clone.go pkg/source/clone_test.go
+git commit -s -m "feat(source): add git clone with sparse checkout and ref override"
+```
+
+---
+
+## Task 3: Skill discovery by SKILL.md
+
+**Files:**
+
+- Create: `pkg/source/discover.go`
+- Create: `pkg/source/discover_test.go`
+
+- [ ] **Step 1: Write failing tests for Discover**
+
+```go
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func writeSkillMD(t *testing.T, dir, content string) {
+	t.Helper()
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+}
+
+func TestDiscoverMultipleSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "alpha"), "---\nname: alpha\n---\nAlpha.")
+	writeSkillMD(t, filepath.Join(root, "beta"), "---\nname: beta\n---\nBeta.")
+	writeSkillMD(t, filepath.Join(root, "gamma"), "---\nname: gamma\n---\nGamma.")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 3 {
+		t.Fatalf("got %d skills, want 3", len(skills))
+	}
+	if skills[0].Name != "alpha" || skills[1].Name != "beta" || skills[2].Name != "gamma" {
+		t.Errorf("skills = %+v, want alpha/beta/gamma sorted", skills)
+	}
+}
+
+func TestDiscoverSingleSkill(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, root, "---\nname: solo\n---\nSolo skill.")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1", len(skills))
+	}
+	if skills[0].Dir != root {
+		t.Errorf("Dir = %q, want %q", skills[0].Dir, root)
+	}
+}
+
+func TestDiscoverSkipsHiddenDirs(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "visible"), "---\nname: visible\n---\n")
+	writeSkillMD(t, filepath.Join(root, ".hidden"), "---\nname: hidden\n---\n")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (hidden should be skipped)", len(skills))
+	}
+}
+
+func TestDiscoverWithFilter(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "code-review"), "---\nname: code-review\n---\n")
+	writeSkillMD(t, filepath.Join(root, "code-gen"), "---\nname: code-gen\n---\n")
+	writeSkillMD(t, filepath.Join(root, "email"), "---\nname: email\n---\n")
+
+	skills, err := source.Discover(root, "code-*")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2", len(skills))
+	}
+}
+
+func TestDiscoverNoSkills(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, "README.md"), []byte("no skills here"), 0o644)
+
+	_, err := source.Discover(root, "")
+	if err == nil {
+		t.Fatal("expected error when no skills found")
+	}
+}
+
+func TestDiscoverNoMatchingFilter(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "alpha"), "---\nname: alpha\n---\n")
+
+	_, err := source.Discover(root, "zzz-*")
+	if err == nil {
+		t.Fatal("expected error when no skills match filter")
+	}
+}
+
+func TestDiscoverDoesNotNest(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "parent"), "---\nname: parent\n---\n")
+	writeSkillMD(t, filepath.Join(root, "parent", "child"), "---\nname: child\n---\n")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (child should not be discovered)", len(skills))
+	}
+	if skills[0].Name != "parent" {
+		t.Errorf("Name = %q, want %q", skills[0].Name, "parent")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/source/ -run TestDiscover -v`
+Expected: FAIL — `Discover` not defined, `DiscoveredSkill` not
+defined.
+
+- [ ] **Step 3: Implement Discover**
+
+```go
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type DiscoveredSkill struct {
+	Dir  string
+	Name string
+}
+
+func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
+	// If the target directory itself contains SKILL.md, it's a single skill.
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+		name := resolveSkillName(dir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				return nil, fmt.Errorf("no skills matching %q in %s", filter, dir)
+			}
+		}
+		return []DiscoveredSkill{{Dir: dir, Name: name}}, nil
+	}
+
+	var skills []DiscoveredSkill
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		subDir := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
+			// Not a skill directory; recurse one more level.
+			nested, _ := discoverNested(subDir, filter)
+			skills = append(skills, nested...)
+			continue
+		}
+
+		name := resolveSkillName(subDir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				continue
+			}
+		}
+		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
+	}
+
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+
+	if len(skills) == 0 {
+		if filter != "" {
+			return nil, fmt.Errorf("no skills matching %q in %s", filter, dir)
+		}
+		return nil, fmt.Errorf("no skills found in %s", dir)
+	}
+
+	return skills, nil
+}
+
+func discoverNested(dir string, filter string) ([]DiscoveredSkill, error) {
+	var skills []DiscoveredSkill
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		subDir := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
+			continue
+		}
+		name := resolveSkillName(subDir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				continue
+			}
+		}
+		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
+	}
+	return skills, nil
+}
+
+func resolveSkillName(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		return filepath.Base(dir)
+	}
+	fm := parseFrontmatterRaw(data)
+	if name, ok := fm["name"].(string); ok && name != "" {
+		return name
+	}
+	return filepath.Base(dir)
+}
+```
+
+Note: `parseFrontmatterRaw` is a helper that will be implemented
+in Task 4 (`generate.go`). For now, add a stub to make this
+compile:
+
+```go
+// stub in discover.go — will move to generate.go in Task 4
+func parseFrontmatterRaw(data []byte) map[string]interface{} {
+	s := string(data)
+	if !strings.HasPrefix(s, "---") {
+		return nil
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	fmStr := s[4 : 3+end]
+	var m map[string]interface{}
+	if err := yaml.Unmarshal([]byte(fmStr), &m); err != nil {
+		return nil
+	}
+	return m
+}
+```
+
+Add `"gopkg.in/yaml.v3"` to imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/source/ -run TestDiscover -v`
+Expected: PASS — all 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/source/discover.go pkg/source/discover_test.go
+git commit -s -m "feat(source): add SKILL.md-based skill discovery with glob filtering"
+```
+
+---
+
+## Task 4: SkillCard generation from frontmatter
+
+**Files:**
+
+- Create: `pkg/source/generate.go`
+- Create: `pkg/source/generate_test.go`
+- Modify: `pkg/source/discover.go` — move `parseFrontmatterRaw`
+  stub to `generate.go`
+
+- [ ] **Step 1: Write failing tests for GenerateSkillCard**
+
+```go
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestGenerateSkillCardFromFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	content := `---
+name: code-review
+description: Reviews code for quality and bugs.
+license: Apache-2.0
+compatibility: claude-3.5-sonnet
+metadata:
+  author: anthropic
+  version: "2.0"
+---
+You are a code review assistant.
+`
+	writeSkillMD(t, dir, content)
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/anthropics/skills.git", "anthropics")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+
+	if sc.APIVersion != "skillimage.io/v1alpha1" {
+		t.Errorf("APIVersion = %q", sc.APIVersion)
+	}
+	if sc.Kind != "SkillCard" {
+		t.Errorf("Kind = %q", sc.Kind)
+	}
+	if sc.Metadata.Name != "code-review" {
+		t.Errorf("Name = %q, want code-review", sc.Metadata.Name)
+	}
+	if sc.Metadata.Description != "Reviews code for quality and bugs." {
+		t.Errorf("Description = %q", sc.Metadata.Description)
+	}
+	if sc.Metadata.Version != "2.0.0" {
+		t.Errorf("Version = %q, want 2.0.0", sc.Metadata.Version)
+	}
+	if sc.Metadata.License != "Apache-2.0" {
+		t.Errorf("License = %q", sc.Metadata.License)
+	}
+	if sc.Metadata.Compatibility != "claude-3.5-sonnet" {
+		t.Errorf("Compatibility = %q", sc.Metadata.Compatibility)
+	}
+	if sc.Metadata.Namespace != "anthropics" {
+		t.Errorf("Namespace = %q, want anthropics", sc.Metadata.Namespace)
+	}
+	if len(sc.Metadata.Authors) != 1 || sc.Metadata.Authors[0].Name != "anthropic" {
+		t.Errorf("Authors = %+v", sc.Metadata.Authors)
+	}
+	if sc.Spec == nil || sc.Spec.Prompt != "SKILL.md" {
+		t.Errorf("Spec.Prompt = %v", sc.Spec)
+	}
+}
+
+func TestGenerateSkillCardFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	// No frontmatter, just raw content.
+	writeSkillMD(t, dir, "You are a helpful assistant. This does many things.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/acme/tools.git", "acme")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+
+	// Falls back to directory name.
+	if sc.Metadata.Name == "" {
+		t.Error("Name should not be empty")
+	}
+	// Falls back to first sentence.
+	if sc.Metadata.Description != "You are a helpful assistant." {
+		t.Errorf("Description = %q, want first sentence", sc.Metadata.Description)
+	}
+	if sc.Metadata.Version != "0.1.0" {
+		t.Errorf("Version = %q, want 0.1.0", sc.Metadata.Version)
+	}
+	if sc.Metadata.Namespace != "acme" {
+		t.Errorf("Namespace = %q, want acme", sc.Metadata.Namespace)
+	}
+}
+
+func TestGenerateSkillCardMalformedFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "---\nbad: [yaml: {{\n---\nContent here.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/org/repo.git", "org")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v (should not fail on bad frontmatter)", err)
+	}
+	// Should fall back to directory name and first sentence.
+	if sc.Metadata.Description != "Content here." {
+		t.Errorf("Description = %q", sc.Metadata.Description)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/source/ -run TestGenerate -v`
+Expected: FAIL — `GenerateSkillCard` not defined.
+
+- [ ] **Step 3: Implement GenerateSkillCard**
+
+```go
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateSkillCard(skillDir, cloneURL, orgFallback string) (*skillcard.SkillCard, error) {
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		return nil, fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	fm := parseFrontmatterRaw(data)
+	body := stripFrontmatterStr(string(data))
+
+	sc := &skillcard.SkillCard{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCard",
+		Metadata: skillcard.Metadata{
+			Name:        stringFromMap(fm, "name", filepath.Base(skillDir)),
+			Namespace:   orgFallback,
+			Version:     normalizeVersion(stringFromMapNested(fm, "metadata", "version", "0.1.0")),
+			Description: stringFromMap(fm, "description", firstSentence(body)),
+			License:     stringFromMap(fm, "license", ""),
+			Compatibility: stringFromMap(fm, "compatibility", ""),
+		},
+		Spec: &skillcard.Spec{
+			Prompt: "SKILL.md",
+		},
+	}
+
+	author := stringFromMapNested(fm, "metadata", "author", "")
+	if author == "" {
+		author = orgFallback
+	}
+	if author != "" {
+		sc.Metadata.Authors = []skillcard.Author{{Name: author}}
+	}
+
+	return sc, nil
+}
+
+func parseFrontmatterRaw(data []byte) map[string]interface{} {
+	s := string(data)
+	if !strings.HasPrefix(s, "---") {
+		return nil
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	fmStr := s[4 : 3+end]
+	var m map[string]interface{}
+	if err := yaml.Unmarshal([]byte(fmStr), &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func stripFrontmatterStr(s string) string {
+	if !strings.HasPrefix(s, "---") {
+		return s
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return s
+	}
+	return strings.TrimSpace(s[3+end+4:])
+}
+
+func stringFromMap(m map[string]interface{}, key, fallback string) string {
+	if m == nil {
+		return fallback
+	}
+	if v, ok := m[key].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func stringFromMapNested(m map[string]interface{}, outer, inner, fallback string) string {
+	if m == nil {
+		return fallback
+	}
+	sub, ok := m[outer].(map[string]interface{})
+	if !ok {
+		return fallback
+	}
+	if v, ok := sub[inner].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func firstSentence(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	if idx := strings.Index(body, "."); idx >= 0 {
+		return body[:idx+1]
+	}
+	if idx := strings.Index(body, "\n"); idx >= 0 {
+		return strings.TrimSpace(body[:idx])
+	}
+	return body
+}
+
+func normalizeVersion(v string) string {
+	parts := strings.Split(v, ".")
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+	return strings.Join(parts[:3], ".")
+}
+```
+
+Remove the `parseFrontmatterRaw` stub from `discover.go` (it now
+lives in `generate.go`). Remove the `"gopkg.in/yaml.v3"` import
+from `discover.go` if it was added.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/source/ -run TestGenerate -v`
+Expected: PASS — all 3 tests.
+
+- [ ] **Step 5: Also re-run discover tests to verify no regression**
+
+Run: `go test ./pkg/source/ -v`
+Expected: PASS — all tests in the package.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/source/generate.go pkg/source/generate_test.go pkg/source/discover.go
+git commit -s -m "feat(source): generate SkillCard from SKILL.md frontmatter"
+```
+
+---
+
+## Task 5: Build with pre-built SkillCard
+
+**Files:**
+
+- Modify: `pkg/oci/client.go:27-33` — add `SkillCard` field to
+  `BuildOptions`
+- Modify: `pkg/oci/build.go:27-52` — use pre-built SkillCard when
+  provided
+- Modify: `pkg/oci/oci_test.go` — add test
+
+- [ ] **Step 1: Write failing test for Build with pre-built SkillCard**
+
+Add to `pkg/oci/oci_test.go`:
+
+```go
+func TestBuildWithPrebuiltSkillCard(t *testing.T) {
+	skillDir := t.TempDir()
+	// Write only SKILL.md, no skill.yaml.
+	os.MkdirAll(skillDir, 0o755)
+	os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("You are a test skill."),
+		0o644,
+	)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	sc := &skillcard.SkillCard{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCard",
+		Metadata: skillcard.Metadata{
+			Name:        "prebuilt-test",
+			Namespace:   "test",
+			Version:     "1.0.0",
+			Description: "A prebuilt test skill.",
+		},
+		Spec: &skillcard.Spec{Prompt: "SKILL.md"},
+	}
+
+	ctx := context.Background()
+	desc, err := client.Build(ctx, skillDir, oci.BuildOptions{SkillCard: sc})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if desc.Digest.String() == "" {
+		t.Error("expected non-empty digest")
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(images))
+	}
+	if images[0].Name != "test/prebuilt-test" {
+		t.Errorf("image name = %q, want %q", images[0].Name, "test/prebuilt-test")
+	}
+}
+```
+
+Add imports for `"os"`, `"path/filepath"`, and
+`"github.com/redhat-et/skillimage/pkg/skillcard"` to the test
+file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pkg/oci/ -run TestBuildWithPrebuiltSkillCard -v`
+Expected: FAIL — `BuildOptions` has no field `SkillCard`.
+
+- [ ] **Step 3: Add SkillCard field to BuildOptions**
+
+In `pkg/oci/client.go`, change lines 27-33:
+
+```go
+type BuildOptions struct {
+	Tag       string
+	MediaType MediaTypeProfile
+	SkillCard *skillcard.SkillCard
+}
+```
+
+Add import `"github.com/redhat-et/skillimage/pkg/skillcard"` to
+`client.go`.
+
+- [ ] **Step 4: Update Build() to use pre-built SkillCard**
+
+In `pkg/oci/build.go`, replace lines 27-52 (the SkillCard
+read/parse/validate block) with:
+
+```go
+func (c *Client) Build(ctx context.Context, skillDir string, opts BuildOptions) (ocispec.Descriptor, error) {
+	var sc *skillcard.SkillCard
+
+	if opts.SkillCard != nil {
+		sc = opts.SkillCard
+	} else {
+		// 1. Read and parse skill.yaml.
+		skillPath := filepath.Join(skillDir, "skill.yaml")
+		f, err := os.Open(skillPath)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("opening skill.yaml: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+
+		var parseErr error
+		sc, parseErr = skillcard.Parse(f)
+		if parseErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("parsing skill.yaml: %w", parseErr)
+		}
+
+		// 2. Validate the SkillCard.
+		validationErrors, valErr := skillcard.Validate(sc)
+		if valErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("validating skill.yaml: %w", valErr)
+		}
+		if len(validationErrors) > 0 {
+			var msgs []string
+			for _, ve := range validationErrors {
+				msgs = append(msgs, ve.String())
+			}
+			return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
+		}
+	}
+
+	// 2b. Count words in SKILL.md if present, excluding YAML frontmatter.
+	// ... rest of the method unchanged from line 54 onward ...
+```
+
+- [ ] **Step 5: Run all OCI tests to verify nothing broke**
+
+Run: `go test ./pkg/oci/ -v`
+Expected: PASS — all existing tests plus the new one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/oci/client.go pkg/oci/build.go pkg/oci/oci_test.go
+git commit -s -m "feat(oci): accept pre-built SkillCard in BuildOptions"
+```
+
+---
+
+## Task 6: Source resolver orchestrator
+
+**Files:**
+
+- Create: `pkg/source/source.go`
+- Create: `pkg/source/source_test.go`
+
+- [ ] **Step 1: Write failing tests for IsRemote and OrgFromCloneURL**
+
+```go
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestIsRemote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://github.com/org/repo", true},
+		{"http://gitlab.com/org/repo", true},
+		{"/local/path/to/skills", false},
+		{"./relative/path", false},
+		{"skills/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := source.IsRemote(tt.input); got != tt.want {
+				t.Errorf("IsRemote(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrgFromCloneURL(t *testing.T) {
+	tests := []struct {
+		cloneURL string
+		want     string
+	}{
+		{"https://github.com/anthropics/skills.git", "anthropics"},
+		{"https://gitlab.com/org/repo.git", "org"},
+		{"https://example.com/repo", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cloneURL, func(t *testing.T) {
+			if got := source.OrgFromCloneURL(tt.cloneURL); got != tt.want {
+				t.Errorf("OrgFromCloneURL(%q) = %q, want %q", tt.cloneURL, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/source/ -run "TestIsRemote|TestOrgFrom" -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement IsRemote, OrgFromCloneURL, and Resolve**
+
+```go
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+)
+
+func IsRemote(input string) bool {
+	return strings.HasPrefix(input, "https://") || strings.HasPrefix(input, "http://")
+}
+
+func OrgFromCloneURL(cloneURL string) string {
+	u, err := url.Parse(cloneURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) >= 2 {
+		return parts[0]
+	}
+	return ""
+}
+
+type ResolveResult struct {
+	Skills    []ResolvedSkill
+	Cleanup   func()
+	SourceURL string
+}
+
+type ResolvedSkill struct {
+	Dir       string
+	Name      string
+	SkillCard *skillcard.SkillCard
+}
+
+func Resolve(ctx context.Context, input string, ref string, filter string) (*ResolveResult, error) {
+	if !IsRemote(input) {
+		return nil, fmt.Errorf("not a remote source: %s", input)
+	}
+
+	src, err := ParseGitURL(input)
+	if err != nil {
+		return nil, err
+	}
+
+	cloneResult, err := Clone(ctx, src, CloneOptions{RefOverride: ref})
+	if err != nil {
+		return nil, err
+	}
+
+	discovered, err := Discover(cloneResult.Dir, filter)
+	if err != nil {
+		cloneResult.Cleanup()
+		return nil, err
+	}
+
+	org := OrgFromCloneURL(src.CloneURL)
+
+	var skills []ResolvedSkill
+	for _, d := range discovered {
+		var sc *skillcard.SkillCard
+
+		// Use existing skill.yaml if present.
+		if hasSkillYAML(d.Dir) {
+			skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: nil})
+			continue
+		}
+
+		sc, err := GenerateSkillCard(d.Dir, src.CloneURL, org)
+		if err != nil {
+			fmt.Printf("Warning: skipping %s: %v\n", d.Name, err)
+			continue
+		}
+
+		// Inject provenance.
+		relPath := relativeToClone(cloneResult.Dir, d.Dir, src.SubPath)
+		sc.Provenance = &skillcard.Provenance{
+			Source: src.CloneURL,
+			Commit: cloneResult.CommitSHA,
+			Path:   relPath,
+		}
+
+		skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: sc})
+	}
+
+	if len(skills) == 0 {
+		cloneResult.Cleanup()
+		return nil, fmt.Errorf("no skills could be resolved from %s", input)
+	}
+
+	return &ResolveResult{
+		Skills:    skills,
+		Cleanup:   cloneResult.Cleanup,
+		SourceURL: input,
+	}, nil
+}
+
+func hasSkillYAML(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "skill.yaml"))
+	return err == nil
+}
+
+func relativeToClone(cloneDir, skillDir, subPath string) string {
+	rel, err := filepath.Rel(cloneDir, skillDir)
+	if err != nil {
+		return filepath.Base(skillDir)
+	}
+	if subPath != "" {
+		return filepath.ToSlash(filepath.Join(subPath, rel))
+	}
+	return filepath.ToSlash(rel)
+}
+```
+
+Add `"os"` and `"path/filepath"` to imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/source/ -run "TestIsRemote|TestOrgFrom" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run all source package tests**
+
+Run: `go test ./pkg/source/ -v`
+Expected: PASS — all tests in the package.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/source/source.go pkg/source/source_test.go
+git commit -s -m "feat(source): add Resolve orchestrator with provenance injection"
+```
+
+---
+
+## Task 7: CLI integration
+
+**Files:**
+
+- Modify: `internal/cli/build.go` — add `--ref`, `--filter` flags,
+  remote source path
+
+- [ ] **Step 1: Update build command with new flags and remote path**
+
+Replace the full content of `internal/cli/build.go`:
+
+```go
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/source"
+	"github.com/spf13/cobra"
+)
+
+func newBuildCmd() *cobra.Command {
+	var tag string
+	var mediaType string
+	var ref string
+	var filter string
+	cmd := &cobra.Command{
+		Use:   "build <dir-or-url>",
+		Short: "Build a skill directory or Git repo into local OCI images",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if source.IsRemote(args[0]) {
+				return runBuildRemote(cmd, args[0], tag, mediaType, ref, filter)
+			}
+			return runBuild(cmd, args[0], tag, mediaType)
+		},
+	}
+	cmd.Flags().StringVar(&tag, "tag", "", "override the image tag (default: <version>-draft)")
+	cmd.Flags().StringVar(&mediaType, "media-type", "", `media type profile: "standard" (default) or "redhat" (for oc-mirror)`)
+	cmd.Flags().StringVar(&ref, "ref", "", "Git ref to checkout (branch, tag, or commit SHA)")
+	cmd.Flags().StringVar(&filter, "filter", "", "glob pattern to filter skills by name")
+	return cmd
+}
+
+func runBuild(cmd *cobra.Command, dir, tag, mediaType string) error {
+	profile, err := oci.ParseMediaTypeProfile(mediaType)
+	if err != nil {
+		return err
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	desc, err := client.Build(context.Background(), dir, oci.BuildOptions{
+		Tag:       tag,
+		MediaType: profile,
+	})
+	if err != nil {
+		return fmt.Errorf("building %s: %w", dir, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Built %s\nDigest: %s\n", dir, desc.Digest)
+	return nil
+}
+
+func runBuildRemote(cmd *cobra.Command, rawURL, tag, mediaType, ref, filter string) error {
+	profile, err := oci.ParseMediaTypeProfile(mediaType)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s", rawURL)
+	if ref != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), " (ref: %s)", ref)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "...")
+
+	result, err := source.Resolve(ctx, rawURL, ref, filter)
+	if err != nil {
+		return err
+	}
+	defer result.Cleanup()
+
+	if tag != "" && len(result.Skills) > 1 {
+		return fmt.Errorf("--tag cannot be used when building multiple skills")
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	var built, failed int
+	for i, skill := range result.Skills {
+		fmt.Fprintf(cmd.OutOrStdout(), "Building %s (%d/%d)...\n", skill.Name, i+1, len(result.Skills))
+
+		desc, err := client.Build(ctx, skill.Dir, oci.BuildOptions{
+			Tag:       tag,
+			MediaType: profile,
+			SkillCard: skill.SkillCard,
+		})
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  Error: %v\n", err)
+			failed++
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  Digest: %s\n", desc.Digest)
+		built++
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\nBuilt %d skills from %s\n", built, rawURL)
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to build", failed)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Run lint and compile check**
+
+Run: `go build ./...`
+Expected: compiles with no errors.
+
+- [ ] **Step 3: Run all tests to verify nothing is broken**
+
+Run: `go test ./... -v`
+Expected: PASS — all tests across all packages.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/build.go
+git commit -s -m "feat(cli): support Git URLs in build command with --ref and --filter"
+```
+
+---
+
+## Task 8: End-to-end manual verification
+
+- [ ] **Step 1: Build from a local directory (regression)**
+
+Run: `go run ./cmd/skillctl build examples/hello-world`
+Expected: `Built examples/hello-world\nDigest: sha256:...`
+
+- [ ] **Step 2: Build from a public GitHub repo**
+
+Run: `go run ./cmd/skillctl build https://github.com/anthropics/skills`
+Expected: clones the repo, discovers skills, builds each one,
+prints summary.
+
+If the Anthropic skills repo doesn't exist or has a different
+structure, use this project's own examples:
+
+Run: `go run ./cmd/skillctl build https://github.com/redhat-et/skillimage/tree/main/examples`
+Expected: discovers and builds the example skills.
+
+- [ ] **Step 3: Build with --ref flag**
+
+Run: `go run ./cmd/skillctl build https://github.com/redhat-et/skillimage/tree/main/examples --ref main`
+Expected: same result as step 2 (explicit ref matches default).
+
+- [ ] **Step 4: Build with --filter flag**
+
+Run: `go run ./cmd/skillctl build https://github.com/redhat-et/skillimage/tree/main/examples --filter "hello-*"`
+Expected: only builds hello-world, skips others.
+
+- [ ] **Step 5: Verify images were stored locally**
+
+Run: `go run ./cmd/skillctl list`
+Expected: lists the images built in steps 1-4.
+
+- [ ] **Step 6: Run full test suite and linter**
+
+Run: `make test && make lint`
+Expected: all pass.
+
+- [ ] **Step 7: Commit any fixes from manual testing**
+
+```bash
+git add -A
+git commit -s -m "fix: adjustments from end-to-end testing"
+```
+
+Only if changes were needed; skip if everything passed.

--- a/docs/superpowers/specs/2026-04-29-remote-git-sources-design.md
+++ b/docs/superpowers/specs/2026-04-29-remote-git-sources-design.md
@@ -1,0 +1,245 @@
+# Remote Git sources for skillctl build
+
+## Summary
+
+Extend `skillctl build` to accept Git repository URLs as sources,
+enabling users to build OCI skill images directly from remote
+repositories without manual cloning. Skills are discovered by
+`SKILL.md` presence, and SkillCards are generated on the fly from
+frontmatter metadata when no `skill.yaml` exists.
+
+Closes #10 and #13.
+
+## Motivation
+
+Currently `skillctl build` only works with local directories. The
+distribution vehicle workflow — pull skills from upstream sources,
+curate, sign, and publish as OCI images — requires manual cloning.
+Many skill repositories (Anthropic, zeroclaw-skills, superpowers
+plugins) don't include `skill.yaml` files, using `SKILL.md`
+frontmatter instead. Supporting remote Git sources with automatic
+SkillCard generation removes both friction points.
+
+## Design
+
+### Source detection
+
+The `build` command accepts both local paths and Git URLs:
+
+```bash
+skillctl build <source> [flags]
+```
+
+Detection heuristic: if `source` starts with `https://` or
+`http://`, treat as Git URL. Otherwise, treat as local path.
+
+### URL parsing
+
+A `ParseGitURL()` function extracts clone URL, ref, and subpath
+from repository URLs.
+
+| Input | CloneURL | Ref | SubPath |
+| ----- | -------- | --- | ------- |
+| `https://github.com/anthropics/skills` | `https://github.com/anthropics/skills.git` | `""` | `""` |
+| `https://github.com/anthropics/skills/tree/main/skills` | `https://github.com/anthropics/skills.git` | `main` | `skills` |
+| `https://github.com/anthropics/skills/tree/v1.0/skills/comms` | `https://github.com/anthropics/skills.git` | `v1.0` | `skills/comms` |
+| `https://gitlab.com/org/repo/-/tree/main/path` | `https://gitlab.com/org/repo.git` | `main` | `path` |
+| `https://unknown-host.com/org/repo` | `https://unknown-host.com/org/repo` | `""` | `""` |
+
+GitHub uses `/tree/<ref>/path`, GitLab uses `/-/tree/<ref>/path`.
+For unknown hosts, the base URL is used as the clone target with
+no ref/subpath extraction.
+
+The `--ref` flag overrides whatever ref was parsed from the URL.
+
+### Git operations
+
+A `Clone()` function handles cloning with a `git` availability
+check up front.
+
+**Prerequisites:**
+
+- `exec.LookPath("git")` — returns actionable error if missing:
+  "git is required for remote sources — install it from
+  https://git-scm.com"
+
+**Clone strategy:**
+
+- When `SubPath` is set: sparse checkout for efficiency
+
+  ```bash
+  git clone --depth 1 --filter=blob:none --sparse --branch <ref> <url> <tmpdir>
+  git -C <tmpdir> sparse-checkout set <subpath>
+  ```
+
+- When `SubPath` is empty: regular shallow clone
+
+  ```bash
+  git clone --depth 1 [--branch <ref>] <url> <tmpdir>
+  ```
+
+- If sparse checkout fails (unsupported server): fall back to
+  full shallow clone with a warning
+
+**Returns:** resolved directory path (tmpdir + SubPath), a cleanup
+function, the HEAD commit SHA (via `git rev-parse HEAD`), and any
+error.
+
+**Auth scope:** public repos only (unauthenticated HTTPS). Private
+repo support (tokens, SSH) deferred to a future iteration.
+
+### Skill discovery
+
+A `Discover()` function walks a directory and returns skill paths.
+
+- Walk recursively using `filepath.WalkDir`
+- A directory containing `SKILL.md` is a skill
+- Skip hidden directories (`.git`, `.github`, etc.)
+- Do not descend into a skill directory's subdirectories
+- If the target directory itself contains `SKILL.md`, treat as
+  single skill (no walk)
+- `--filter` matches against resolved skill name via
+  `filepath.Match` glob
+- Return sorted list; error if no skills found
+
+### SkillCard generation
+
+When a skill directory has `SKILL.md` but no `skill.yaml`, generate
+a SkillCard in memory from frontmatter metadata.
+
+**Field mapping:**
+
+| SKILL.md frontmatter | SkillCard field | Fallback |
+| -------------------- | --------------- | -------- |
+| `name` | `metadata.name` | directory name |
+| `description` | `metadata.description` | text up to first period or newline in SKILL.md body |
+| `metadata.version` | `metadata.version` | `0.1.0` |
+| `metadata.author` | `metadata.authors[0].name` | GitHub org from clone URL |
+| `license` | `metadata.license` | — |
+| `compatibility` | `metadata.compatibility` | — |
+| — | `metadata.namespace` | GitHub org from clone URL |
+| — | `apiVersion` | `skillimage.io/v1alpha1` (always) |
+| — | `kind` | `SkillCard` (always) |
+| — | `spec.prompt` | `SKILL.md` (always) |
+
+**Precedence:** if `skill.yaml` exists alongside `SKILL.md`, use
+it as-is. Generated SkillCards are not written to disk.
+
+### Provenance injection
+
+When building from Git, provenance fields are populated
+automatically on every SkillCard:
+
+- `provenance.source` — the clone URL
+- `provenance.commit` — HEAD commit SHA from the cloned repo
+- `provenance.path` — path within the repo (SubPath + skill dir)
+
+### CLI changes
+
+**New flags:**
+
+| Flag | Description |
+| ---- | ----------- |
+| `--ref` | Override Git ref (branch, tag, or commit SHA) |
+| `--filter` | Glob pattern to select skills by name |
+
+**Existing flags** (`--tag`, `--media-type`) work unchanged, applied
+to each built image. `--tag` is rejected when building multiple
+skills (ambiguous).
+
+**Output for multi-skill builds:**
+
+```text
+Cloning https://github.com/anthropics/skills (ref: main)...
+Building internal-comms (1/3)...
+  Digest: sha256:abc123...
+Building code-review (2/3)...
+  Digest: sha256:def456...
+Building email-drafter (3/3)...
+  Digest: sha256:789ghi...
+
+Built 3 skills from https://github.com/anthropics/skills
+```
+
+### Changes to existing code
+
+- `internal/cli/build.go` — `runBuild()` gains the remote path:
+  detect URL, resolve via `pkg/source`, loop over discovered skills.
+  Local single-skill path stays unchanged.
+- `pkg/oci/build.go` — `Build()` gets a new option to accept a
+  pre-built SkillCard instead of always reading `skill.yaml` from
+  disk.
+- `pkg/skillcard/` — no changes needed.
+
+## Package structure
+
+New package: `pkg/source/`
+
+| File | Responsibility |
+| ---- | -------------- |
+| `source.go` | `IsRemote()` detection, top-level `Resolve()` orchestrator |
+| `giturl.go` | `ParseGitURL()` — URL parsing for GitHub, GitLab, generic |
+| `clone.go` | `Clone()` — git check, shallow clone, sparse checkout, cleanup |
+| `discover.go` | `Discover()` — walk for SKILL.md, filter by glob |
+| `generate.go` | `GenerateSkillCard()` — SKILL.md frontmatter to in-memory SkillCard |
+
+## Data flow
+
+```text
+skillctl build https://github.com/anthropics/skills/tree/main/skills
+    │
+    ├─ source.IsRemote(input) → true
+    ├─ source.ParseGitURL(input) → GitSource{CloneURL, Ref:"main", SubPath:"skills"}
+    ├─ source.Clone(ctx, gitSource, opts)
+    │       ├─ exec.LookPath("git")
+    │       ├─ sparse checkout (SubPath is set)
+    │       ├─ git rev-parse HEAD → commitSHA
+    │       └─ returns (tmpDir/skills/, cleanup, commitSHA)
+    ├─ source.Discover(dir, filter) → [{path, name}, ...]
+    │       ├─ walk for SKILL.md files
+    │       └─ apply --filter glob
+    ├─ For each discovered skill:
+    │       ├─ Has skill.yaml? → skillcard.Parse() as today
+    │       ├─ No skill.yaml? → source.GenerateSkillCard(skillDir, frontmatter, gitSource)
+    │       ├─ Inject provenance (source URL, commitSHA, path-in-repo)
+    │       └─ oci.Build(ctx, skillDir, opts) → Descriptor
+    └─ cleanup() removes tmpDir
+```
+
+## Error handling
+
+| Scenario | Behavior |
+| -------- | -------- |
+| `git` not installed | "git is required for remote sources — install it from https://git-scm.com" |
+| Clone failure | Wrap git stderr: "failed to clone %s: %s" |
+| Ref doesn't exist | Git's own error ("Remote branch X not found") |
+| SubPath missing after clone | "path %q not found in repository %s" |
+| No SKILL.md found | "no skills found in %s" |
+| No skills match `--filter` | "no skills matching %q in %s" |
+| SKILL.md has no frontmatter | Generate SkillCard from fallbacks (dir name, default version, org from URL) |
+| Malformed frontmatter YAML | Warning, fall back to directory-name-based generation |
+| `--tag` with multiple skills | "--tag cannot be used when building multiple skills" |
+| `skill.yaml` exists with `SKILL.md` | Use `skill.yaml`, don't regenerate |
+| Sparse checkout fails | Fall back to full shallow clone, print warning |
+| Temp dir cleanup fails | Log warning, don't fail the build |
+| One skill in batch fails | Report error, continue building the rest, exit non-zero |
+
+## Scope boundaries
+
+**In scope:**
+
+- Git URL parsing (GitHub, GitLab, generic hosts)
+- Shallow clone with sparse checkout optimization
+- Skill discovery by SKILL.md
+- SkillCard generation from SKILL.md frontmatter
+- Provenance auto-population
+- Batch builds with `--filter`
+- `--ref` flag for ref override
+
+**Out of scope (future work):**
+
+- Private repo authentication (SSH, tokens, credential helpers)
+- `manifest.toml` parsing (issue #13 field mapping table)
+- Interactive fallback for missing required fields
+- `skillctl generate` as a standalone command
+- Non-Git sources (S3, HTTP tarballs)

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -5,22 +5,30 @@ import (
 	"fmt"
 
 	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/source"
 	"github.com/spf13/cobra"
 )
 
 func newBuildCmd() *cobra.Command {
 	var tag string
 	var mediaType string
+	var ref string
+	var filter string
 	cmd := &cobra.Command{
-		Use:   "build <dir>",
-		Short: "Build a skill directory into a local OCI image",
+		Use:   "build <dir-or-url>",
+		Short: "Build a skill directory or Git repo into local OCI images",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if source.IsRemote(args[0]) {
+				return runBuildRemote(cmd, args[0], tag, mediaType, ref, filter)
+			}
 			return runBuild(cmd, args[0], tag, mediaType)
 		},
 	}
 	cmd.Flags().StringVar(&tag, "tag", "", "override the image tag (default: <version>-draft)")
 	cmd.Flags().StringVar(&mediaType, "media-type", "", `media type profile: "standard" (default) or "redhat" (for oc-mirror)`)
+	cmd.Flags().StringVar(&ref, "ref", "", "Git ref to checkout (branch, tag, or commit SHA)")
+	cmd.Flags().StringVar(&filter, "filter", "", "glob pattern to filter skills by name")
 	return cmd
 }
 
@@ -44,5 +52,59 @@ func runBuild(cmd *cobra.Command, dir, tag, mediaType string) error {
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Built %s\nDigest: %s\n", dir, desc.Digest)
+	return nil
+}
+
+func runBuildRemote(cmd *cobra.Command, rawURL, tag, mediaType, ref, filter string) error {
+	profile, err := oci.ParseMediaTypeProfile(mediaType)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s", rawURL)
+	if ref != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), " (ref: %s)", ref)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "...")
+
+	result, err := source.Resolve(ctx, rawURL, ref, filter)
+	if err != nil {
+		return err
+	}
+	defer result.Cleanup()
+
+	if tag != "" && len(result.Skills) > 1 {
+		return fmt.Errorf("--tag cannot be used when building multiple skills")
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	var built, failed int
+	for i, skill := range result.Skills {
+		fmt.Fprintf(cmd.OutOrStdout(), "Building %s (%d/%d)...\n", skill.Name, i+1, len(result.Skills))
+
+		desc, err := client.Build(ctx, skill.Dir, oci.BuildOptions{
+			Tag:       tag,
+			MediaType: profile,
+			SkillCard: skill.SkillCard,
+		})
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "  Error: %v\n", err)
+			failed++
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  Digest: %s\n", desc.Digest)
+		built++
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "\nBuilt %d skills from %s\n", built, rawURL)
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to build", failed)
+	}
 	return nil
 }

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
-	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/redhat-et/skillimage/pkg/source"
@@ -43,7 +43,7 @@ func runBuild(cmd *cobra.Command, dir, tag, mediaType string) error {
 		return err
 	}
 
-	desc, err := client.Build(context.Background(), dir, oci.BuildOptions{
+	desc, err := client.Build(cmd.Context(), dir, oci.BuildOptions{
 		Tag:       tag,
 		MediaType: profile,
 	})
@@ -61,9 +61,10 @@ func runBuildRemote(cmd *cobra.Command, rawURL, tag, mediaType, ref, filter stri
 		return err
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 
-	fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s", rawURL)
+	displayURL := sanitizeURL(rawURL)
+	fmt.Fprintf(cmd.OutOrStdout(), "Cloning %s", displayURL)
 	if ref != "" {
 		fmt.Fprintf(cmd.OutOrStdout(), " (ref: %s)", ref)
 	}
@@ -102,9 +103,18 @@ func runBuildRemote(cmd *cobra.Command, rawURL, tag, mediaType, ref, filter stri
 		built++
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "\nBuilt %d skills from %s\n", built, rawURL)
+	fmt.Fprintf(cmd.OutOrStdout(), "\nBuilt %d skills from %s\n", built, displayURL)
 	if failed > 0 {
 		return fmt.Errorf("%d skill(s) failed to build", failed)
 	}
 	return nil
+}
+
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
 }

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -25,30 +25,35 @@ import (
 // Build reads a skill directory, validates the SkillCard, creates an OCI image,
 // and stores it in the local OCI layout. It returns the manifest descriptor.
 func (c *Client) Build(ctx context.Context, skillDir string, opts BuildOptions) (ocispec.Descriptor, error) {
-	// 1. Read and parse skill.yaml.
-	skillPath := filepath.Join(skillDir, "skill.yaml")
-	f, err := os.Open(skillPath)
-	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("opening skill.yaml: %w", err)
-	}
-	defer func() { _ = f.Close() }()
+	var sc *skillcard.SkillCard
 
-	sc, err := skillcard.Parse(f)
-	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("parsing skill.yaml: %w", err)
-	}
-
-	// 2. Validate the SkillCard.
-	validationErrors, err := skillcard.Validate(sc)
-	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("validating skill.yaml: %w", err)
-	}
-	if len(validationErrors) > 0 {
-		var msgs []string
-		for _, ve := range validationErrors {
-			msgs = append(msgs, ve.String())
+	if opts.SkillCard != nil {
+		sc = opts.SkillCard
+	} else {
+		skillPath := filepath.Join(skillDir, "skill.yaml")
+		f, err := os.Open(skillPath)
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("opening skill.yaml: %w", err)
 		}
-		return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
+		defer func() { _ = f.Close() }()
+
+		var parseErr error
+		sc, parseErr = skillcard.Parse(f)
+		if parseErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("parsing skill.yaml: %w", parseErr)
+		}
+
+		validationErrors, valErr := skillcard.Validate(sc)
+		if valErr != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("validating skill.yaml: %w", valErr)
+		}
+		if len(validationErrors) > 0 {
+			var msgs []string
+			for _, ve := range validationErrors {
+				msgs = append(msgs, ve.String())
+			}
+			return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
+		}
 	}
 
 	// 2b. Count words in SKILL.md if present, excluding YAML frontmatter.

--- a/pkg/oci/build.go
+++ b/pkg/oci/build.go
@@ -42,18 +42,18 @@ func (c *Client) Build(ctx context.Context, skillDir string, opts BuildOptions) 
 		if parseErr != nil {
 			return ocispec.Descriptor{}, fmt.Errorf("parsing skill.yaml: %w", parseErr)
 		}
+	}
 
-		validationErrors, valErr := skillcard.Validate(sc)
-		if valErr != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("validating skill.yaml: %w", valErr)
+	validationErrors, valErr := skillcard.Validate(sc)
+	if valErr != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("validating SkillCard: %w", valErr)
+	}
+	if len(validationErrors) > 0 {
+		var msgs []string
+		for _, ve := range validationErrors {
+			msgs = append(msgs, ve.String())
 		}
-		if len(validationErrors) > 0 {
-			var msgs []string
-			for _, ve := range validationErrors {
-				msgs = append(msgs, ve.String())
-			}
-			return ocispec.Descriptor{}, fmt.Errorf("skill.yaml validation failed: %s", strings.Join(msgs, "; "))
-		}
+		return ocispec.Descriptor{}, fmt.Errorf("SkillCard validation failed: %s", strings.Join(msgs, "; "))
 	}
 
 	// 2b. Count words in SKILL.md if present, excluding YAML frontmatter.

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -2,6 +2,8 @@ package oci
 
 import (
 	"oras.land/oras-go/v2/content/oci"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 // Client provides OCI operations against a local OCI layout store.
@@ -30,6 +32,9 @@ type BuildOptions struct {
 	// MediaType selects the media type profile. Empty or "standard" uses
 	// standard OCI types; "redhat" uses Red Hat-specific types for oc-mirror.
 	MediaType MediaTypeProfile
+	// SkillCard is a pre-built SkillCard to use instead of reading skill.yaml
+	// from disk. When non-nil, Build skips the file read/parse/validate steps.
+	SkillCard *skillcard.SkillCard
 }
 
 // PushOptions configures the Push operation.

--- a/pkg/oci/oci_test.go
+++ b/pkg/oci/oci_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/redhat-et/skillimage/pkg/lifecycle"
 	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 func writeTestSkill(t *testing.T, dir string) {
@@ -558,5 +559,57 @@ spec:
 
 	if result.WordCount != "" {
 		t.Errorf("wordcount should be empty for empty SKILL.md, got %q", result.WordCount)
+	}
+}
+
+func TestBuildWithPrebuiltSkillCard(t *testing.T) {
+	skillDir := t.TempDir()
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(skillDir, "SKILL.md"),
+		[]byte("You are a test skill."),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	sc := &skillcard.SkillCard{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCard",
+		Metadata: skillcard.Metadata{
+			Name:        "prebuilt-test",
+			Namespace:   "test",
+			Version:     "1.0.0",
+			Description: "A prebuilt test skill.",
+		},
+		Spec: &skillcard.Spec{Prompt: "SKILL.md"},
+	}
+
+	ctx := context.Background()
+	desc, err := client.Build(ctx, skillDir, oci.BuildOptions{SkillCard: sc})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if desc.Digest.String() == "" {
+		t.Error("expected non-empty digest")
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(images))
+	}
+	if images[0].Name != "test/prebuilt-test" {
+		t.Errorf("image name = %q, want %q", images[0].Name, "test/prebuilt-test")
 	}
 }

--- a/pkg/source/clone.go
+++ b/pkg/source/clone.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+var commitSHAPattern = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
 
 type CloneOptions struct {
 	RefOverride string
@@ -67,7 +70,15 @@ func Clone(ctx context.Context, src GitSource, opts CloneOptions) (*CloneResult,
 	return &CloneResult{Dir: resolvedDir, CommitSHA: sha, Cleanup: cleanup}, nil
 }
 
+func isCommitSHA(ref string) bool {
+	return commitSHAPattern.MatchString(ref)
+}
+
 func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+	if isCommitSHA(ref) {
+		return cloneAtCommit(ctx, cloneURL, ref, destDir)
+	}
+
 	if subPath != "" {
 		if err := sparseClone(ctx, cloneURL, ref, subPath, destDir); err == nil {
 			return nil
@@ -75,6 +86,13 @@ func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) erro
 	}
 
 	return shallowClone(ctx, cloneURL, ref, destDir)
+}
+
+func cloneAtCommit(ctx context.Context, cloneURL, sha, destDir string) error {
+	if err := runGit(ctx, "", "clone", "--no-checkout", cloneURL, destDir); err != nil {
+		return err
+	}
+	return runGit(ctx, destDir, "checkout", sha)
 }
 
 func sparseClone(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
@@ -120,7 +138,23 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git %v: %s", args, stderr.String())
+		return fmt.Errorf("git %s failed: %s", args[0], sanitizeGitOutput(stderr.String()))
 	}
 	return nil
+}
+
+func sanitizeGitOutput(s string) string {
+	s = strings.TrimSpace(s)
+	// Strip lines that may contain credentials in URLs.
+	var clean []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.Contains(line, "@") && strings.Contains(line, "://") {
+			continue
+		}
+		clean = append(clean, line)
+	}
+	if len(clean) == 0 {
+		return "(git output redacted — may contain credentials)"
+	}
+	return strings.Join(clean, "\n")
 }

--- a/pkg/source/clone.go
+++ b/pkg/source/clone.go
@@ -83,6 +83,12 @@ func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) erro
 		if err := sparseClone(ctx, cloneURL, ref, subPath, destDir); err == nil {
 			return nil
 		}
+		// Sparse clone may have partially populated destDir; clean it
+		// before falling back to a full shallow clone.
+		entries, _ := os.ReadDir(destDir)
+		for _, e := range entries {
+			_ = os.RemoveAll(filepath.Join(destDir, e.Name()))
+		}
 	}
 
 	return shallowClone(ctx, cloneURL, ref, destDir)

--- a/pkg/source/clone.go
+++ b/pkg/source/clone.go
@@ -1,0 +1,126 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type CloneOptions struct {
+	RefOverride string
+}
+
+type CloneResult struct {
+	Dir       string
+	CommitSHA string
+	Cleanup   func()
+}
+
+func CheckGit() error {
+	_, err := exec.LookPath("git")
+	if err != nil {
+		return fmt.Errorf("git is required for remote sources — install it from https://git-scm.com")
+	}
+	return nil
+}
+
+func Clone(ctx context.Context, src GitSource, opts CloneOptions) (*CloneResult, error) {
+	if err := CheckGit(); err != nil {
+		return nil, err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "skillctl-clone-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	ref := opts.RefOverride
+	if ref == "" {
+		ref = src.Ref
+	}
+
+	if err := cloneRepo(ctx, src.CloneURL, ref, src.SubPath, tmpDir); err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	resolvedDir := tmpDir
+	if src.SubPath != "" {
+		resolvedDir = filepath.Join(tmpDir, src.SubPath)
+		if _, err := os.Stat(resolvedDir); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("path %q not found in repository %s", src.SubPath, src.CloneURL)
+		}
+	}
+
+	sha, err := commitSHA(ctx, tmpDir)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("reading commit SHA: %w", err)
+	}
+
+	return &CloneResult{Dir: resolvedDir, CommitSHA: sha, Cleanup: cleanup}, nil
+}
+
+func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+	if subPath != "" {
+		if err := sparseClone(ctx, cloneURL, ref, subPath, destDir); err == nil {
+			return nil
+		}
+	}
+
+	return shallowClone(ctx, cloneURL, ref, destDir)
+}
+
+func sparseClone(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+	args := []string{"clone", "--depth", "1", "--filter=blob:none", "--sparse"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, cloneURL, destDir)
+
+	if err := runGit(ctx, "", args...); err != nil {
+		return err
+	}
+
+	return runGit(ctx, destDir, "sparse-checkout", "set", subPath)
+}
+
+func shallowClone(ctx context.Context, cloneURL, ref, destDir string) error {
+	args := []string{"clone", "--depth", "1"}
+	if ref != "" {
+		args = append(args, "--branch", ref)
+	}
+	args = append(args, cloneURL, destDir)
+
+	return runGit(ctx, "", args...)
+}
+
+func commitSHA(ctx context.Context, repoDir string) (string, error) {
+	var stdout bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "HEAD")
+	cmd.Dir = repoDir
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %v: %s", args, stderr.String())
+	}
+	return nil
+}

--- a/pkg/source/clone_test.go
+++ b/pkg/source/clone_test.go
@@ -1,0 +1,166 @@
+package source_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestCheckGit(t *testing.T) {
+	err := source.CheckGit()
+	if err != nil {
+		t.Skipf("git not available in test environment: %v", err)
+	}
+}
+
+func TestCloneShallow(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	skillDir := filepath.Join(workDir, "skills", "hello")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("creating skill directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: hello\n---\nHello skill."), 0o644); err != nil {
+		t.Fatalf("writing SKILL.md: %v", err)
+	}
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+		Ref:      "",
+		SubPath:  "skills/hello",
+	}
+
+	ctx := context.Background()
+	result, err := source.Clone(ctx, src, source.CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer result.Cleanup()
+
+	if _, err := os.Stat(filepath.Join(result.Dir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not found in cloned directory: %v", err)
+	}
+
+	if result.CommitSHA == "" {
+		t.Error("expected non-empty CommitSHA")
+	}
+}
+
+func TestCloneSubPathNotFound(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	workDir := t.TempDir()
+	bareDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatalf("writing README.md: %v", err)
+	}
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+		SubPath:  "nonexistent/path",
+	}
+
+	ctx := context.Background()
+	_, err := source.Clone(ctx, src, source.CloneOptions{})
+	if err == nil {
+		t.Fatal("expected error for nonexistent subpath")
+	}
+}
+
+func TestCloneRefOverride(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	workDir := t.TempDir()
+	bareDir := t.TempDir()
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s: %v", args, out, err)
+		}
+	}
+
+	run(workDir, "init")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("v1"), 0o644); err != nil {
+		t.Fatalf("writing SKILL.md v1: %v", err)
+	}
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "v1")
+	run(workDir, "tag", "v1.0")
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("v2"), 0o644); err != nil {
+		t.Fatalf("writing SKILL.md v2: %v", err)
+	}
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "v2")
+	run(workDir, "clone", "--bare", ".", bareDir+"/repo.git")
+
+	src := source.GitSource{
+		CloneURL: bareDir + "/repo.git",
+	}
+
+	ctx := context.Background()
+	result, err := source.Clone(ctx, src, source.CloneOptions{RefOverride: "v1.0"})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer result.Cleanup()
+
+	data, err := os.ReadFile(filepath.Join(result.Dir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("reading SKILL.md: %v", err)
+	}
+	if string(data) != "v1" {
+		t.Errorf("SKILL.md content = %q, want %q (tag v1.0)", string(data), "v1")
+	}
+}

--- a/pkg/source/discover.go
+++ b/pkg/source/discover.go
@@ -1,0 +1,102 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type DiscoveredSkill struct {
+	Dir  string
+	Name string
+}
+
+func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
+		name := resolveSkillName(dir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				return nil, fmt.Errorf("no skills matching %q in %s", filter, dir)
+			}
+		}
+		return []DiscoveredSkill{{Dir: dir, Name: name}}, nil
+	}
+
+	var skills []DiscoveredSkill
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		subDir := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
+			nested, _ := discoverNested(subDir, filter)
+			skills = append(skills, nested...)
+			continue
+		}
+
+		name := resolveSkillName(subDir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				continue
+			}
+		}
+		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
+	}
+
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+
+	if len(skills) == 0 {
+		if filter != "" {
+			return nil, fmt.Errorf("no skills matching %q in %s", filter, dir)
+		}
+		return nil, fmt.Errorf("no skills found in %s", dir)
+	}
+
+	return skills, nil
+}
+
+func discoverNested(dir string, filter string) ([]DiscoveredSkill, error) {
+	var skills []DiscoveredSkill
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		subDir := filepath.Join(dir, entry.Name())
+		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
+			continue
+		}
+		name := resolveSkillName(subDir)
+		if filter != "" {
+			if matched, _ := filepath.Match(filter, name); !matched {
+				continue
+			}
+		}
+		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
+	}
+	return skills, nil
+}
+
+func resolveSkillName(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		return filepath.Base(dir)
+	}
+	fm := parseFrontmatterRaw(data)
+	if name, ok := fm["name"].(string); ok && name != "" {
+		return name
+	}
+	return filepath.Base(dir)
+}

--- a/pkg/source/discover.go
+++ b/pkg/source/discover.go
@@ -37,7 +37,10 @@ func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
 
 		subDir := filepath.Join(dir, entry.Name())
 		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
-			nested, _ := discoverNested(subDir, filter)
+			nested, nestedErr := discoverNested(subDir, filter)
+			if nestedErr != nil {
+				return nil, fmt.Errorf("discovering skills in %s: %w", subDir, nestedErr)
+			}
 			skills = append(skills, nested...)
 			continue
 		}

--- a/pkg/source/discover.go
+++ b/pkg/source/discover.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,6 +15,12 @@ type DiscoveredSkill struct {
 }
 
 func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
+	if filter != "" {
+		if _, err := filepath.Match(filter, "test"); err != nil {
+			return nil, fmt.Errorf("invalid --filter pattern %q: %w", filter, err)
+		}
+	}
+
 	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err == nil {
 		name := resolveSkillName(dir)
 		if filter != "" {
@@ -25,33 +32,33 @@ func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
 	}
 
 	var skills []DiscoveredSkill
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("reading directory %s: %w", dir, err)
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
-			continue
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-
-		subDir := filepath.Join(dir, entry.Name())
-		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
-			nested, nestedErr := discoverNested(subDir, filter)
-			if nestedErr != nil {
-				return nil, fmt.Errorf("discovering skills in %s: %w", subDir, nestedErr)
-			}
-			skills = append(skills, nested...)
-			continue
+		if !d.IsDir() {
+			return nil
 		}
-
-		name := resolveSkillName(subDir)
+		if strings.HasPrefix(d.Name(), ".") {
+			return fs.SkipDir
+		}
+		if path == dir {
+			return nil
+		}
+		if _, statErr := os.Stat(filepath.Join(path, "SKILL.md")); statErr != nil {
+			return nil
+		}
+		name := resolveSkillName(path)
 		if filter != "" {
 			if matched, _ := filepath.Match(filter, name); !matched {
-				continue
+				return fs.SkipDir
 			}
 		}
-		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
+		skills = append(skills, DiscoveredSkill{Dir: path, Name: name})
+		return fs.SkipDir
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", dir, err)
 	}
 
 	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
@@ -63,32 +70,6 @@ func Discover(dir string, filter string) ([]DiscoveredSkill, error) {
 		return nil, fmt.Errorf("no skills found in %s", dir)
 	}
 
-	return skills, nil
-}
-
-func discoverNested(dir string, filter string) ([]DiscoveredSkill, error) {
-	var skills []DiscoveredSkill
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
-			continue
-		}
-		subDir := filepath.Join(dir, entry.Name())
-		if _, err := os.Stat(filepath.Join(subDir, "SKILL.md")); err != nil {
-			continue
-		}
-		name := resolveSkillName(subDir)
-		if filter != "" {
-			if matched, _ := filepath.Match(filter, name); !matched {
-				continue
-			}
-		}
-		skills = append(skills, DiscoveredSkill{Dir: subDir, Name: name})
-	}
 	return skills, nil
 }
 

--- a/pkg/source/discover_test.go
+++ b/pkg/source/discover_test.go
@@ -10,8 +10,12 @@ import (
 
 func writeSkillMD(t *testing.T, dir, content string) {
 	t.Helper()
-	os.MkdirAll(dir, 0o755)
-	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDiscoverMultipleSkills(t *testing.T) {
@@ -79,7 +83,9 @@ func TestDiscoverWithFilter(t *testing.T) {
 
 func TestDiscoverNoSkills(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, "README.md"), []byte("no skills here"), 0o644)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("no skills here"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	_, err := source.Discover(root, "")
 	if err == nil {

--- a/pkg/source/discover_test.go
+++ b/pkg/source/discover_test.go
@@ -1,0 +1,115 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func writeSkillMD(t *testing.T, dir, content string) {
+	t.Helper()
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644)
+}
+
+func TestDiscoverMultipleSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "alpha"), "---\nname: alpha\n---\nAlpha.")
+	writeSkillMD(t, filepath.Join(root, "beta"), "---\nname: beta\n---\nBeta.")
+	writeSkillMD(t, filepath.Join(root, "gamma"), "---\nname: gamma\n---\nGamma.")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 3 {
+		t.Fatalf("got %d skills, want 3", len(skills))
+	}
+	if skills[0].Name != "alpha" || skills[1].Name != "beta" || skills[2].Name != "gamma" {
+		t.Errorf("skills = %+v, want alpha/beta/gamma sorted", skills)
+	}
+}
+
+func TestDiscoverSingleSkill(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, root, "---\nname: solo\n---\nSolo skill.")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1", len(skills))
+	}
+	if skills[0].Dir != root {
+		t.Errorf("Dir = %q, want %q", skills[0].Dir, root)
+	}
+}
+
+func TestDiscoverSkipsHiddenDirs(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "visible"), "---\nname: visible\n---\n")
+	writeSkillMD(t, filepath.Join(root, ".hidden"), "---\nname: hidden\n---\n")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (hidden should be skipped)", len(skills))
+	}
+}
+
+func TestDiscoverWithFilter(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "code-review"), "---\nname: code-review\n---\n")
+	writeSkillMD(t, filepath.Join(root, "code-gen"), "---\nname: code-gen\n---\n")
+	writeSkillMD(t, filepath.Join(root, "email"), "---\nname: email\n---\n")
+
+	skills, err := source.Discover(root, "code-*")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2", len(skills))
+	}
+}
+
+func TestDiscoverNoSkills(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, "README.md"), []byte("no skills here"), 0o644)
+
+	_, err := source.Discover(root, "")
+	if err == nil {
+		t.Fatal("expected error when no skills found")
+	}
+}
+
+func TestDiscoverNoMatchingFilter(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "alpha"), "---\nname: alpha\n---\n")
+
+	_, err := source.Discover(root, "zzz-*")
+	if err == nil {
+		t.Fatal("expected error when no skills match filter")
+	}
+}
+
+func TestDiscoverDoesNotNest(t *testing.T) {
+	root := t.TempDir()
+	writeSkillMD(t, filepath.Join(root, "parent"), "---\nname: parent\n---\n")
+	writeSkillMD(t, filepath.Join(root, "parent", "child"), "---\nname: child\n---\n")
+
+	skills, err := source.Discover(root, "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("got %d skills, want 1 (child should not be discovered)", len(skills))
+	}
+	if skills[0].Name != "parent" {
+		t.Errorf("Name = %q, want %q", skills[0].Name, "parent")
+	}
+}

--- a/pkg/source/generate.go
+++ b/pkg/source/generate.go
@@ -113,9 +113,14 @@ func firstSentence(body string) string {
 }
 
 func normalizeVersion(v string) string {
+	var suffix string
+	if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+		suffix = v[idx:]
+		v = v[:idx]
+	}
 	parts := strings.Split(v, ".")
 	for len(parts) < 3 {
 		parts = append(parts, "0")
 	}
-	return strings.Join(parts[:3], ".")
+	return strings.Join(parts[:3], ".") + suffix
 }

--- a/pkg/source/generate.go
+++ b/pkg/source/generate.go
@@ -1,0 +1,121 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+	"gopkg.in/yaml.v3"
+)
+
+func GenerateSkillCard(skillDir, cloneURL, orgFallback string) (*skillcard.SkillCard, error) {
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		return nil, fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	fm := parseFrontmatterRaw(data)
+	body := stripFrontmatterStr(string(data))
+
+	sc := &skillcard.SkillCard{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCard",
+		Metadata: skillcard.Metadata{
+			Name:          stringFromMap(fm, "name", filepath.Base(skillDir)),
+			Namespace:     orgFallback,
+			Version:       normalizeVersion(stringFromMapNested(fm, "metadata", "version", "0.1.0")),
+			Description:   stringFromMap(fm, "description", firstSentence(body)),
+			License:       stringFromMap(fm, "license", ""),
+			Compatibility: stringFromMap(fm, "compatibility", ""),
+		},
+		Spec: &skillcard.Spec{
+			Prompt: "SKILL.md",
+		},
+	}
+
+	author := stringFromMapNested(fm, "metadata", "author", "")
+	if author == "" {
+		author = orgFallback
+	}
+	if author != "" {
+		sc.Metadata.Authors = []skillcard.Author{{Name: author}}
+	}
+
+	return sc, nil
+}
+
+func parseFrontmatterRaw(data []byte) map[string]any {
+	s := string(data)
+	if !strings.HasPrefix(s, "---") {
+		return nil
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return nil
+	}
+	fmStr := s[4 : 3+end]
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(fmStr), &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+func stripFrontmatterStr(s string) string {
+	if !strings.HasPrefix(s, "---") {
+		return s
+	}
+	end := strings.Index(s[3:], "\n---")
+	if end < 0 {
+		return s
+	}
+	return strings.TrimSpace(s[3+end+4:])
+}
+
+func stringFromMap(m map[string]any, key, fallback string) string {
+	if m == nil {
+		return fallback
+	}
+	if v, ok := m[key].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func stringFromMapNested(m map[string]any, outer, inner, fallback string) string {
+	if m == nil {
+		return fallback
+	}
+	sub, ok := m[outer].(map[string]any)
+	if !ok {
+		return fallback
+	}
+	if v, ok := sub[inner].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+func firstSentence(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	if before, _, found := strings.Cut(body, "."); found {
+		return before + "."
+	}
+	if before, _, found := strings.Cut(body, "\n"); found {
+		return strings.TrimSpace(before)
+	}
+	return body
+}
+
+func normalizeVersion(v string) string {
+	parts := strings.Split(v, ".")
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+	return strings.Join(parts[:3], ".")
+}

--- a/pkg/source/generate_test.go
+++ b/pkg/source/generate_test.go
@@ -1,0 +1,85 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestGenerateSkillCardFromFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\nname: code-review\ndescription: Reviews code for quality and bugs.\nlicense: Apache-2.0\ncompatibility: claude-3.5-sonnet\nmetadata:\n  author: anthropic\n  version: \"2.0\"\n---\nYou are a code review assistant.\n"
+	writeSkillMD(t, dir, content)
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/anthropics/skills.git", "anthropics")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+
+	if sc.APIVersion != "skillimage.io/v1alpha1" {
+		t.Errorf("APIVersion = %q", sc.APIVersion)
+	}
+	if sc.Kind != "SkillCard" {
+		t.Errorf("Kind = %q", sc.Kind)
+	}
+	if sc.Metadata.Name != "code-review" {
+		t.Errorf("Name = %q, want code-review", sc.Metadata.Name)
+	}
+	if sc.Metadata.Description != "Reviews code for quality and bugs." {
+		t.Errorf("Description = %q", sc.Metadata.Description)
+	}
+	if sc.Metadata.Version != "2.0.0" {
+		t.Errorf("Version = %q, want 2.0.0", sc.Metadata.Version)
+	}
+	if sc.Metadata.License != "Apache-2.0" {
+		t.Errorf("License = %q", sc.Metadata.License)
+	}
+	if sc.Metadata.Compatibility != "claude-3.5-sonnet" {
+		t.Errorf("Compatibility = %q", sc.Metadata.Compatibility)
+	}
+	if sc.Metadata.Namespace != "anthropics" {
+		t.Errorf("Namespace = %q, want anthropics", sc.Metadata.Namespace)
+	}
+	if len(sc.Metadata.Authors) != 1 || sc.Metadata.Authors[0].Name != "anthropic" {
+		t.Errorf("Authors = %+v", sc.Metadata.Authors)
+	}
+	if sc.Spec == nil || sc.Spec.Prompt != "SKILL.md" {
+		t.Errorf("Spec.Prompt = %v", sc.Spec)
+	}
+}
+
+func TestGenerateSkillCardFallbacks(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "You are a helpful assistant. This does many things.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/acme/tools.git", "acme")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+
+	if sc.Metadata.Name == "" {
+		t.Error("Name should not be empty")
+	}
+	if sc.Metadata.Description != "You are a helpful assistant." {
+		t.Errorf("Description = %q, want first sentence", sc.Metadata.Description)
+	}
+	if sc.Metadata.Version != "0.1.0" {
+		t.Errorf("Version = %q, want 0.1.0", sc.Metadata.Version)
+	}
+	if sc.Metadata.Namespace != "acme" {
+		t.Errorf("Namespace = %q, want acme", sc.Metadata.Namespace)
+	}
+}
+
+func TestGenerateSkillCardMalformedFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "---\nbad: [yaml: {{\n---\nContent here.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/org/repo.git", "org")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v (should not fail on bad frontmatter)", err)
+	}
+	if sc.Metadata.Description != "Content here." {
+		t.Errorf("Description = %q", sc.Metadata.Description)
+	}
+}

--- a/pkg/source/giturl.go
+++ b/pkg/source/giturl.go
@@ -53,13 +53,11 @@ func parseGitHub(u *url.URL, parts []string) (GitSource, error) {
 }
 
 func parseGitLab(u *url.URL, parts []string) (GitSource, error) {
-	org := parts[0]
-	repo := strings.TrimSuffix(parts[1], ".git")
-	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", u.Host, org, repo)
+	var ref, subPath, groupRepoPath string
 
-	var ref, subPath string
 	for i, p := range parts {
 		if p == "-" && i+2 < len(parts) && parts[i+1] == "tree" {
+			groupRepoPath = strings.Join(parts[:i], "/")
 			ref = parts[i+2]
 			if i+3 < len(parts) {
 				subPath = strings.Join(parts[i+3:], "/")
@@ -67,6 +65,12 @@ func parseGitLab(u *url.URL, parts []string) (GitSource, error) {
 			break
 		}
 	}
+
+	if groupRepoPath == "" {
+		groupRepoPath = strings.Join(parts[:2], "/")
+	}
+	groupRepoPath = strings.TrimSuffix(groupRepoPath, ".git")
+	cloneURL := fmt.Sprintf("https://%s/%s.git", u.Host, groupRepoPath)
 
 	return GitSource{CloneURL: cloneURL, Ref: ref, SubPath: subPath}, nil
 }

--- a/pkg/source/giturl.go
+++ b/pkg/source/giturl.go
@@ -1,0 +1,84 @@
+package source
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+type GitSource struct {
+	CloneURL string
+	Ref      string
+	SubPath  string
+}
+
+func ParseGitURL(raw string) (GitSource, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" {
+		return GitSource{}, fmt.Errorf("not a valid URL: %s", raw)
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return GitSource{}, fmt.Errorf("URL must contain at least org/repo: %s", raw)
+	}
+
+	host := u.Host
+
+	switch {
+	case host == "github.com":
+		return parseGitHub(u, parts)
+	case host == "gitlab.com" || containsGitLab(parts):
+		return parseGitLab(u, parts)
+	default:
+		return parseGeneric(u, parts)
+	}
+}
+
+func parseGitHub(u *url.URL, parts []string) (GitSource, error) {
+	org := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", u.Host, org, repo)
+
+	var ref, subPath string
+	if len(parts) > 3 && parts[2] == "tree" {
+		ref = parts[3]
+		if len(parts) > 4 {
+			subPath = strings.Join(parts[4:], "/")
+		}
+	}
+
+	return GitSource{CloneURL: cloneURL, Ref: ref, SubPath: subPath}, nil
+}
+
+func parseGitLab(u *url.URL, parts []string) (GitSource, error) {
+	org := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	cloneURL := fmt.Sprintf("https://%s/%s/%s.git", u.Host, org, repo)
+
+	var ref, subPath string
+	for i, p := range parts {
+		if p == "-" && i+2 < len(parts) && parts[i+1] == "tree" {
+			ref = parts[i+2]
+			if i+3 < len(parts) {
+				subPath = strings.Join(parts[i+3:], "/")
+			}
+			break
+		}
+	}
+
+	return GitSource{CloneURL: cloneURL, Ref: ref, SubPath: subPath}, nil
+}
+
+func parseGeneric(u *url.URL, _ []string) (GitSource, error) {
+	return GitSource{
+		CloneURL: u.String(),
+		Ref:      "",
+		SubPath:  "",
+	}, nil
+}
+
+func containsGitLab(parts []string) bool {
+	return slices.Contains(parts, "-")
+}

--- a/pkg/source/giturl_test.go
+++ b/pkg/source/giturl_test.go
@@ -68,6 +68,15 @@ func TestParseGitURL(t *testing.T) {
 			},
 		},
 		{
+			name: "gitlab nested group",
+			raw:  "https://gitlab.com/org/subgroup/repo/-/tree/main/skills",
+			want: source.GitSource{
+				CloneURL: "https://gitlab.com/org/subgroup/repo.git",
+				Ref:      "main",
+				SubPath:  "skills",
+			},
+		},
+		{
 			name:    "not a URL",
 			raw:     "/some/local/path",
 			wantErr: true,

--- a/pkg/source/giturl_test.go
+++ b/pkg/source/giturl_test.go
@@ -1,0 +1,91 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestParseGitURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    source.GitSource
+		wantErr bool
+	}{
+		{
+			name: "github repo root",
+			raw:  "https://github.com/anthropics/skills",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name: "github with ref and subpath",
+			raw:  "https://github.com/anthropics/skills/tree/main/skills",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "main",
+				SubPath:  "skills",
+			},
+		},
+		{
+			name: "github with tag ref and deep subpath",
+			raw:  "https://github.com/anthropics/skills/tree/v1.0/skills/internal-comms",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "v1.0",
+				SubPath:  "skills/internal-comms",
+			},
+		},
+		{
+			name: "gitlab with tree path",
+			raw:  "https://gitlab.com/org/repo/-/tree/main/path/to/skill",
+			want: source.GitSource{
+				CloneURL: "https://gitlab.com/org/repo.git",
+				Ref:      "main",
+				SubPath:  "path/to/skill",
+			},
+		},
+		{
+			name: "unknown host plain URL",
+			raw:  "https://unknown-host.com/org/repo",
+			want: source.GitSource{
+				CloneURL: "https://unknown-host.com/org/repo",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name: "github repo with .git suffix",
+			raw:  "https://github.com/anthropics/skills.git",
+			want: source.GitSource{
+				CloneURL: "https://github.com/anthropics/skills.git",
+				Ref:      "",
+				SubPath:  "",
+			},
+		},
+		{
+			name:    "not a URL",
+			raw:     "/some/local/path",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := source.ParseGitURL(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseGitURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseGitURL() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -75,6 +75,11 @@ func Resolve(ctx context.Context, input string, ref string, filter string) (*Res
 			continue
 		}
 
+		if sc.Metadata.Namespace == "" || sc.Metadata.Name == "" {
+			fmt.Fprintf(os.Stderr, "Warning: skipping %s: generated SkillCard missing namespace or name\n", d.Name)
+			continue
+		}
+
 		relPath := relativeToClone(cloneResult.Dir, d.Dir, src.SubPath)
 		sc.Provenance = &skillcard.Provenance{
 			Source: src.CloneURL,

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,0 +1,114 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+)
+
+func IsRemote(input string) bool {
+	return strings.HasPrefix(input, "https://") || strings.HasPrefix(input, "http://")
+}
+
+func OrgFromCloneURL(cloneURL string) string {
+	u, err := url.Parse(cloneURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) >= 2 {
+		return parts[0]
+	}
+	return ""
+}
+
+type ResolveResult struct {
+	Skills    []ResolvedSkill
+	Cleanup   func()
+	SourceURL string
+}
+
+type ResolvedSkill struct {
+	Dir       string
+	Name      string
+	SkillCard *skillcard.SkillCard
+}
+
+func Resolve(ctx context.Context, input string, ref string, filter string) (*ResolveResult, error) {
+	if !IsRemote(input) {
+		return nil, fmt.Errorf("not a remote source: %s", input)
+	}
+
+	src, err := ParseGitURL(input)
+	if err != nil {
+		return nil, err
+	}
+
+	cloneResult, err := Clone(ctx, src, CloneOptions{RefOverride: ref})
+	if err != nil {
+		return nil, err
+	}
+
+	discovered, err := Discover(cloneResult.Dir, filter)
+	if err != nil {
+		cloneResult.Cleanup()
+		return nil, err
+	}
+
+	org := OrgFromCloneURL(src.CloneURL)
+
+	var skills []ResolvedSkill
+	for _, d := range discovered {
+		if hasSkillYAML(d.Dir) {
+			skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: nil})
+			continue
+		}
+
+		sc, err := GenerateSkillCard(d.Dir, src.CloneURL, org)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", d.Name, err)
+			continue
+		}
+
+		relPath := relativeToClone(cloneResult.Dir, d.Dir, src.SubPath)
+		sc.Provenance = &skillcard.Provenance{
+			Source: src.CloneURL,
+			Commit: cloneResult.CommitSHA,
+			Path:   relPath,
+		}
+
+		skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: sc})
+	}
+
+	if len(skills) == 0 {
+		cloneResult.Cleanup()
+		return nil, fmt.Errorf("no skills could be resolved from %s", input)
+	}
+
+	return &ResolveResult{
+		Skills:    skills,
+		Cleanup:   cloneResult.Cleanup,
+		SourceURL: input,
+	}, nil
+}
+
+func hasSkillYAML(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "skill.yaml"))
+	return err == nil
+}
+
+func relativeToClone(cloneDir, skillDir, subPath string) string {
+	rel, err := filepath.Rel(cloneDir, skillDir)
+	if err != nil {
+		return filepath.Base(skillDir)
+	}
+	if subPath != "" {
+		return filepath.ToSlash(filepath.Join(subPath, rel))
+	}
+	return filepath.ToSlash(rel)
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -64,28 +64,35 @@ func Resolve(ctx context.Context, input string, ref string, filter string) (*Res
 
 	var skills []ResolvedSkill
 	for _, d := range discovered {
+		var sc *skillcard.SkillCard
+
 		if hasSkillYAML(d.Dir) {
-			skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: nil})
-			continue
-		}
-
-		sc, err := GenerateSkillCard(d.Dir, src.CloneURL, org)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", d.Name, err)
-			continue
-		}
-
-		if sc.Metadata.Namespace == "" || sc.Metadata.Name == "" {
-			fmt.Fprintf(os.Stderr, "Warning: skipping %s: generated SkillCard missing namespace or name\n", d.Name)
-			continue
+			parsed, parseErr := parseSkillYAML(d.Dir)
+			if parseErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", d.Name, parseErr)
+				continue
+			}
+			sc = parsed
+		} else {
+			generated, genErr := GenerateSkillCard(d.Dir, src.CloneURL, org)
+			if genErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", d.Name, genErr)
+				continue
+			}
+			if generated.Metadata.Namespace == "" || generated.Metadata.Name == "" {
+				fmt.Fprintf(os.Stderr, "Warning: skipping %s: generated SkillCard missing namespace or name\n", d.Name)
+				continue
+			}
+			sc = generated
 		}
 
 		relPath := relativeToClone(cloneResult.Dir, d.Dir, src.SubPath)
-		sc.Provenance = &skillcard.Provenance{
-			Source: src.CloneURL,
-			Commit: cloneResult.CommitSHA,
-			Path:   relPath,
+		if sc.Provenance == nil {
+			sc.Provenance = &skillcard.Provenance{}
 		}
+		sc.Provenance.Source = src.CloneURL
+		sc.Provenance.Commit = cloneResult.CommitSHA
+		sc.Provenance.Path = relPath
 
 		skills = append(skills, ResolvedSkill{Dir: d.Dir, Name: d.Name, SkillCard: sc})
 	}
@@ -105,6 +112,15 @@ func Resolve(ctx context.Context, input string, ref string, filter string) (*Res
 func hasSkillYAML(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, "skill.yaml"))
 	return err == nil
+}
+
+func parseSkillYAML(dir string) (*skillcard.SkillCard, error) {
+	f, err := os.Open(filepath.Join(dir, "skill.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("opening skill.yaml: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return skillcard.Parse(f)
 }
 
 func relativeToClone(cloneDir, skillDir, subPath string) string {

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -1,0 +1,47 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/source"
+)
+
+func TestIsRemote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://github.com/org/repo", true},
+		{"http://gitlab.com/org/repo", true},
+		{"/local/path/to/skills", false},
+		{"./relative/path", false},
+		{"skills/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := source.IsRemote(tt.input); got != tt.want {
+				t.Errorf("IsRemote(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrgFromCloneURL(t *testing.T) {
+	tests := []struct {
+		cloneURL string
+		want     string
+	}{
+		{"https://github.com/anthropics/skills.git", "anthropics"},
+		{"https://gitlab.com/org/repo.git", "org"},
+		{"https://example.com/repo", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cloneURL, func(t *testing.T) {
+			if got := source.OrgFromCloneURL(tt.cloneURL); got != tt.want {
+				t.Errorf("OrgFromCloneURL(%q) = %q, want %q", tt.cloneURL, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Build OCI skill images directly from Git repository URLs (`skillctl build https://github.com/org/repo`)
- Discover skills by `SKILL.md` presence (no `skill.yaml` required in source repos)
- Generate SkillCards on the fly from SKILL.md frontmatter metadata
- Support GitHub, GitLab, and generic Git host URLs
- Sparse checkout optimization when targeting a subdirectory

Closes #10. Closes #13.

## Usage

```bash
# Build all skills from a repo
skillctl build https://github.com/anthropics/skills

# Build skills from a specific subdirectory
skillctl build https://github.com/anthropics/skills/tree/main/skills

# Build a single skill
skillctl build https://github.com/anthropics/skills/tree/main/skills/code-review

# Filter by name glob
skillctl build https://github.com/org/repo --filter "code-*"

# Pin to a specific ref
skillctl build https://github.com/org/repo --ref v1.0
```

## Design

New `pkg/source` package (source resolver layer) that sits between the CLI and `pkg/oci`:

| File | Responsibility |
| ---- | -------------- |
| `giturl.go` | URL parsing for GitHub, GitLab, generic hosts |
| `clone.go` | Shallow clone with sparse checkout, ref override |
| `discover.go` | Walk directories for SKILL.md, glob filtering |
| `generate.go` | SKILL.md frontmatter → in-memory SkillCard |
| `source.go` | Orchestrator: parse → clone → discover → generate → provenance |

`pkg/oci.BuildOptions` gains a `SkillCard` field so generated SkillCards
can be passed in without writing temporary files.

## Test plan

- [x] URL parsing: 7 test cases (GitHub, GitLab, generic, errors)
- [x] Git clone: 4 test cases (shallow, subpath, ref override, bad subpath)
- [x] Skill discovery: 7 test cases (multi, single, hidden, filter, nesting)
- [x] SkillCard generation: 3 test cases (frontmatter, fallbacks, malformed)
- [x] Pre-built SkillCard build: 1 test case + all existing OCI tests pass
- [x] Orchestrator: 2 test cases (IsRemote, OrgFromCloneURL)
- [x] End-to-end: tested against live GitHub repos
- [x] Linter: 0 issues
- [x] Local build regression: unchanged behavior confirmed


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `build` command now accepts remote Git repository URLs as input
  * Added `--ref` flag to specify Git branches or tags for remote sources
  * Added `--filter` flag to select specific skills from multi-skill repositories
  * Automatic discovery and sequential building of multiple skills from a single remote repository
  * Support for sparse checkouts and subpath handling within cloned repositories

* **Documentation**
  * New implementation plan and design specification for remote Git source support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->