### PR TITLE
feat: add rm/delete command to remove local skill images

### DIFF
--- a/dev/plans/2026-04-30-rm-delete-command.md
+++ b/dev/plans/2026-04-30-rm-delete-command.md
@@ -1,0 +1,416 @@
+# rm/delete command implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `skillctl rm` (alias `delete`) to remove skill images
+from the local OCI store by name:tag reference.
+
+**Architecture:** A `Remove()` method on `pkg/oci.Client` calls
+`store.Resolve()` then `store.Untag()`. A thin CLI command in
+`internal/cli/rm.go` handles argument parsing, confirmation
+prompts, and output formatting. Follows the same pattern as
+the existing `prune` command.
+
+**Tech Stack:** Go, cobra, oras-go (`content/oci.Store`)
+
+---
+
+### Task 1: Client.Remove method — test
+
+**Files:**
+- Create: `pkg/oci/remove_test.go`
+
+- [ ] **Step 1: Write TestRemove — remove an existing image**
+
+```go
+package oci_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+)
+
+func TestRemove(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	err = client.Remove(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 0 {
+		t.Errorf("expected 0 images after remove, got %d", len(images))
+	}
+}
+```
+
+- [ ] **Step 2: Write TestRemoveNotFound — error on missing ref**
+
+```go
+func TestRemoveNotFound(t *testing.T) {
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = client.Remove(context.Background(), "no/such-image:1.0.0")
+	if err == nil {
+		t.Fatal("expected error for non-existent image")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
+	}
+}
+```
+
+Add `"strings"` to the import block.
+
+- [ ] **Step 3: Write TestRemoveMultipleImages — remove one, keep another**
+
+```go
+func TestRemoveMultipleImages(t *testing.T) {
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Build first image
+	skillDir1 := t.TempDir()
+	writeTestSkill(t, skillDir1)
+	_, err = client.Build(ctx, skillDir1, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build first: %v", err)
+	}
+
+	// Build second image with different name
+	skillDir2 := t.TempDir()
+	writeTestSkillNamed(t, skillDir2, "other-skill")
+	_, err = client.Build(ctx, skillDir2, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build second: %v", err)
+	}
+
+	// Remove only the first
+	err = client.Remove(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image after remove, got %d", len(images))
+	}
+	if images[0].Name != "test/other-skill" {
+		t.Errorf("remaining image = %q, want %q", images[0].Name, "test/other-skill")
+	}
+}
+```
+
+This test uses a helper `writeTestSkillNamed` — add it to the
+test file:
+
+```go
+func writeTestSkillNamed(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillYAML := []byte(fmt.Sprintf(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: %s
+  namespace: test
+  version: 1.0.0
+  description: A test skill.
+spec:
+  prompt: SKILL.md
+`, name))
+	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Test prompt."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+Add `"fmt"`, `"os"`, and `"path/filepath"` to the import block.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./pkg/oci/ -run "TestRemove" -v`
+
+Expected: compilation failure — `client.Remove` undefined.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/oci/remove_test.go
+git commit -s -m "test: add failing tests for Client.Remove"
+```
+
+---
+
+### Task 2: Client.Remove method — implementation
+
+**Files:**
+- Create: `pkg/oci/remove.go`
+
+- [ ] **Step 1: Implement Remove**
+
+```go
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"oras.land/oras-go/v2/errdef"
+)
+
+// Remove removes a skill image from the local store by its tag
+// reference (e.g., "test/test-skill:1.0.0-draft"). It does not
+// clean up unreferenced blobs — use Prune for that.
+func (c *Client) Remove(ctx context.Context, ref string) error {
+	if _, err := c.store.Resolve(ctx, ref); err != nil {
+		if errdef.IsNotFound(err) {
+			return fmt.Errorf("image not found: %s", ref)
+		}
+		return fmt.Errorf("resolving %s: %w", ref, err)
+	}
+
+	if err := c.store.Untag(ctx, ref); err != nil {
+		return fmt.Errorf("removing %s: %w", ref, err)
+	}
+
+	return nil
+}
+```
+
+Note: `errdef.IsNotFound` is from `oras.land/oras-go/v2/errdef`,
+already imported elsewhere in the package (see `build.go` line 19).
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./pkg/oci/ -run "TestRemove" -v`
+
+Expected: all three tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/oci/remove.go
+git commit -s -m "feat: add Client.Remove to untag local images"
+```
+
+---
+
+### Task 3: CLI rm command
+
+**Files:**
+- Create: `internal/cli/rm.go`
+- Modify: `internal/cli/root.go:29` (add `newRmCmd()`)
+
+- [ ] **Step 1: Create the rm command**
+
+```go
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newRmCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "rm <ref> [<ref>...]",
+		Aliases: []string{"delete"},
+		Short:   "Remove skill images from local store",
+		Long: `Remove one or more skill images from the local store by
+tag reference (e.g., test/hello-world:1.0.0-draft).
+
+Does not clean up unreferenced blobs — run 'skillctl prune'
+after removal to reclaim disk space.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRm(cmd, args, force)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "skip confirmation prompt")
+	return cmd
+}
+
+func runRm(cmd *cobra.Command, refs []string, force bool) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Resolve all refs first to report errors before confirming.
+	images, err := client.ListLocal()
+	if err != nil {
+		return fmt.Errorf("listing images: %w", err)
+	}
+	knownRefs := make(map[string]bool, len(images))
+	for _, img := range images {
+		knownRefs[img.Name+":"+img.Tag] = true
+	}
+
+	var valid []string
+	var hadErrors bool
+	for _, ref := range refs {
+		if !knownRefs[ref] {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: image not found: %s\n", ref)
+			hadErrors = true
+			continue
+		}
+		valid = append(valid, ref)
+	}
+
+	if len(valid) == 0 {
+		if hadErrors {
+			return fmt.Errorf("no valid images to remove")
+		}
+		return nil
+	}
+
+	// Confirm unless --force.
+	if !force {
+		if len(valid) == 1 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Remove %s? [y/N] ", valid[0])
+		} else {
+			for _, ref := range valid {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", ref)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Remove %d image(s)? [y/N] ", len(valid))
+		}
+
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return nil
+		}
+		answer := strings.TrimSpace(scanner.Text())
+		if answer != "y" && answer != "Y" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	// Remove each valid ref.
+	for _, ref := range valid {
+		if err := client.Remove(ctx, ref); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			hadErrors = true
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed %s\n", ref)
+	}
+
+	if hadErrors {
+		return fmt.Errorf("some images could not be removed")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Register the command in root.go**
+
+Add this line after the `newPruneCmd()` registration (line 29
+in `internal/cli/root.go`):
+
+```go
+cmd.AddCommand(newRmCmd())
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build ./cmd/skillctl/`
+
+Expected: clean build.
+
+- [ ] **Step 4: Manual smoke test**
+
+Run:
+
+```bash
+# Build a test image
+./bin/skillctl build testdata/skills/hello-world
+
+# List it
+./bin/skillctl list
+
+# Remove it (with confirmation)
+./bin/skillctl rm examples/hello-world:1.0.0-draft
+
+# Verify it's gone
+./bin/skillctl list
+```
+
+Alternatively, if no testdata exists, build from the test
+fixtures in the test suite.
+
+- [ ] **Step 5: Run linter**
+
+Run: `make lint`
+
+Expected: no new warnings.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cli/rm.go internal/cli/root.go
+git commit -s -m "feat: add skillctl rm command to remove local images
+
+Closes #22"
+```

--- a/dev/plans/2026-04-30-rm-delete-command.md
+++ b/dev/plans/2026-04-30-rm-delete-command.md
@@ -18,7 +18,7 @@ the existing `prune` command.
 
 ---
 
-### Task 1: Client.Remove method — test
+## Task 1: Client.Remove method — test
 
 **Files:**
 - Create: `pkg/oci/remove_test.go`
@@ -180,7 +180,7 @@ git commit -s -m "test: add failing tests for Client.Remove"
 
 ---
 
-### Task 2: Client.Remove method — implementation
+## Task 2: Client.Remove method — implementation
 
 **Files:**
 - Create: `pkg/oci/remove.go`
@@ -240,7 +240,7 @@ git commit -s -m "feat: add Client.Remove to untag local images"
 
 ---
 
-### Task 3: CLI rm command
+## Task 3: CLI rm command
 
 **Files:**
 - Create: `internal/cli/rm.go`

--- a/dev/specs/2026-04-30-rm-delete-command-design.md
+++ b/dev/specs/2026-04-30-rm-delete-command-design.md
@@ -1,0 +1,119 @@
+# rm/delete command for local skill images
+
+## Summary
+
+Add `skillctl rm` (alias `delete`) to remove skill images from the
+local OCI store by name:tag reference. Supports multiple refs in a
+single invocation, confirms before removal unless `--force` is set,
+and defers blob cleanup to `skillctl prune`.
+
+Closes #22.
+
+## Motivation
+
+After building or pulling images, they accumulate in the local store
+(`~/.local/share/skillctl/store/`) with no targeted cleanup
+mechanism. The existing `prune` command only removes images
+superseded by promotion — it cannot remove a specific image by
+reference. Users need a way to remove individual images.
+
+## Design
+
+### CLI command
+
+**File:** `internal/cli/rm.go`
+
+```
+skillctl rm <ref> [<ref>...] [flags]
+```
+
+| Field | Value |
+| ----- | ----- |
+| Use | `rm <ref> [<ref>...]` |
+| Aliases | `delete` |
+| Short | Remove skill images from local store |
+| Args | One or more `name:tag` references |
+
+**Flags:**
+
+| Flag | Short | Type | Default | Description |
+| ---- | ----- | ---- | ------- | ----------- |
+| `--force` | `-f` | bool | false | Skip confirmation prompt |
+
+**Behavior:**
+
+1. Create OCI client via `defaultClient()`
+2. Resolve each ref against the local store to verify it exists
+3. Print the list of images to be removed
+4. Unless `--force`, prompt for confirmation:
+   - Single image: `Remove examples/hello-world:1.0.0-draft? [y/N]`
+   - Multiple images: list all, then `Remove 3 image(s)? [y/N]`
+5. Call `client.Remove(ctx, ref)` for each ref
+6. Print each removed image on success
+7. If a ref doesn't exist, print an error for that ref but
+   continue with the rest
+8. Exit code 1 if any removal failed
+
+**Not in scope (v1):**
+
+- Digest-based removal (`sha256:abc...`) — tag-based only
+- Glob/wildcard patterns (`examples/*`)
+- Automatic blob garbage collection (use `prune` separately)
+
+### Client method
+
+**File:** `pkg/oci/remove.go`
+
+```go
+func (c *Client) Remove(ctx context.Context, ref string) error
+```
+
+1. Call `c.store.Resolve(ctx, ref)` to verify the ref exists
+2. If not found, return `"image not found: <ref>"`
+3. Call `c.store.Untag(ctx, ref)` to remove the tag
+4. Return wrapped error on failure
+
+No blob cleanup — unreferenced blobs are cleaned up by
+`skillctl prune`.
+
+### Confirmation prompt
+
+Read from `os.Stdin` using `bufio.Scanner`. Accept `y` or `Y` as
+confirmation; anything else (including empty input) is treated as
+decline. This matches the `[y/N]` convention where N is the default.
+
+### Error handling
+
+| Scenario | Behavior |
+| -------- | -------- |
+| Ref not found | Print error, continue with remaining refs |
+| Untag failure | Print error, continue with remaining refs |
+| All refs fail | Exit code 1 |
+| Some refs fail | Print successes and errors, exit code 1 |
+| User declines confirmation | Exit code 0, no action |
+
+### Testing
+
+**Unit tests** in `pkg/oci/remove_test.go`:
+
+- Build an image, remove by ref, verify absent from `ListLocal()`
+- Remove a non-existent ref, verify error message
+- Remove multiple refs (mix of valid and invalid), verify partial
+  success behavior
+
+Tests follow the existing pattern in `pkg/oci/` — create a temp
+store, build test images, then exercise removal.
+
+## Alternatives considered
+
+**Direct store access in CLI:** Skip the `Client.Remove()` method
+and call `store.Untag()` from the CLI. Rejected because it breaks
+the established pattern where CLI calls client methods.
+
+**Service layer abstraction:** Create a `RemoveService` in
+`internal/service/`. Rejected as over-engineered for a simple
+untag operation.
+
+**Auto GC after removal:** Run garbage collection automatically
+after untagging. Rejected to keep `rm` fast and predictable,
+consistent with container tooling conventions.

--- a/dev/specs/2026-04-30-rm-delete-command-design.md
+++ b/dev/specs/2026-04-30-rm-delete-command-design.md
@@ -23,7 +23,7 @@ reference. Users need a way to remove individual images.
 
 **File:** `internal/cli/rm.go`
 
-```
+```text
 skillctl rm <ref> [<ref>...] [flags]
 ```
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newRmCmd() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "rm <ref> [<ref>...]",
+		Aliases: []string{"delete"},
+		Short:   "Remove skill images from local store",
+		Long: `Remove one or more skill images from the local store by
+tag reference (e.g., test/hello-world:1.0.0-draft).
+
+Does not clean up unreferenced blobs — run 'skillctl prune'
+after removal to reclaim disk space.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRm(cmd, args, force)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "skip confirmation prompt")
+	return cmd
+}
+
+func runRm(cmd *cobra.Command, refs []string, force bool) error {
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Resolve all refs first to report errors before confirming.
+	images, err := client.ListLocal()
+	if err != nil {
+		return fmt.Errorf("listing images: %w", err)
+	}
+	knownRefs := make(map[string]bool, len(images))
+	for _, img := range images {
+		knownRefs[img.Name+":"+img.Tag] = true
+	}
+
+	var valid []string
+	var hadErrors bool
+	for _, ref := range refs {
+		if !knownRefs[ref] {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: image not found: %s\n", ref)
+			hadErrors = true
+			continue
+		}
+		valid = append(valid, ref)
+	}
+
+	if len(valid) == 0 {
+		if hadErrors {
+			return fmt.Errorf("no valid images to remove")
+		}
+		return nil
+	}
+
+	// Confirm unless --force.
+	if !force {
+		if len(valid) == 1 {
+			fmt.Fprintf(cmd.OutOrStdout(), "Remove %s? [y/N] ", valid[0])
+		} else {
+			for _, ref := range valid {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", ref)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Remove %d image(s)? [y/N] ", len(valid))
+		}
+
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return nil
+		}
+		answer := strings.TrimSpace(scanner.Text())
+		if answer != "y" && answer != "Y" {
+			fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+			return nil
+		}
+	}
+
+	// Remove each valid ref.
+	for _, ref := range valid {
+		if err := client.Remove(ctx, ref); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			hadErrors = true
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed %s\n", ref)
+	}
+
+	if hadErrors {
+		return fmt.Errorf("some images could not be removed")
+	}
+	return nil
+}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -81,6 +81,9 @@ func runRm(cmd *cobra.Command, refs []string, force bool) error {
 
 		scanner := bufio.NewScanner(os.Stdin)
 		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("reading confirmation: %w", err)
+			}
 			return nil
 		}
 		answer := strings.TrimSpace(scanner.Text())

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -2,9 +2,7 @@ package cli
 
 import (
 	"bufio"
-	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -38,7 +36,7 @@ func runRm(cmd *cobra.Command, refs []string, force bool) error {
 		return err
 	}
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 
 	// Resolve all refs first to report errors before confirming.
 	images, err := client.ListLocal()
@@ -79,7 +77,7 @@ func runRm(cmd *cobra.Command, refs []string, force bool) error {
 			fmt.Fprintf(cmd.OutOrStdout(), "Remove %d image(s)? [y/N] ", len(valid))
 		}
 
-		scanner := bufio.NewScanner(os.Stdin)
+		scanner := bufio.NewScanner(cmd.InOrStdin())
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				return fmt.Errorf("reading confirmation: %w", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ func NewRootCmd(version string) *cobra.Command {
 	cmd.AddCommand(newInstallCmd())
 	cmd.AddCommand(newTagCmd())
 	cmd.AddCommand(newPruneCmd())
+	cmd.AddCommand(newRmCmd())
 	cmd.AddCommand(newServeCmd())
 	cmd.AddCommand(newCollectionCmd())
 

--- a/pkg/oci/remove.go
+++ b/pkg/oci/remove.go
@@ -8,6 +8,9 @@ import (
 	"oras.land/oras-go/v2/errdef"
 )
 
+// Remove removes a skill image from the local store by its tag reference
+// (e.g., "test/test-skill:1.0.0-draft"). Unreferenced blobs are not
+// cleaned up; use Prune for that.
 func (c *Client) Remove(ctx context.Context, ref string) error {
 	if _, err := c.store.Resolve(ctx, ref); err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {

--- a/pkg/oci/remove.go
+++ b/pkg/oci/remove.go
@@ -1,0 +1,24 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"oras.land/oras-go/v2/errdef"
+)
+
+func (c *Client) Remove(ctx context.Context, ref string) error {
+	if _, err := c.store.Resolve(ctx, ref); err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return fmt.Errorf("image not found: %s", ref)
+		}
+		return fmt.Errorf("resolving %s: %w", ref, err)
+	}
+
+	if err := c.store.Untag(ctx, ref); err != nil {
+		return fmt.Errorf("removing %s: %w", ref, err)
+	}
+
+	return nil
+}

--- a/pkg/oci/remove_test.go
+++ b/pkg/oci/remove_test.go
@@ -1,0 +1,124 @@
+package oci_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+)
+
+func TestRemove(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	err = client.Remove(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 0 {
+		t.Errorf("expected 0 images after remove, got %d", len(images))
+	}
+}
+
+func TestRemoveNotFound(t *testing.T) {
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	err = client.Remove(context.Background(), "no/such-image:1.0.0")
+	if err == nil {
+		t.Fatal("expected error for non-existent image")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
+	}
+}
+
+func TestRemoveMultipleImages(t *testing.T) {
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Build first image
+	skillDir1 := t.TempDir()
+	writeTestSkill(t, skillDir1)
+	_, err = client.Build(ctx, skillDir1, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build first: %v", err)
+	}
+
+	// Build second image with different name
+	skillDir2 := t.TempDir()
+	writeTestSkillNamed(t, skillDir2, "other-skill")
+	_, err = client.Build(ctx, skillDir2, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build second: %v", err)
+	}
+
+	// Remove only the first
+	err = client.Remove(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	images, err := client.ListLocal()
+	if err != nil {
+		t.Fatalf("ListLocal: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image after remove, got %d", len(images))
+	}
+	if images[0].Name != "test/other-skill" {
+		t.Errorf("remaining image = %q, want %q", images[0].Name, "test/other-skill")
+	}
+}
+
+func writeTestSkillNamed(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillYAML := []byte(fmt.Sprintf(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: %s
+  namespace: test
+  version: 1.0.0
+  description: A test skill.
+spec:
+  prompt: SKILL.md
+`, name))
+	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), skillYAML, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Test prompt."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/oci/remove_test.go
+++ b/pkg/oci/remove_test.go
@@ -105,7 +105,7 @@ func writeTestSkillNamed(t *testing.T, dir, name string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	skillYAML := []byte(fmt.Sprintf(`apiVersion: skillimage.io/v1alpha1
+	skillYAML := fmt.Appendf(nil, `apiVersion: skillimage.io/v1alpha1
 kind: SkillCard
 metadata:
   name: %s
@@ -114,7 +114,7 @@ metadata:
   description: A test skill.
 spec:
   prompt: SKILL.md
-`, name))
+`, name)
 	if err := os.WriteFile(filepath.Join(dir, "skill.yaml"), skillYAML, 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Add `skillctl rm` (alias `delete`) to remove skill images from the local OCI store by name:tag reference
- Support multiple refs in a single invocation with confirmation prompt (skippable via `--force`)
- Add `Client.Remove()` method to `pkg/oci` backed by oras-go `Untag()`

Closes #22

## Design decisions

- Tag-based removal only (no digest or glob support in v1)
- Blob cleanup deferred to existing `skillctl prune`
- Pre-validates all refs before prompting for confirmation
- Partial failure: reports errors per-ref, continues with remaining, exits non-zero if any failed

## Test plan

- [x] `TestRemove` — build image, remove by ref, verify absent from ListLocal
- [x] `TestRemoveNotFound` — error on non-existent ref contains "not found"
- [x] `TestRemoveMultipleImages` — remove one of two images, verify other remains
- [x] `go test ./...` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `rm` command to remove locally stored skill images by name:tag reference
  * Supports removing multiple images in a single operation
  * Includes `--force` flag to skip confirmation prompts
  * Displays a confirmation prompt before removal (unless bypassed with `--force`)
  * Returns appropriate exit codes for success and partial/complete failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->