### PR TITLE
feat: provenance tracking and installed skills listing

### DIFF
--- a/dev/plans/2026-04-30-installed-skills-listing.md
+++ b/dev/plans/2026-04-30-installed-skills-listing.md
@@ -1,0 +1,861 @@
+# Provenance tracking and installed skills listing — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate provenance metadata during `skillctl install`
+and add `list --installed` to show installed skills across agent
+directories.
+
+**Architecture:** A `ResolveDigest()` method on `pkg/oci.Client`
+returns the digest for a local ref. The install command uses it
+to populate `Provenance.source` and `Provenance.commit` in
+`skill.yaml` after unpacking. A new `pkg/installed/` package
+scans agent target directories for installed skills. The `list`
+command gains `--installed`, `--target`, and `--output` flags.
+
+**Tech Stack:** Go, cobra, oras-go, yaml.v3
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `pkg/oci/resolve.go` | Create | `ResolveDigest` method |
+| `pkg/oci/resolve_test.go` | Create | Tests for `ResolveDigest` |
+| `internal/cli/install.go` | Modify | Write provenance after unpack |
+| `pkg/installed/installed.go` | Create | `InstalledSkill` type, `Scan` function |
+| `pkg/installed/installed_test.go` | Create | Tests for `Scan` |
+| `internal/cli/list.go` | Modify | Add `--installed`, `--target`, `-o` flags |
+
+---
+
+## Task 1: ResolveDigest — test
+
+**Files:**
+- Create: `pkg/oci/resolve_test.go`
+
+- [ ] **Step 1: Write TestResolveDigest**
+
+```go
+package oci_test
+
+import (
+    "context"
+    "strings"
+    "testing"
+
+    "github.com/redhat-et/skillimage/pkg/oci"
+)
+
+func TestResolveDigest(t *testing.T) {
+    skillDir := t.TempDir()
+    writeTestSkill(t, skillDir)
+
+    storeDir := t.TempDir()
+    client, err := oci.NewClient(storeDir)
+    if err != nil {
+        t.Fatalf("NewClient: %v", err)
+    }
+
+    ctx := context.Background()
+    _, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+    if err != nil {
+        t.Fatalf("Build: %v", err)
+    }
+
+    digest, err := client.ResolveDigest(ctx, "test/test-skill:1.0.0-draft")
+    if err != nil {
+        t.Fatalf("ResolveDigest: %v", err)
+    }
+    if !strings.HasPrefix(digest, "sha256:") {
+        t.Errorf("digest = %q, want sha256: prefix", digest)
+    }
+}
+```
+
+- [ ] **Step 2: Write TestResolveDigestNotFound**
+
+```go
+func TestResolveDigestNotFound(t *testing.T) {
+    storeDir := t.TempDir()
+    client, err := oci.NewClient(storeDir)
+    if err != nil {
+        t.Fatalf("NewClient: %v", err)
+    }
+
+    _, err = client.ResolveDigest(context.Background(), "no/such:1.0.0")
+    if err == nil {
+        t.Fatal("expected error for non-existent ref")
+    }
+    if !strings.Contains(err.Error(), "not found") {
+        t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./pkg/oci/ -run "TestResolveDigest" -v`
+
+Expected: compilation failure — `client.ResolveDigest` undefined.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/oci/resolve_test.go
+git commit -s -m "test: add failing tests for Client.ResolveDigest"
+```
+
+---
+
+## Task 2: ResolveDigest — implementation
+
+**Files:**
+- Create: `pkg/oci/resolve.go`
+
+- [ ] **Step 1: Implement ResolveDigest**
+
+```go
+package oci
+
+import (
+    "context"
+    "errors"
+    "fmt"
+
+    "oras.land/oras-go/v2/errdef"
+)
+
+// ResolveDigest returns the digest of a locally stored image
+// identified by its tag reference.
+func (c *Client) ResolveDigest(ctx context.Context, ref string) (string, error) {
+    desc, err := c.store.Resolve(ctx, ref)
+    if err != nil {
+        if errors.Is(err, errdef.ErrNotFound) {
+            return "", fmt.Errorf("image not found: %s", ref)
+        }
+        return "", fmt.Errorf("resolving %s: %w", ref, err)
+    }
+    return desc.Digest.String(), nil
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./pkg/oci/ -run "TestResolveDigest" -v`
+
+Expected: both tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/oci/resolve.go
+git commit -s -m "feat: add Client.ResolveDigest for local ref lookup"
+```
+
+---
+
+## Task 3: Install provenance — test and implementation
+
+**Files:**
+- Modify: `internal/cli/install.go`
+
+This task modifies `runInstall` to write provenance into
+`skill.yaml` after unpacking. Since the install command is a CLI
+function (not a library method), we test it end-to-end at the
+`pkg/oci` level by verifying the provenance flow: build, unpack,
+read back, check fields.
+
+- [ ] **Step 1: Write TestInstallProvenance in pkg/oci/resolve_test.go**
+
+Add this test to `pkg/oci/resolve_test.go` (it tests the
+provenance write-back flow using the same build/unpack pattern
+the install command uses):
+
+```go
+func TestInstallProvenance(t *testing.T) {
+    skillDir := t.TempDir()
+    writeTestSkill(t, skillDir)
+
+    storeDir := t.TempDir()
+    client, err := oci.NewClient(storeDir)
+    if err != nil {
+        t.Fatalf("NewClient: %v", err)
+    }
+
+    ctx := context.Background()
+    _, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+    if err != nil {
+        t.Fatalf("Build: %v", err)
+    }
+
+    ref := "test/test-skill:1.0.0-draft"
+
+    // Unpack to a temp dir (simulates install).
+    outputDir := t.TempDir()
+    err = client.Unpack(ctx, ref, outputDir)
+    if err != nil {
+        t.Fatalf("Unpack: %v", err)
+    }
+
+    // Resolve digest.
+    digest, err := client.ResolveDigest(ctx, ref)
+    if err != nil {
+        t.Fatalf("ResolveDigest: %v", err)
+    }
+
+    // Read skill.yaml back, set provenance, write it back.
+    skillPath := filepath.Join(outputDir, "test-skill", "skill.yaml")
+    f, err := os.Open(skillPath)
+    if err != nil {
+        t.Fatalf("opening skill.yaml: %v", err)
+    }
+    sc, err := skillcard.Parse(f)
+    f.Close()
+    if err != nil {
+        t.Fatalf("parsing skill.yaml: %v", err)
+    }
+
+    if sc.Provenance == nil {
+        sc.Provenance = &skillcard.Provenance{}
+    }
+    sc.Provenance.Source = ref
+    sc.Provenance.Commit = digest
+
+    wf, err := os.Create(skillPath)
+    if err != nil {
+        t.Fatalf("creating skill.yaml for write: %v", err)
+    }
+    err = skillcard.Serialize(sc, wf)
+    wf.Close()
+    if err != nil {
+        t.Fatalf("serializing skill.yaml: %v", err)
+    }
+
+    // Read it back and verify provenance fields.
+    f2, err := os.Open(skillPath)
+    if err != nil {
+        t.Fatalf("re-opening skill.yaml: %v", err)
+    }
+    defer f2.Close()
+    sc2, err := skillcard.Parse(f2)
+    if err != nil {
+        t.Fatalf("re-parsing skill.yaml: %v", err)
+    }
+
+    if sc2.Provenance == nil {
+        t.Fatal("expected provenance to be set")
+    }
+    if sc2.Provenance.Source != ref {
+        t.Errorf("source = %q, want %q", sc2.Provenance.Source, ref)
+    }
+    if sc2.Provenance.Commit != digest {
+        t.Errorf("commit = %q, want %q", sc2.Provenance.Commit, digest)
+    }
+}
+```
+
+Add `"os"`, `"path/filepath"`, and
+`"github.com/redhat-et/skillimage/pkg/skillcard"` to the imports
+(skillcard is already imported in oci_test.go's package — this
+file is in the same package `oci_test`).
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./pkg/oci/ -run "TestInstallProvenance" -v`
+
+Expected: PASS (the test exercises Parse/Serialize, not the
+install CLI — this verifies the provenance roundtrip works).
+
+- [ ] **Step 3: Modify runInstall to write provenance**
+
+In `internal/cli/install.go`, update `runInstall`. The new
+function body replaces the current one:
+
+```go
+func runInstall(cmd *cobra.Command, ref string, target string, outputDir string) error {
+    if target == "" && outputDir == "" {
+        return fmt.Errorf("specify --target <agent> or -o <directory>")
+    }
+    if target != "" && outputDir != "" {
+        return fmt.Errorf("use --target or -o, not both")
+    }
+
+    if target != "" {
+        relPath, ok := agentTargets[strings.ToLower(target)]
+        if !ok {
+            var names []string
+            for k := range agentTargets {
+                names = append(names, k)
+            }
+            return fmt.Errorf("unknown target %q (supported: %s)", target, strings.Join(names, ", "))
+        }
+        home, err := os.UserHomeDir()
+        if err != nil {
+            return fmt.Errorf("finding home directory: %w", err)
+        }
+        outputDir = filepath.Join(home, relPath)
+    }
+
+    if err := os.MkdirAll(outputDir, 0o755); err != nil {
+        return fmt.Errorf("creating directory %s: %w", outputDir, err)
+    }
+
+    client, err := defaultClient()
+    if err != nil {
+        return err
+    }
+
+    ctx := cmd.Context()
+    if err := client.Unpack(ctx, ref, outputDir); err != nil {
+        return fmt.Errorf("installing %s: %w", ref, err)
+    }
+
+    // Extract skill name for path and output message.
+    skillName := ref
+    if idx := strings.LastIndex(ref, "/"); idx >= 0 {
+        skillName = ref[idx+1:]
+    }
+    if idx := strings.LastIndex(skillName, ":"); idx >= 0 {
+        skillName = skillName[:idx]
+    }
+    dest := filepath.Join(outputDir, skillName)
+
+    // Write provenance into skill.yaml.
+    if err := writeProvenance(ctx, client, ref, dest); err != nil {
+        return fmt.Errorf("writing provenance: %w", err)
+    }
+
+    fmt.Fprintf(cmd.OutOrStdout(), "Installed %s to %s\n", ref, dest)
+    return nil
+}
+```
+
+Add the `writeProvenance` helper function below `runInstall`:
+
+```go
+func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir string) error {
+    digest, err := client.ResolveDigest(ctx, ref)
+    if err != nil {
+        return err
+    }
+
+    skillPath := filepath.Join(skillDir, "skill.yaml")
+    f, err := os.Open(skillPath)
+    if err != nil {
+        return fmt.Errorf("opening skill.yaml: %w", err)
+    }
+    sc, err := skillcard.Parse(f)
+    f.Close()
+    if err != nil {
+        return fmt.Errorf("parsing skill.yaml: %w", err)
+    }
+
+    if sc.Provenance == nil {
+        sc.Provenance = &skillcard.Provenance{}
+    }
+    sc.Provenance.Source = ref
+    sc.Provenance.Commit = digest
+
+    wf, err := os.Create(skillPath)
+    if err != nil {
+        return fmt.Errorf("creating skill.yaml: %w", err)
+    }
+    defer wf.Close()
+    return skillcard.Serialize(sc, wf)
+}
+```
+
+Update the imports in `install.go`:
+
+```go
+import (
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "github.com/spf13/cobra"
+
+    "github.com/redhat-et/skillimage/pkg/oci"
+    "github.com/redhat-et/skillimage/pkg/skillcard"
+)
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `go build ./cmd/skillctl/`
+
+Expected: clean build.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/install.go pkg/oci/resolve_test.go
+git commit -s -m "feat: write provenance into skill.yaml during install"
+```
+
+---
+
+## Task 4: Installed skills scanner — test
+
+**Files:**
+- Create: `pkg/installed/installed_test.go`
+
+- [ ] **Step 1: Write TestScan**
+
+```go
+package installed_test
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+
+    "github.com/redhat-et/skillimage/pkg/installed"
+)
+
+func writeSkillYAML(t *testing.T, dir, name, version, source, commit string) {
+    t.Helper()
+    skillDir := filepath.Join(dir, name)
+    if err := os.MkdirAll(skillDir, 0o755); err != nil {
+        t.Fatal(err)
+    }
+    yaml := "apiVersion: skillimage.io/v1alpha1\n" +
+        "kind: SkillCard\n" +
+        "metadata:\n" +
+        "  name: " + name + "\n" +
+        "  namespace: test\n" +
+        "  version: " + version + "\n" +
+        "  description: A test skill.\n" +
+        "spec:\n" +
+        "  prompt: SKILL.md\n"
+    if source != "" {
+        yaml += "provenance:\n" +
+            "  source: " + source + "\n" +
+            "  commit: " + commit + "\n"
+    }
+    if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), []byte(yaml), 0o644); err != nil {
+        t.Fatal(err)
+    }
+}
+
+func TestScan(t *testing.T) {
+    claudeDir := t.TempDir()
+    cursorDir := t.TempDir()
+
+    writeSkillYAML(t, claudeDir, "hello-world", "1.0.0",
+        "test/hello-world:1.0.0-draft", "sha256:abc123")
+    writeSkillYAML(t, cursorDir, "summarizer", "2.0.0", "", "")
+
+    targets := map[string]string{
+        "claude": claudeDir,
+        "cursor": cursorDir,
+    }
+
+    skills, err := installed.Scan(targets)
+    if err != nil {
+        t.Fatalf("Scan: %v", err)
+    }
+    if len(skills) != 2 {
+        t.Fatalf("expected 2 skills, got %d", len(skills))
+    }
+
+    // Find the hello-world skill (has provenance).
+    var hw, sm *installed.InstalledSkill
+    for i := range skills {
+        switch skills[i].Name {
+        case "hello-world":
+            hw = &skills[i]
+        case "summarizer":
+            sm = &skills[i]
+        }
+    }
+
+    if hw == nil {
+        t.Fatal("hello-world skill not found")
+    }
+    if hw.Version != "1.0.0" {
+        t.Errorf("hw version = %q, want %q", hw.Version, "1.0.0")
+    }
+    if hw.Source != "test/hello-world:1.0.0-draft" {
+        t.Errorf("hw source = %q, want %q", hw.Source, "test/hello-world:1.0.0-draft")
+    }
+    if hw.Target != "claude" {
+        t.Errorf("hw target = %q, want %q", hw.Target, "claude")
+    }
+
+    if sm == nil {
+        t.Fatal("summarizer skill not found")
+    }
+    if sm.Source != "" {
+        t.Errorf("sm source = %q, want empty (local)", sm.Source)
+    }
+    if sm.Target != "cursor" {
+        t.Errorf("sm target = %q, want %q", sm.Target, "cursor")
+    }
+}
+```
+
+- [ ] **Step 2: Write TestScanNonExistentDir**
+
+```go
+func TestScanNonExistentDir(t *testing.T) {
+    targets := map[string]string{
+        "claude": "/nonexistent/path/that/does/not/exist",
+    }
+
+    skills, err := installed.Scan(targets)
+    if err != nil {
+        t.Fatalf("Scan should not error on missing dir: %v", err)
+    }
+    if len(skills) != 0 {
+        t.Errorf("expected 0 skills, got %d", len(skills))
+    }
+}
+```
+
+- [ ] **Step 3: Write TestScanMalformedSkillYAML**
+
+```go
+func TestScanMalformedSkillYAML(t *testing.T) {
+    dir := t.TempDir()
+    skillDir := filepath.Join(dir, "bad-skill")
+    if err := os.MkdirAll(skillDir, 0o755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.WriteFile(
+        filepath.Join(skillDir, "skill.yaml"),
+        []byte("this is not valid yaml: [[["),
+        0o644,
+    ); err != nil {
+        t.Fatal(err)
+    }
+
+    targets := map[string]string{"claude": dir}
+    skills, err := installed.Scan(targets)
+    if err != nil {
+        t.Fatalf("Scan should not error on malformed yaml: %v", err)
+    }
+    if len(skills) != 0 {
+        t.Errorf("expected 0 skills (malformed skipped), got %d", len(skills))
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./pkg/installed/ -v`
+
+Expected: compilation failure — package does not exist.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/installed/installed_test.go
+git commit -s -m "test: add failing tests for installed skills scanner"
+```
+
+---
+
+## Task 5: Installed skills scanner — implementation
+
+**Files:**
+- Create: `pkg/installed/installed.go`
+
+- [ ] **Step 1: Implement the InstalledSkill type and Scan function**
+
+```go
+package installed
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+
+    "github.com/redhat-et/skillimage/pkg/skillcard"
+)
+
+// InstalledSkill holds metadata for a skill installed to an agent directory.
+type InstalledSkill struct {
+    Name    string
+    Version string
+    Source  string
+    Digest  string
+    Target  string
+    Path    string
+}
+
+// Scan reads agent target directories and returns metadata for each
+// installed skill. targets maps target names (e.g., "claude") to
+// directory paths. Directories that don't exist are silently skipped.
+// Malformed skill.yaml files are skipped with a warning to stderr.
+func Scan(targets map[string]string) ([]InstalledSkill, error) {
+    var skills []InstalledSkill
+
+    for target, dir := range targets {
+        entries, err := os.ReadDir(dir)
+        if err != nil {
+            if os.IsNotExist(err) {
+                continue
+            }
+            return nil, fmt.Errorf("reading %s: %w", dir, err)
+        }
+
+        for _, entry := range entries {
+            if !entry.IsDir() {
+                continue
+            }
+
+            skillPath := filepath.Join(dir, entry.Name(), "skill.yaml")
+            f, err := os.Open(skillPath)
+            if err != nil {
+                continue
+            }
+
+            sc, err := skillcard.Parse(f)
+            f.Close()
+            if err != nil {
+                fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", skillPath, err)
+                continue
+            }
+
+            skill := InstalledSkill{
+                Name:    sc.Metadata.Name,
+                Version: sc.Metadata.Version,
+                Target:  target,
+                Path:    filepath.Join(dir, entry.Name()),
+            }
+            if sc.Provenance != nil {
+                skill.Source = sc.Provenance.Source
+                skill.Digest = sc.Provenance.Commit
+            }
+
+            skills = append(skills, skill)
+        }
+    }
+
+    return skills, nil
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./pkg/installed/ -v`
+
+Expected: all three tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/installed/installed.go
+git commit -s -m "feat: add installed skills scanner package"
+```
+
+---
+
+## Task 6: list --installed flags and output
+
+**Files:**
+- Modify: `internal/cli/list.go`
+
+- [ ] **Step 1: Rewrite list.go with new flags**
+
+Replace the entire file content:
+
+```go
+package cli
+
+import (
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+    "text/tabwriter"
+
+    "github.com/spf13/cobra"
+
+    "github.com/redhat-et/skillimage/pkg/installed"
+)
+
+func newListCmd() *cobra.Command {
+    var showInstalled bool
+    var target string
+    var outputDir string
+
+    cmd := &cobra.Command{
+        Use:     "list",
+        Aliases: []string{"ls"},
+        Short:   "List skill images in local store",
+        Long: `List skill images stored locally, or show installed skills
+across agent directories.
+
+Without --installed, lists images in the local OCI store.
+With --installed, scans agent skill directories for installed skills.
+
+Supported targets for --installed:
+  claude    ~/.claude/skills/
+  cursor    ~/.cursor/skills/
+  windsurf  ~/.codeium/windsurf/skills/
+  opencode  ~/.config/opencode/skills/
+  openclaw  ~/.openclaw/skills/`,
+        Args: cobra.NoArgs,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            if showInstalled {
+                return runListInstalled(cmd, target, outputDir)
+            }
+            return runList(cmd)
+        },
+    }
+
+    cmd.Flags().BoolVarP(&showInstalled, "installed", "i", false, "list installed skills")
+    cmd.Flags().StringVarP(&target, "target", "t", "", "filter to a specific agent target")
+    cmd.Flags().StringVarP(&outputDir, "output", "o", "", "scan a custom directory")
+
+    return cmd
+}
+
+func runList(cmd *cobra.Command) error {
+    client, err := defaultClient()
+    if err != nil {
+        return err
+    }
+
+    images, err := client.ListLocal()
+    if err != nil {
+        return fmt.Errorf("listing images: %w", err)
+    }
+
+    if len(images) == 0 {
+        fmt.Fprintln(cmd.OutOrStdout(), "No images found in local store.")
+        return nil
+    }
+
+    w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+    fmt.Fprintln(w, "NAME\tTAG\tSTATUS\tDIGEST\tCREATED")
+    for _, img := range images {
+        shortDigest := img.Digest
+        if len(shortDigest) > 19 {
+            shortDigest = shortDigest[:19]
+        }
+        fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+            img.Name, img.Tag, img.Status, shortDigest, img.Created)
+    }
+    return w.Flush()
+}
+
+func runListInstalled(cmd *cobra.Command, target, outputDir string) error {
+    if target != "" && outputDir != "" {
+        return fmt.Errorf("use --target or -o, not both")
+    }
+
+    targets, err := resolveListTargets(target, outputDir)
+    if err != nil {
+        return err
+    }
+
+    skills, err := installed.Scan(targets)
+    if err != nil {
+        return fmt.Errorf("scanning installed skills: %w", err)
+    }
+
+    if len(skills) == 0 {
+        fmt.Fprintln(cmd.OutOrStdout(), "No installed skills found.")
+        return nil
+    }
+
+    w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+    fmt.Fprintln(w, "NAME\tVERSION\tSOURCE\tTARGET")
+    for _, s := range skills {
+        source := s.Source
+        if source == "" {
+            source = "(local)"
+        }
+        fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Name, s.Version, source, s.Target)
+    }
+    return w.Flush()
+}
+
+func resolveListTargets(target, outputDir string) (map[string]string, error) {
+    if outputDir != "" {
+        abs, err := filepath.Abs(outputDir)
+        if err != nil {
+            return nil, fmt.Errorf("resolving path: %w", err)
+        }
+        return map[string]string{outputDir: abs}, nil
+    }
+
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return nil, fmt.Errorf("finding home directory: %w", err)
+    }
+
+    if target != "" {
+        relPath, ok := agentTargets[strings.ToLower(target)]
+        if !ok {
+            var names []string
+            for k := range agentTargets {
+                names = append(names, k)
+            }
+            return nil, fmt.Errorf("unknown target %q (supported: %s)", target, strings.Join(names, ", "))
+        }
+        return map[string]string{target: filepath.Join(home, relPath)}, nil
+    }
+
+    targets := make(map[string]string, len(agentTargets))
+    for name, relPath := range agentTargets {
+        targets[name] = filepath.Join(home, relPath)
+    }
+    return targets, nil
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./cmd/skillctl/`
+
+Expected: clean build.
+
+- [ ] **Step 3: Run linter**
+
+Run: `make lint`
+
+Expected: no new warnings.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cli/list.go
+git commit -s -m "feat: add list --installed to show installed skills
+
+Closes #27 (partially)"
+```

--- a/dev/specs/2026-04-30-installed-skills-listing-design.md
+++ b/dev/specs/2026-04-30-installed-skills-listing-design.md
@@ -1,0 +1,147 @@
+# Provenance tracking and installed skills listing
+
+## Summary
+
+Populate OCI provenance metadata during `skillctl install` so
+installed skills know where they came from, then add
+`list --installed` to show what's installed across agent target
+directories.
+
+This is sub-project 1 of issue #27. Sub-project 2 (upgrade
+command) depends on this and will be designed separately.
+
+Closes #27 (partially).
+
+## Motivation
+
+Once a user pulls and installs skills, there's no way to see
+what's installed or where it came from. The `Provenance` struct
+in `skill.yaml` already has the right fields (`source`, `commit`,
+`path`) but they're not populated during install. This work
+populates them and adds a listing command to surface the
+information.
+
+## Design
+
+### Provenance tracking during install
+
+**Current flow:** `runInstall` calls `client.Unpack(ctx, ref, dir)`
+which extracts files to disk. No metadata is written about the
+source image.
+
+**New flow:** After `Unpack`, the install command:
+
+1. Resolves the ref's digest via `client.ResolveDigest(ctx, ref)`
+2. Reads `skill.yaml` from the unpacked skill directory
+3. Sets `Provenance.source` to the OCI ref (e.g.,
+   `quay.io/skills/summarize:2.1.0`)
+4. Sets `Provenance.commit` to the image digest (e.g.,
+   `sha256:abc123...`)
+5. Writes the updated `skill.yaml` back to disk
+
+**New client method:**
+
+```go
+// File: pkg/oci/resolve.go
+func (c *Client) ResolveDigest(ctx context.Context, ref string) (string, error)
+```
+
+Returns the digest string for a ref in the local store. Calls
+`c.store.Resolve(ctx, ref)` and returns `desc.Digest.String()`.
+
+**Field mapping:**
+
+| Provenance field | Value | Example |
+|------------------|-------|---------|
+| `source` | Full OCI reference | `quay.io/skills/summarize:2.1.0` |
+| `commit` | Image digest | `sha256:abc123...` |
+| `path` | Not set by install | (preserved if already set) |
+
+The `path` field is populated by the Git source builder
+(`pkg/source/`) and is unrelated to OCI installs.
+
+### Installed skills listing
+
+**New flags on `list` command:**
+
+| Flag | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--installed` | `-i` | bool | false | List installed skills |
+| `--target` | `-t` | string | `""` | Filter to a specific agent |
+| `--output` | `-o` | string | `""` | Scan a custom directory |
+
+Flag interactions:
+
+- Without `--installed`: current behavior (local OCI store),
+  `--target` and `-o` are ignored
+- `--installed` alone: scan all known agent target directories
+- `--installed --target claude`: scan only Claude's skill dir
+- `--installed -o ~/myskills`: scan a custom directory
+- `--target` and `-o` are mutually exclusive (same as install)
+
+**New package: `pkg/installed/`**
+
+```go
+// File: pkg/installed/installed.go
+
+type InstalledSkill struct {
+    Name    string // skill name from metadata
+    Version string // version from metadata
+    Source  string // OCI ref from provenance (empty if local)
+    Digest  string // image digest from provenance
+    Target  string // agent name or directory path
+    Path    string // full filesystem path to skill directory
+}
+
+func Scan(targets map[string]string) ([]InstalledSkill, error)
+```
+
+`Scan` takes a map of `{targetName: dirPath}` and for each
+directory, looks for `*/skill.yaml` one level deep. Parses each
+`skill.yaml` and returns `InstalledSkill` entries. Directories
+that don't exist are silently skipped (agent not installed).
+
+**Output format:**
+
+```text
+NAME              VERSION  SOURCE                              TARGET
+hello-world       1.0.0    test/hello-world:1.0.0-draft        claude
+my-summarizer     2.1.0    quay.io/skills/summarize:2.1.0      cursor
+local-skill       1.0.0    (local)                             ~/myskills
+```
+
+Skills without provenance source show `(local)`.
+
+### Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| skill.yaml missing after unpack | Error from install (should not happen) |
+| skill.yaml unparseable after unpack | Error from install |
+| Serialize fails writing back | Error from install |
+| Target dir doesn't exist (listing) | Skip silently |
+| Malformed skill.yaml in target dir | Skip, print warning to stderr |
+| No installed skills found | Print "No installed skills found." |
+
+### Testing
+
+**`pkg/oci/resolve.go`** — unit test:
+- Build an image, call `ResolveDigest`, verify non-empty digest
+- Call `ResolveDigest` on non-existent ref, verify error
+
+**`pkg/installed/installed.go`** — unit test:
+- Create temp dirs with skill.yaml files (with and without
+  provenance), call `Scan`, verify results
+- Scan with non-existent directory, verify no error
+- Scan with malformed skill.yaml, verify it's skipped
+
+**Install provenance** — unit test:
+- Use existing test patterns: build image, unpack, verify
+  skill.yaml contains provenance after the install flow
+
+## Out of scope
+
+- `--upgradable` flag (sub-project 2)
+- `upgrade` command (sub-project 2)
+- Digest-based version comparison
+- Remote registry queries during listing

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -90,15 +90,7 @@ func runInstall(cmd *cobra.Command, ref string, target string, outputDir string)
 		return fmt.Errorf("installing %s: %w", ref, err)
 	}
 
-	// Extract skill name for path and output message.
-	skillName := ref
-	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
-		skillName = ref[idx+1:]
-	}
-	if idx := strings.LastIndex(skillName, ":"); idx >= 0 {
-		skillName = skillName[:idx]
-	}
-	dest := filepath.Join(outputDir, skillName)
+	dest := filepath.Join(outputDir, oci.SkillNameFromRef(ref))
 
 	// Write provenance into skill.yaml.
 	if err := writeProvenance(ctx, client, ref, dest); err != nil {
@@ -147,14 +139,13 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 }
 
 func newSkillCardFromRef(ref string) *skillcard.SkillCard {
-	name := ref
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		name = name[idx+1:]
-	}
+	name := oci.SkillNameFromRef(ref)
+
 	version := "unknown"
-	if idx := strings.LastIndex(name, ":"); idx >= 0 {
-		version = name[idx+1:]
-		name = name[:idx]
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		version = ref[idx+1:]
+	} else if idx := strings.LastIndex(ref, ":"); idx >= 0 {
+		version = ref[idx+1:]
 	}
 
 	namespace := "unknown"

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 var agentTargets = map[string]string{
@@ -82,11 +85,12 @@ func runInstall(cmd *cobra.Command, ref string, target string, outputDir string)
 		return err
 	}
 
-	if err := client.Unpack(context.Background(), ref, outputDir); err != nil {
+	ctx := cmd.Context()
+	if err := client.Unpack(ctx, ref, outputDir); err != nil {
 		return fmt.Errorf("installing %s: %w", ref, err)
 	}
 
-	// Extract skill name for the output message
+	// Extract skill name for path and output message.
 	skillName := ref
 	if idx := strings.LastIndex(ref, "/"); idx >= 0 {
 		skillName = ref[idx+1:]
@@ -94,8 +98,44 @@ func runInstall(cmd *cobra.Command, ref string, target string, outputDir string)
 	if idx := strings.LastIndex(skillName, ":"); idx >= 0 {
 		skillName = skillName[:idx]
 	}
-
 	dest := filepath.Join(outputDir, skillName)
+
+	// Write provenance into skill.yaml.
+	if err := writeProvenance(ctx, client, ref, dest); err != nil {
+		return fmt.Errorf("writing provenance: %w", err)
+	}
+
 	fmt.Fprintf(cmd.OutOrStdout(), "Installed %s to %s\n", ref, dest)
 	return nil
+}
+
+func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir string) error {
+	digest, err := client.ResolveDigest(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	skillPath := filepath.Join(skillDir, "skill.yaml")
+	f, err := os.Open(skillPath)
+	if err != nil {
+		return fmt.Errorf("opening skill.yaml: %w", err)
+	}
+	sc, err := skillcard.Parse(f)
+	f.Close()
+	if err != nil {
+		return fmt.Errorf("parsing skill.yaml: %w", err)
+	}
+
+	if sc.Provenance == nil {
+		sc.Provenance = &skillcard.Provenance{}
+	}
+	sc.Provenance.Source = ref
+	sc.Provenance.Commit = digest
+
+	wf, err := os.Create(skillPath)
+	if err != nil {
+		return fmt.Errorf("creating skill.yaml: %w", err)
+	}
+	defer wf.Close()
+	return skillcard.Serialize(sc, wf)
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -116,17 +116,20 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 	}
 
 	skillPath := filepath.Join(skillDir, "skill.yaml")
+	var sc *skillcard.SkillCard
+
 	f, err := os.Open(skillPath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("opening skill.yaml: %w", err)
 		}
-		return fmt.Errorf("opening skill.yaml: %w", err)
-	}
-	sc, err := skillcard.Parse(f)
-	_ = f.Close()
-	if err != nil {
-		return fmt.Errorf("parsing skill.yaml: %w", err)
+		sc = newSkillCardFromRef(ref)
+	} else {
+		sc, err = skillcard.Parse(f)
+		_ = f.Close()
+		if err != nil {
+			return fmt.Errorf("parsing skill.yaml: %w", err)
+		}
 	}
 
 	if sc.Provenance == nil {
@@ -141,4 +144,32 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 	}
 	defer func() { _ = wf.Close() }()
 	return skillcard.Serialize(sc, wf)
+}
+
+func newSkillCardFromRef(ref string) *skillcard.SkillCard {
+	name := ref
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	version := "unknown"
+	if idx := strings.LastIndex(name, ":"); idx >= 0 {
+		version = name[idx+1:]
+		name = name[:idx]
+	}
+
+	namespace := "unknown"
+	if idx := strings.Index(ref, "/"); idx >= 0 {
+		namespace = ref[:idx]
+	}
+
+	return &skillcard.SkillCard{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCard",
+		Metadata: skillcard.Metadata{
+			Name:        name,
+			Namespace:   namespace,
+			Version:     version,
+			Description: "Installed from " + ref,
+		},
+	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -118,6 +118,9 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 	skillPath := filepath.Join(skillDir, "skill.yaml")
 	f, err := os.Open(skillPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return fmt.Errorf("opening skill.yaml: %w", err)
 	}
 	sc, err := skillcard.Parse(f)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -121,7 +121,7 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 		return fmt.Errorf("opening skill.yaml: %w", err)
 	}
 	sc, err := skillcard.Parse(f)
-	f.Close()
+	_ = f.Close()
 	if err != nil {
 		return fmt.Errorf("parsing skill.yaml: %w", err)
 	}
@@ -136,6 +136,6 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 	if err != nil {
 		return fmt.Errorf("creating skill.yaml: %w", err)
 	}
-	defer wf.Close()
+	defer func() { _ = wf.Close() }()
 	return skillcard.Serialize(sc, wf)
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestNewSkillCardFromRef(t *testing.T) {
+	tests := []struct {
+		ref       string
+		wantName  string
+		wantVer   string
+		wantNS    string
+	}{
+		{
+			ref:      "test/hello-world:1.0.0-draft",
+			wantName: "hello-world",
+			wantVer:  "1.0.0-draft",
+			wantNS:   "test",
+		},
+		{
+			ref:      "quay.io/skills/summarize:2.1.0",
+			wantName: "summarize",
+			wantVer:  "2.1.0",
+			wantNS:   "quay.io",
+		},
+		{
+			ref:      "skill:latest",
+			wantName: "skill",
+			wantVer:  "latest",
+			wantNS:   "unknown",
+		},
+		{
+			ref:      "ns/skill@sha256:abc123",
+			wantName: "skill",
+			wantVer:  "sha256:abc123",
+			wantNS:   "ns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			sc := newSkillCardFromRef(tt.ref)
+			if sc.Metadata.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", sc.Metadata.Name, tt.wantName)
+			}
+			if sc.Metadata.Version != tt.wantVer {
+				t.Errorf("version = %q, want %q", sc.Metadata.Version, tt.wantVer)
+			}
+			if sc.Metadata.Namespace != tt.wantNS {
+				t.Errorf("namespace = %q, want %q", sc.Metadata.Namespace, tt.wantNS)
+			}
+			if sc.APIVersion != "skillimage.io/v1alpha1" {
+				t.Errorf("apiVersion = %q, want %q", sc.APIVersion, "skillimage.io/v1alpha1")
+			}
+		})
+	}
+}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -112,6 +112,13 @@ func runListInstalled(cmd *cobra.Command, target, outputDir string) error {
 
 func resolveListTargets(target, outputDir string) (map[string]string, error) {
 	if outputDir != "" {
+		if strings.HasPrefix(outputDir, "~/") || outputDir == "~" {
+			h, err := os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("finding home directory: %w", err)
+			}
+			outputDir = filepath.Join(h, outputDir[1:])
+		}
 		abs, err := filepath.Abs(outputDir)
 		if err != nil {
 			return nil, fmt.Errorf("resolving path: %w", err)

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -2,22 +2,54 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
+	"github.com/redhat-et/skillimage/pkg/installed"
 )
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	var showInstalled bool
+	var target string
+	var outputDir string
+
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List skill images in local store",
-		Args:    cobra.NoArgs,
-		RunE:    runList,
+		Long: `List skill images stored locally, or show installed skills
+across agent directories.
+
+Without --installed, lists images in the local OCI store.
+With --installed, scans agent skill directories for installed skills.
+
+Supported targets for --installed:
+  claude    ~/.claude/skills/
+  cursor    ~/.cursor/skills/
+  windsurf  ~/.codeium/windsurf/skills/
+  opencode  ~/.config/opencode/skills/
+  openclaw  ~/.openclaw/skills/`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if showInstalled {
+				return runListInstalled(cmd, target, outputDir)
+			}
+			return runList(cmd)
+		},
 	}
+
+	cmd.Flags().BoolVarP(&showInstalled, "installed", "i", false, "list installed skills")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "filter to a specific agent target")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "scan a custom directory")
+
+	return cmd
 }
 
-func runList(cmd *cobra.Command, args []string) error {
+func runList(cmd *cobra.Command) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err
@@ -44,4 +76,69 @@ func runList(cmd *cobra.Command, args []string) error {
 			img.Name, img.Tag, img.Status, shortDigest, img.Created)
 	}
 	return w.Flush()
+}
+
+func runListInstalled(cmd *cobra.Command, target, outputDir string) error {
+	if target != "" && outputDir != "" {
+		return fmt.Errorf("use --target or -o, not both")
+	}
+
+	targets, err := resolveListTargets(target, outputDir)
+	if err != nil {
+		return err
+	}
+
+	skills, err := installed.Scan(targets)
+	if err != nil {
+		return fmt.Errorf("scanning installed skills: %w", err)
+	}
+
+	if len(skills) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No installed skills found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tVERSION\tSOURCE\tTARGET")
+	for _, s := range skills {
+		source := s.Source
+		if source == "" {
+			source = "(local)"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Name, s.Version, source, s.Target)
+	}
+	return w.Flush()
+}
+
+func resolveListTargets(target, outputDir string) (map[string]string, error) {
+	if outputDir != "" {
+		abs, err := filepath.Abs(outputDir)
+		if err != nil {
+			return nil, fmt.Errorf("resolving path: %w", err)
+		}
+		return map[string]string{outputDir: abs}, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("finding home directory: %w", err)
+	}
+
+	if target != "" {
+		relPath, ok := agentTargets[strings.ToLower(target)]
+		if !ok {
+			var names []string
+			for k := range agentTargets {
+				names = append(names, k)
+			}
+			return nil, fmt.Errorf("unknown target %q (supported: %s)", target, strings.Join(names, ", "))
+		}
+		return map[string]string{target: filepath.Join(home, relPath)}, nil
+	}
+
+	targets := make(map[string]string, len(agentTargets))
+	for name, relPath := range agentTargets {
+		targets[name] = filepath.Join(home, relPath)
+	}
+	return targets, nil
 }

--- a/pkg/installed/installed.go
+++ b/pkg/installed/installed.go
@@ -46,7 +46,7 @@ func Scan(targets map[string]string) ([]InstalledSkill, error) {
 			}
 
 			sc, err := skillcard.Parse(f)
-			f.Close()
+			_ = f.Close()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", skillPath, err)
 				continue

--- a/pkg/installed/installed.go
+++ b/pkg/installed/installed.go
@@ -1,0 +1,71 @@
+package installed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+)
+
+// InstalledSkill holds metadata for a skill installed to an agent directory.
+type InstalledSkill struct {
+	Name    string
+	Version string
+	Source  string
+	Digest  string
+	Target  string
+	Path    string
+}
+
+// Scan reads agent target directories and returns metadata for each
+// installed skill. targets maps target names (e.g., "claude") to
+// directory paths. Directories that don't exist are silently skipped.
+// Malformed skill.yaml files are skipped with a warning to stderr.
+func Scan(targets map[string]string) ([]InstalledSkill, error) {
+	var skills []InstalledSkill
+
+	for target, dir := range targets {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("reading %s: %w", dir, err)
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			skillPath := filepath.Join(dir, entry.Name(), "skill.yaml")
+			f, err := os.Open(skillPath)
+			if err != nil {
+				continue
+			}
+
+			sc, err := skillcard.Parse(f)
+			f.Close()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: skipping %s: %v\n", skillPath, err)
+				continue
+			}
+
+			skill := InstalledSkill{
+				Name:    sc.Metadata.Name,
+				Version: sc.Metadata.Version,
+				Target:  target,
+				Path:    filepath.Join(dir, entry.Name()),
+			}
+			if sc.Provenance != nil {
+				skill.Source = sc.Provenance.Source
+				skill.Digest = sc.Provenance.Commit
+			}
+
+			skills = append(skills, skill)
+		}
+	}
+
+	return skills, nil
+}

--- a/pkg/installed/installed.go
+++ b/pkg/installed/installed.go
@@ -1,9 +1,11 @@
 package installed
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
@@ -28,10 +30,10 @@ func Scan(targets map[string]string) ([]InstalledSkill, error) {
 	for target, dir := range targets {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
+			if !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Warning: cannot read %s: %v\n", dir, err)
 			}
-			return nil, fmt.Errorf("reading %s: %w", dir, err)
+			continue
 		}
 
 		for _, entry := range entries {
@@ -66,6 +68,13 @@ func Scan(targets map[string]string) ([]InstalledSkill, error) {
 			skills = append(skills, skill)
 		}
 	}
+
+	slices.SortFunc(skills, func(a, b InstalledSkill) int {
+		if c := cmp.Compare(a.Target, b.Target); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
 
 	return skills, nil
 }

--- a/pkg/installed/installed.go
+++ b/pkg/installed/installed.go
@@ -44,6 +44,9 @@ func Scan(targets map[string]string) ([]InstalledSkill, error) {
 			skillPath := filepath.Join(dir, entry.Name(), "skill.yaml")
 			f, err := os.Open(skillPath)
 			if err != nil {
+				if !os.IsNotExist(err) {
+					fmt.Fprintf(os.Stderr, "Warning: cannot read %s: %v\n", skillPath, err)
+				}
 				continue
 			}
 

--- a/pkg/installed/installed_test.go
+++ b/pkg/installed/installed_test.go
@@ -1,0 +1,128 @@
+package installed_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/installed"
+)
+
+func writeSkillYAML(t *testing.T, dir, name, version, source, commit string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "apiVersion: skillimage.io/v1alpha1\n" +
+		"kind: SkillCard\n" +
+		"metadata:\n" +
+		"  name: " + name + "\n" +
+		"  namespace: test\n" +
+		"  version: " + version + "\n" +
+		"  description: A test skill.\n" +
+		"spec:\n" +
+		"  prompt: SKILL.md\n"
+	if source != "" {
+		yaml += "provenance:\n" +
+			"  source: " + source + "\n" +
+			"  commit: " + commit + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "skill.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScan(t *testing.T) {
+	claudeDir := t.TempDir()
+	cursorDir := t.TempDir()
+
+	writeSkillYAML(t, claudeDir, "hello-world", "1.0.0",
+		"test/hello-world:1.0.0-draft", "sha256:abc123")
+	writeSkillYAML(t, cursorDir, "summarizer", "2.0.0", "", "")
+
+	targets := map[string]string{
+		"claude": claudeDir,
+		"cursor": cursorDir,
+	}
+
+	skills, err := installed.Scan(targets)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(skills))
+	}
+
+	// Find the hello-world skill (has provenance).
+	var hw, sm *installed.InstalledSkill
+	for i := range skills {
+		switch skills[i].Name {
+		case "hello-world":
+			hw = &skills[i]
+		case "summarizer":
+			sm = &skills[i]
+		}
+	}
+
+	if hw == nil {
+		t.Fatal("hello-world skill not found")
+	}
+	if hw.Version != "1.0.0" {
+		t.Errorf("hw version = %q, want %q", hw.Version, "1.0.0")
+	}
+	if hw.Source != "test/hello-world:1.0.0-draft" {
+		t.Errorf("hw source = %q, want %q", hw.Source, "test/hello-world:1.0.0-draft")
+	}
+	if hw.Target != "claude" {
+		t.Errorf("hw target = %q, want %q", hw.Target, "claude")
+	}
+
+	if sm == nil {
+		t.Fatal("summarizer skill not found")
+	}
+	if sm.Source != "" {
+		t.Errorf("sm source = %q, want empty (local)", sm.Source)
+	}
+	if sm.Target != "cursor" {
+		t.Errorf("sm target = %q, want %q", sm.Target, "cursor")
+	}
+}
+
+func TestScanNonExistentDir(t *testing.T) {
+	targets := map[string]string{
+		"claude": "/nonexistent/path/that/does/not/exist",
+	}
+
+	skills, err := installed.Scan(targets)
+	if err != nil {
+		t.Fatalf("Scan should not error on missing dir: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills, got %d", len(skills))
+	}
+}
+
+func TestScanMalformedSkillYAML(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "bad-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(skillDir, "skill.yaml"),
+		[]byte("this is not valid yaml: [[["),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := map[string]string{"claude": dir}
+	skills, err := installed.Scan(targets)
+	if err != nil {
+		t.Fatalf("Scan should not error on malformed yaml: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills (malformed skipped), got %d", len(skills))
+	}
+}

--- a/pkg/installed/installed_test.go
+++ b/pkg/installed/installed_test.go
@@ -91,7 +91,7 @@ func TestScan(t *testing.T) {
 
 func TestScanNonExistentDir(t *testing.T) {
 	targets := map[string]string{
-		"claude": "/nonexistent/path/that/does/not/exist",
+		"claude": filepath.Join(t.TempDir(), "does", "not", "exist"),
 	}
 
 	skills, err := installed.Scan(targets)

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -65,7 +65,7 @@ func (c *Client) Unpack(ctx context.Context, ref string, outputDir string) error
 	}
 
 	// 3. Extract skill name from the ref (last segment before :tag).
-	skillName := skillNameFromRef(ref)
+	skillName := SkillNameFromRef(ref)
 
 	// 4. Create outputDir/skillName/ directory.
 	targetDir := filepath.Join(outputDir, skillName)
@@ -83,9 +83,10 @@ func (c *Client) Unpack(ctx context.Context, ref string, outputDir string) error
 	return nil
 }
 
-// skillNameFromRef extracts the skill name from a reference like
-// "namespace/name:tag" -- it returns "name".
-func skillNameFromRef(ref string) string {
+// SkillNameFromRef extracts the skill name from a reference like
+// "namespace/name:tag" — it returns "name". Handles both tag
+// (name:tag) and digest (name@sha256:...) references.
+func SkillNameFromRef(ref string) string {
 	name := ref
 	if idx := strings.Index(ref, "@"); idx >= 0 {
 		name = ref[:idx]

--- a/pkg/oci/ref_test.go
+++ b/pkg/oci/ref_test.go
@@ -63,9 +63,9 @@ func TestSkillNameFromRef(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.ref, func(t *testing.T) {
-			got := skillNameFromRef(tt.ref)
+			got := SkillNameFromRef(tt.ref)
 			if got != tt.want {
-				t.Errorf("skillNameFromRef(%q) = %q, want %q", tt.ref, got, tt.want)
+				t.Errorf("SkillNameFromRef(%q) = %q, want %q", tt.ref, got, tt.want)
 			}
 		})
 	}

--- a/pkg/oci/resolve.go
+++ b/pkg/oci/resolve.go
@@ -1,0 +1,22 @@
+package oci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"oras.land/oras-go/v2/errdef"
+)
+
+// ResolveDigest returns the digest of a locally stored image
+// identified by its tag reference.
+func (c *Client) ResolveDigest(ctx context.Context, ref string) (string, error) {
+	desc, err := c.store.Resolve(ctx, ref)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return "", fmt.Errorf("image not found: %s", ref)
+		}
+		return "", fmt.Errorf("resolving %s: %w", ref, err)
+	}
+	return desc.Digest.String(), nil
+}

--- a/pkg/oci/resolve_test.go
+++ b/pkg/oci/resolve_test.go
@@ -2,10 +2,13 @@ package oci_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
 )
 
 func TestResolveDigest(t *testing.T) {
@@ -46,5 +49,86 @@ func TestResolveDigestNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
+	}
+}
+
+func TestInstallProvenance(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	ref := "test/test-skill:1.0.0-draft"
+
+	// Unpack to a temp dir (simulates install).
+	outputDir := t.TempDir()
+	err = client.Unpack(ctx, ref, outputDir)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+
+	// Resolve digest.
+	digest, err := client.ResolveDigest(ctx, ref)
+	if err != nil {
+		t.Fatalf("ResolveDigest: %v", err)
+	}
+
+	// Read skill.yaml back, set provenance, write it back.
+	skillPath := filepath.Join(outputDir, "test-skill", "skill.yaml")
+	f, err := os.Open(skillPath)
+	if err != nil {
+		t.Fatalf("opening skill.yaml: %v", err)
+	}
+	sc, err := skillcard.Parse(f)
+	f.Close()
+	if err != nil {
+		t.Fatalf("parsing skill.yaml: %v", err)
+	}
+
+	if sc.Provenance == nil {
+		sc.Provenance = &skillcard.Provenance{}
+	}
+	sc.Provenance.Source = ref
+	sc.Provenance.Commit = digest
+
+	wf, err := os.Create(skillPath)
+	if err != nil {
+		t.Fatalf("creating skill.yaml for write: %v", err)
+	}
+	err = skillcard.Serialize(sc, wf)
+	wf.Close()
+	if err != nil {
+		t.Fatalf("serializing skill.yaml: %v", err)
+	}
+
+	// Read it back and verify provenance fields.
+	f2, err := os.Open(skillPath)
+	if err != nil {
+		t.Fatalf("re-opening skill.yaml: %v", err)
+	}
+	defer f2.Close()
+	sc2, err := skillcard.Parse(f2)
+	if err != nil {
+		t.Fatalf("re-parsing skill.yaml: %v", err)
+	}
+
+	if sc2.Provenance == nil {
+		t.Fatal("expected provenance to be set")
+	}
+	if sc2.Provenance.Source != ref {
+		t.Errorf("source = %q, want %q", sc2.Provenance.Source, ref)
+	}
+	if sc2.Provenance.Commit != digest {
+		t.Errorf("commit = %q, want %q", sc2.Provenance.Commit, digest)
 	}
 }

--- a/pkg/oci/resolve_test.go
+++ b/pkg/oci/resolve_test.go
@@ -1,0 +1,50 @@
+package oci_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redhat-et/skillimage/pkg/oci"
+)
+
+func TestResolveDigest(t *testing.T) {
+	skillDir := t.TempDir()
+	writeTestSkill(t, skillDir)
+
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	ctx := context.Background()
+	_, err = client.Build(ctx, skillDir, oci.BuildOptions{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	digest, err := client.ResolveDigest(ctx, "test/test-skill:1.0.0-draft")
+	if err != nil {
+		t.Fatalf("ResolveDigest: %v", err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Errorf("digest = %q, want sha256: prefix", digest)
+	}
+}
+
+func TestResolveDigestNotFound(t *testing.T) {
+	storeDir := t.TempDir()
+	client, err := oci.NewClient(storeDir)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.ResolveDigest(context.Background(), "no/such:1.0.0")
+	if err == nil {
+		t.Fatal("expected error for non-existent ref")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "not found")
+	}
+}

--- a/pkg/oci/resolve_test.go
+++ b/pkg/oci/resolve_test.go
@@ -90,7 +90,7 @@ func TestInstallProvenance(t *testing.T) {
 		t.Fatalf("opening skill.yaml: %v", err)
 	}
 	sc, err := skillcard.Parse(f)
-	f.Close()
+	_ = f.Close()
 	if err != nil {
 		t.Fatalf("parsing skill.yaml: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestInstallProvenance(t *testing.T) {
 		t.Fatalf("creating skill.yaml for write: %v", err)
 	}
 	err = skillcard.Serialize(sc, wf)
-	wf.Close()
+	_ = wf.Close()
 	if err != nil {
 		t.Fatalf("serializing skill.yaml: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestInstallProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-opening skill.yaml: %v", err)
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 	sc2, err := skillcard.Parse(f2)
 	if err != nil {
 		t.Fatalf("re-parsing skill.yaml: %v", err)


### PR DESCRIPTION
## Summary

- Populate `provenance.source` (OCI ref) and `provenance.commit` (digest) in `skill.yaml` during `skillctl install`
- Add `pkg/installed/` package with `Scan()` function to discover installed skills across agent directories
- Add `list --installed` flag to show installed skills, with `--target` and `-o` filters

This is sub-project 1 of #27. The upgrade command (sub-project 2) will be designed separately.

## Design decisions

- Provenance stored in existing `skill.yaml` Provenance fields (no new files or schema changes)
- `Scan()` reads `*/skill.yaml` one level deep in each target directory — fast for typical skill counts
- Skills without provenance show `(local)` in the SOURCE column
- Non-existent target directories silently skipped; malformed skill.yaml warned and skipped

## Test plan

- [x] `TestResolveDigest` — build image, resolve digest, verify sha256 prefix
- [x] `TestResolveDigestNotFound` — error on non-existent ref
- [x] `TestInstallProvenance` — build, unpack, write provenance, read back, verify fields
- [x] `TestScan` — scan two target dirs with/without provenance, verify results
- [x] `TestScanNonExistentDir` — no error on missing directory
- [x] `TestScanMalformedSkillYAML` — malformed files skipped
- [x] `go test ./...` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--installed` flag to the `list` command to view installed skills
  * Added `--target` flag to filter installed skills by specific agent
  * Added `--output` flag to scan custom directories for installed skills
  * Install command now tracks provenance metadata for installed skills, including source reference and resolved digest

<!-- end of auto-generated comment: release notes by coderabbit.ai -->