### PR TITLE
feat: support Git source URLs in collection YAML

### DIFF
--- a/examples/dev-collection.yaml
+++ b/examples/dev-collection.yaml
@@ -1,0 +1,10 @@
+apiVersion: skillimage.io/v1alpha1
+kind: SkillCollection
+metadata:
+  name: dev-skills
+  version: 0.1.0
+  description: Development collection with Git source and OCI image entries
+skills:
+  - source: https://github.com/anthropics/courses/tree/master/prompt_engineering_interactive_tutorial/skills/code-review
+  - name: document-summarizer
+    image: quay.io/skillimage/business/document-summarizer:1.0.0-testing

--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -378,26 +378,23 @@ func installFromSource(ctx context.Context, client *oci.Client, s collection.Ski
 }
 
 func installFromImage(ctx context.Context, client *oci.Client, s collection.SkillRef, destDir string, force bool, w io.Writer) (string, error) {
-	if !force {
-		installedDigest := readInstalledCommit(destDir, s.Name)
-		if installedDigest != "" {
-			localDigest, err := client.ResolveDigest(ctx, s.Image)
-			if err == nil && localDigest == installedDigest {
-				fmt.Fprintf(w, "  %s (image)  up to date\n", s.Name)
+	if !looksLocal(s.Image) {
+		fmt.Fprintf(w, "  %s (image)  pulling...", s.Name)
+		desc, err := client.Pull(ctx, s.Image, oci.PullOptions{})
+		if err != nil {
+			fmt.Fprintln(w)
+			return "", fmt.Errorf("pulling %s: %w", s.Image, err)
+		}
+
+		if !force {
+			installedDigest := readInstalledCommit(destDir, s.Name)
+			if installedDigest == desc.Digest.String() {
+				fmt.Fprintf(w, "  up to date\n")
 				return "skipped", nil
 			}
 		}
-	}
-
-	fmt.Fprintf(w, "  %s (image)  pulling...", s.Name)
-
-	if !looksLocal(s.Image) {
-		if _, err := client.ResolveDigest(ctx, s.Image); err != nil {
-			if _, pullErr := client.Pull(ctx, s.Image, oci.PullOptions{}); pullErr != nil {
-				fmt.Fprintln(w)
-				return "", fmt.Errorf("pulling %s: %w", s.Image, pullErr)
-			}
-		}
+	} else {
+		fmt.Fprintf(w, "  %s (image)  installing...", s.Name)
 	}
 
 	if err := client.Unpack(ctx, s.Image, destDir); err != nil {
@@ -407,7 +404,7 @@ func installFromImage(ctx context.Context, client *oci.Client, s collection.Skil
 
 	skillDir := filepath.Join(destDir, oci.SkillNameFromRef(s.Image))
 	if err := WriteProvenance(ctx, client, s.Image, skillDir); err != nil {
-		fmt.Fprintf(os.Stderr, "  warning: provenance write failed: %v\n", err)
+		fmt.Fprintf(w, "  warning: provenance write failed: %v\n", err)
 	}
 
 	fmt.Fprintf(w, "  installed\n")

--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -3,9 +3,15 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/redhat-et/skillimage/pkg/collection"
 	"github.com/redhat-et/skillimage/pkg/oci"
+	"github.com/redhat-et/skillimage/pkg/skillcard"
+	"github.com/redhat-et/skillimage/pkg/source"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +24,7 @@ func newCollectionCmd() *cobra.Command {
 	cmd.AddCommand(newCollectionPullCmd())
 	cmd.AddCommand(newCollectionVolumeCmd())
 	cmd.AddCommand(newCollectionGenerateCmd())
+	cmd.AddCommand(newCollectionInstallCmd())
 	return cmd
 }
 
@@ -150,4 +157,304 @@ func newCollectionGenerateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&file, "file", "f", "", "path to collection YAML file")
 	cmd.Flags().StringVar(&mountRoot, "mount-root", "/skills", "root mount path for volumes")
 	return cmd
+}
+
+func newCollectionInstallCmd() *cobra.Command {
+	var file string
+	var target string
+	var outputDir string
+	var force bool
+	var ref string
+	cmd := &cobra.Command{
+		Use:   "install [-f <file> | <git-url>]",
+		Short: "Install skills from a collection into an agent's skill directory",
+		Long: `Install skills defined in a collection YAML into a directory
+where an agent can find them. Skills can be referenced by OCI
+image (image:) or Git source URL (source:).
+
+Source entries clone the repo, build locally, and install.
+Image entries pull from the registry and install.
+
+Skills that haven't changed since last install are skipped
+unless --force is set.
+
+Examples:
+  skillctl collection install -f ./collection.yaml --target claude
+  skillctl collection install https://github.com/myorg/skills/tree/main/collection.yaml -t claude
+  skillctl collection install -f ./collection.yaml -o ~/my-skills --force`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCollectionInstall(cmd, file, args, target, outputDir, force, ref)
+		},
+	}
+	cmd.Flags().StringVarP(&file, "file", "f", "", "path to local collection YAML file")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "agent name (claude, cursor, windsurf, opencode, openclaw)")
+	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "custom output directory")
+	cmd.Flags().BoolVar(&force, "force", false, "reinstall even if skills are up to date")
+	cmd.Flags().StringVar(&ref, "ref", "", "Git ref override (for collection YAML URL)")
+	return cmd
+}
+
+func runCollectionInstall(cmd *cobra.Command, file string, args []string, target, outputDir string, force bool, ref string) error {
+	col, cleanup, err := resolveCollectionInput(cmd.Context(), file, args, ref)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return err
+	}
+
+	if errs := collection.Validate(col); len(errs) > 0 {
+		return fmt.Errorf("invalid collection:\n  %s", strings.Join(errs, "\n  "))
+	}
+
+	dirs, err := resolveTargetDirs(target, outputDir, false)
+	if err != nil {
+		return err
+	}
+	var destDir string
+	for _, d := range dirs {
+		destDir = d
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", destDir, err)
+	}
+
+	client, err := defaultClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+	errW := cmd.ErrOrStderr()
+
+	fmt.Fprintf(w, "Installing collection %q (%d skills)\n", col.Metadata.Name, len(col.Skills))
+
+	var installed, skipped, failed int
+	for _, s := range col.Skills {
+		switch {
+		case s.Source != "":
+			result, installErr := installFromSource(ctx, client, s, destDir, force, w)
+			switch {
+			case installErr != nil:
+				fmt.Fprintf(errW, "  %s (source)  error: %v\n", skillLabel(s), installErr)
+				failed++
+			case result == "skipped":
+				skipped++
+			default:
+				installed++
+			}
+		case s.Image != "":
+			result, installErr := installFromImage(ctx, client, s, destDir, force, w)
+			switch {
+			case installErr != nil:
+				fmt.Fprintf(errW, "  %s (image)  error: %v\n", s.Name, installErr)
+				failed++
+			case result == "skipped":
+				skipped++
+			default:
+				installed++
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "Installed %d skills", installed)
+	if skipped > 0 {
+		fmt.Fprintf(w, ", %d up to date", skipped)
+	}
+	fmt.Fprintln(w)
+
+	if failed > 0 {
+		return fmt.Errorf("%d skill(s) failed to install", failed)
+	}
+	return nil
+}
+
+func resolveCollectionInput(ctx context.Context, file string, args []string, ref string) (*collection.SkillCollection, func(), error) {
+	if file != "" && len(args) > 0 {
+		return nil, nil, fmt.Errorf("specify -f <file> or a Git URL, not both")
+	}
+	if file != "" {
+		col, err := collection.ParseFile(file)
+		return col, nil, err
+	}
+	if len(args) == 0 {
+		return nil, nil, fmt.Errorf("specify -f <file> or a Git URL")
+	}
+
+	rawURL := args[0]
+	if !source.IsRemote(rawURL) {
+		return nil, nil, fmt.Errorf("not a valid URL: %s\n\nUse -f for local files", rawURL)
+	}
+
+	src, err := source.ParseGitURL(rawURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cloneResult, err := source.Clone(ctx, src, source.CloneOptions{RefOverride: ref})
+	if err != nil {
+		return nil, nil, fmt.Errorf("cloning collection: %w", err)
+	}
+
+	yamlPath := cloneResult.Dir
+	info, statErr := os.Stat(yamlPath)
+	if statErr != nil {
+		cloneResult.Cleanup()
+		return nil, nil, fmt.Errorf("collection file not found at %s in repository", src.SubPath)
+	}
+	if info.IsDir() {
+		cloneResult.Cleanup()
+		return nil, nil, fmt.Errorf("URL must point to a collection YAML file, not a directory: %s", src.SubPath)
+	}
+
+	col, err := collection.ParseFile(yamlPath)
+	if err != nil {
+		cloneResult.Cleanup()
+		return nil, nil, err
+	}
+
+	return col, cloneResult.Cleanup, nil
+}
+
+func installFromSource(ctx context.Context, client *oci.Client, s collection.SkillRef, destDir string, force bool, w io.Writer) (string, error) {
+	label := skillLabel(s)
+
+	src, err := source.ParseGitURL(s.Source)
+	if err != nil {
+		return "", err
+	}
+
+	if !force && label != "" {
+		installedSHA := readInstalledCommit(destDir, label)
+		if installedSHA != "" {
+			refToCheck := src.Ref
+			if refToCheck == "" {
+				refToCheck = "HEAD"
+			}
+			remoteSHA, lsErr := source.LsRemote(ctx, src.CloneURL, refToCheck)
+			if lsErr == nil && remoteSHA == installedSHA {
+				fmt.Fprintf(w, "  %s (source)  up to date\n", label)
+				return "skipped", nil
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "  %s (source)  cloning...", label)
+
+	result, err := source.Resolve(ctx, s.Source, "", "")
+	if err != nil {
+		fmt.Fprintln(w)
+		return "", err
+	}
+	defer result.Cleanup()
+
+	if len(result.Skills) == 0 {
+		fmt.Fprintln(w)
+		return "", fmt.Errorf("no skills found at %s", s.Source)
+	}
+
+	skill := result.Skills[0]
+	if label == "" {
+		label = skill.Name
+	}
+
+	fmt.Fprintf(w, "  building...")
+
+	if _, err := client.Build(ctx, skill.Dir, oci.BuildOptions{SkillCard: skill.SkillCard}); err != nil {
+		fmt.Fprintln(w)
+		return "", fmt.Errorf("building: %w", err)
+	}
+
+	buildRef := fmt.Sprintf("%s/%s:%s", skill.SkillCard.Metadata.Namespace, skill.SkillCard.Metadata.Name, skill.SkillCard.Metadata.Version)
+	if err := client.Unpack(ctx, buildRef, destDir); err != nil {
+		fmt.Fprintln(w)
+		return "", fmt.Errorf("unpacking: %w", err)
+	}
+
+	skillDir := filepath.Join(destDir, skill.Name)
+	writeSourceProvenance(skillDir, skill.SkillCard)
+
+	fmt.Fprintf(w, "  installed\n")
+	return "installed", nil
+}
+
+func installFromImage(ctx context.Context, client *oci.Client, s collection.SkillRef, destDir string, force bool, w io.Writer) (string, error) {
+	if !force {
+		installedDigest := readInstalledCommit(destDir, s.Name)
+		if installedDigest != "" {
+			localDigest, err := client.ResolveDigest(ctx, s.Image)
+			if err == nil && localDigest == installedDigest {
+				fmt.Fprintf(w, "  %s (image)  up to date\n", s.Name)
+				return "skipped", nil
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "  %s (image)  pulling...", s.Name)
+
+	if !looksLocal(s.Image) {
+		if _, err := client.ResolveDigest(ctx, s.Image); err != nil {
+			if _, pullErr := client.Pull(ctx, s.Image, oci.PullOptions{}); pullErr != nil {
+				fmt.Fprintln(w)
+				return "", fmt.Errorf("pulling %s: %w", s.Image, pullErr)
+			}
+		}
+	}
+
+	if err := client.Unpack(ctx, s.Image, destDir); err != nil {
+		fmt.Fprintln(w)
+		return "", fmt.Errorf("unpacking %s: %w", s.Image, err)
+	}
+
+	skillDir := filepath.Join(destDir, oci.SkillNameFromRef(s.Image))
+	if err := WriteProvenance(ctx, client, s.Image, skillDir); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: provenance write failed: %v\n", err)
+	}
+
+	fmt.Fprintf(w, "  installed\n")
+	return "installed", nil
+}
+
+func skillLabel(s collection.SkillRef) string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return ""
+}
+
+func readInstalledCommit(destDir, skillName string) string {
+	skillPath := filepath.Join(destDir, skillName, "skill.yaml")
+	f, err := os.Open(skillPath)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+
+	sc, err := skillcard.Parse(f)
+	if err != nil {
+		return ""
+	}
+	if sc.Provenance == nil {
+		return ""
+	}
+	return sc.Provenance.Commit
+}
+
+func writeSourceProvenance(skillDir string, sc *skillcard.SkillCard) {
+	if sc.Provenance == nil {
+		sc.Provenance = &skillcard.Provenance{}
+	}
+
+	skillPath := filepath.Join(skillDir, "skill.yaml")
+	wf, err := os.Create(skillPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: could not write provenance: %v\n", err)
+		return
+	}
+	defer func() { _ = wf.Close() }()
+	if err := skillcard.Serialize(sc, wf); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: could not serialize provenance: %v\n", err)
+	}
 }

--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/redhat-et/skillimage/pkg/collection"
+	"github.com/redhat-et/skillimage/pkg/lifecycle"
 	"github.com/redhat-et/skillimage/pkg/oci"
 	"github.com/redhat-et/skillimage/pkg/skillcard"
 	"github.com/redhat-et/skillimage/pkg/source"
@@ -370,7 +371,8 @@ func installFromSource(ctx context.Context, client *oci.Client, s collection.Ski
 		return "", fmt.Errorf("building: %w", err)
 	}
 
-	buildRef := fmt.Sprintf("%s/%s:%s", skill.SkillCard.Metadata.Namespace, skill.SkillCard.Metadata.Name, skill.SkillCard.Metadata.Version)
+	tag := lifecycle.TagForState(skill.SkillCard.Metadata.Version, lifecycle.Draft)
+	buildRef := fmt.Sprintf("%s/%s:%s", skill.SkillCard.Metadata.Namespace, skill.SkillCard.Metadata.Name, tag)
 	if err := client.Unpack(ctx, buildRef, destDir); err != nil {
 		fmt.Fprintln(w)
 		return "", fmt.Errorf("unpacking: %w", err)

--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -326,17 +326,23 @@ func installFromSource(ctx context.Context, client *oci.Client, s collection.Ski
 		return "", err
 	}
 
-	if !force && label != "" {
-		installedSHA := readInstalledCommit(destDir, label)
-		if installedSHA != "" {
-			refToCheck := src.Ref
-			if refToCheck == "" {
-				refToCheck = "HEAD"
-			}
-			remoteSHA, lsErr := source.LsRemote(ctx, src.CloneURL, refToCheck)
-			if lsErr == nil && remoteSHA == installedSHA {
-				fmt.Fprintf(w, "  %s (source)  up to date\n", label)
-				return "skipped", nil
+	if !force {
+		lookupName := label
+		if lookupName == "" {
+			lookupName = filepath.Base(src.SubPath)
+		}
+		if lookupName != "" && lookupName != "." {
+			installedSHA := readInstalledCommit(destDir, lookupName)
+			if installedSHA != "" {
+				refToCheck := src.Ref
+				if refToCheck == "" {
+					refToCheck = "HEAD"
+				}
+				remoteSHA, lsErr := source.LsRemote(ctx, src.CloneURL, refToCheck)
+				if lsErr == nil && remoteSHA == installedSHA {
+					fmt.Fprintf(w, "  %s (source)  up to date\n", lookupName)
+					return "skipped", nil
+				}
 			}
 		}
 	}

--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -356,9 +356,6 @@ func installFromSource(ctx context.Context, client *oci.Client, s collection.Ski
 	}
 
 	skill := result.Skills[0]
-	if label == "" {
-		label = skill.Name
-	}
 
 	fmt.Fprintf(w, "  building...")
 

--- a/internal/cli/collection_install_test.go
+++ b/internal/cli/collection_install_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCollectionInstallRequiresInput(t *testing.T) {
+	cmd := NewRootCmd("test")
+	cmd.SetArgs([]string{"collection", "install", "--target", "claude"})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no -f or URL given")
+	}
+}
+
+func TestCollectionInstallRequiresTarget(t *testing.T) {
+	dir := t.TempDir()
+	colFile := filepath.Join(dir, "collection.yaml")
+	content := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCollection
+metadata:
+  name: test
+  version: 1.0.0
+skills:
+  - name: s1
+    image: quay.io/org/s1:1.0.0
+`)
+	if err := os.WriteFile(colFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd("test")
+	cmd.SetArgs([]string{"collection", "install", "-f", colFile})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no --target or -o given")
+	}
+}
+
+func TestCollectionInstallInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	colFile := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(colFile, []byte("not: valid: yaml: ["), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd("test")
+	cmd.SetArgs([]string{"collection", "install", "-f", colFile, "-o", dir})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestCollectionInstallValidationError(t *testing.T) {
+	dir := t.TempDir()
+	colFile := filepath.Join(dir, "collection.yaml")
+	content := []byte(`apiVersion: skillimage.io/v1alpha1
+kind: SkillCollection
+metadata:
+  name: test
+  version: 1.0.0
+skills:
+  - name: both-set
+    image: quay.io/org/s:1.0.0
+    source: https://github.com/org/repo/tree/main/s
+`)
+	if err := os.WriteFile(colFile, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd("test")
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"collection", "install", "-f", colFile, "-o", dir})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -104,7 +104,7 @@ func runInstall(cmd *cobra.Command, ref string, target string, outputDir string)
 	dest := filepath.Join(outputDir, oci.SkillNameFromRef(ref))
 
 	// Write provenance into skill.yaml.
-	if err := writeProvenance(ctx, client, ref, dest); err != nil {
+	if err := WriteProvenance(ctx, client, ref, dest); err != nil {
 		return fmt.Errorf("writing provenance: %w", err)
 	}
 
@@ -112,7 +112,7 @@ func runInstall(cmd *cobra.Command, ref string, target string, outputDir string)
 	return nil
 }
 
-func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir string) error {
+func WriteProvenance(ctx context.Context, client *oci.Client, ref, skillDir string) error {
 	digest, err := client.ResolveDigest(ctx, ref)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func writeProvenance(ctx context.Context, client *oci.Client, ref, skillDir stri
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("opening skill.yaml: %w", err)
 		}
-		sc = newSkillCardFromRef(ref)
+		sc = NewSkillCardFromRef(ref)
 	} else {
 		sc, err = skillcard.Parse(f)
 		_ = f.Close()
@@ -175,7 +175,7 @@ func tagFromRef(ref string) string {
 	return ""
 }
 
-func newSkillCardFromRef(ref string) *skillcard.SkillCard {
+func NewSkillCardFromRef(ref string) *skillcard.SkillCard {
 	name := oci.SkillNameFromRef(ref)
 
 	version := tagFromRef(ref)

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -39,7 +39,7 @@ func TestNewSkillCardFromRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.ref, func(t *testing.T) {
-			sc := newSkillCardFromRef(tt.ref)
+			sc := NewSkillCardFromRef(tt.ref)
 			if sc.Metadata.Name != tt.wantName {
 				t.Errorf("name = %q, want %q", sc.Metadata.Name, tt.wantName)
 			}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -157,7 +157,7 @@ func upgradeSkill(ctx context.Context, client *oci.Client, c installed.UpgradeCa
 		return fmt.Errorf("unpacking %s: %w", c.LatestRef, err)
 	}
 
-	if err := writeProvenance(ctx, client, c.LatestRef, c.Installed.Path); err != nil {
+	if err := WriteProvenance(ctx, client, c.LatestRef, c.Installed.Path); err != nil {
 		return fmt.Errorf("writing provenance: %w", err)
 	}
 

--- a/pkg/collection/collection.go
+++ b/pkg/collection/collection.go
@@ -22,8 +22,9 @@ type Metadata struct {
 }
 
 type SkillRef struct {
-	Name  string `yaml:"name"`
-	Image string `yaml:"image"`
+	Name   string `yaml:"name,omitempty"`
+	Image  string `yaml:"image,omitempty"`
+	Source string `yaml:"source,omitempty"`
 }
 
 func Parse(r io.Reader) (*SkillCollection, error) {
@@ -62,16 +63,20 @@ func Validate(col *SkillCollection) []string {
 	}
 	seen := make(map[string]bool)
 	for i, s := range col.Skills {
-		if s.Name == "" {
+		switch {
+		case s.Image != "" && s.Source != "":
+			errs = append(errs, fmt.Sprintf("skills[%d]: image and source are mutually exclusive", i))
+		case s.Image == "" && s.Source == "":
+			errs = append(errs, fmt.Sprintf("skills[%d]: image or source is required", i))
+		case s.Image != "" && s.Name == "":
 			errs = append(errs, fmt.Sprintf("skills[%d].name is required", i))
-		}
-		if s.Image == "" {
-			errs = append(errs, fmt.Sprintf("skills[%d].image is required", i))
 		}
 		if s.Name != "" && seen[s.Name] {
 			errs = append(errs, fmt.Sprintf("duplicate skill name %q", s.Name))
 		}
-		seen[s.Name] = true
+		if s.Name != "" {
+			seen[s.Name] = true
+		}
 	}
 	return errs
 }

--- a/pkg/collection/collection.go
+++ b/pkg/collection/collection.go
@@ -69,7 +69,7 @@ func Validate(col *SkillCollection) []string {
 		case s.Image == "" && s.Source == "":
 			errs = append(errs, fmt.Sprintf("skills[%d]: image or source is required", i))
 		case s.Image != "" && s.Name == "":
-			errs = append(errs, fmt.Sprintf("skills[%d].name is required", i))
+			errs = append(errs, fmt.Sprintf("skills[%d].name is required for image entries", i))
 		}
 		if s.Name != "" && seen[s.Name] {
 			errs = append(errs, fmt.Sprintf("duplicate skill name %q", s.Name))

--- a/pkg/collection/collection_test.go
+++ b/pkg/collection/collection_test.go
@@ -183,3 +183,83 @@ func TestGenerateKubeYAMLCustomMountRoot(t *testing.T) {
 		t.Errorf("expected custom mount root, got:\n%s", output)
 	}
 }
+
+func TestParseSourceField(t *testing.T) {
+	input := `apiVersion: skillimage.io/v1alpha1
+kind: SkillCollection
+metadata:
+  name: dev-skills
+  version: 0.1.0
+skills:
+  - source: https://github.com/myorg/skills/tree/main/code-reviewer
+  - name: stable-tool
+    image: quay.io/myorg/stable-tool:1.0.0
+`
+	col, err := collection.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if col.Skills[0].Source != "https://github.com/myorg/skills/tree/main/code-reviewer" {
+		t.Errorf("skill[0].source = %q", col.Skills[0].Source)
+	}
+	if col.Skills[1].Image != "quay.io/myorg/stable-tool:1.0.0" {
+		t.Errorf("skill[1].image = %q", col.Skills[1].Image)
+	}
+}
+
+func TestValidateSourceAndImageExclusive(t *testing.T) {
+	col := &collection.SkillCollection{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCollection",
+		Metadata:   collection.Metadata{Name: "test", Version: "1.0.0"},
+		Skills: []collection.SkillRef{
+			{Name: "both", Image: "quay.io/org/s:1.0.0", Source: "https://github.com/org/repo/tree/main/s"},
+		},
+	}
+	errs := collection.Validate(col)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "mutually exclusive") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mutually exclusive error, got: %v", errs)
+	}
+}
+
+func TestValidateNeitherImageNorSource(t *testing.T) {
+	col := &collection.SkillCollection{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCollection",
+		Metadata:   collection.Metadata{Name: "test", Version: "1.0.0"},
+		Skills: []collection.SkillRef{
+			{Name: "empty"},
+		},
+	}
+	errs := collection.Validate(col)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "image or source is required") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'image or source is required' error, got: %v", errs)
+	}
+}
+
+func TestValidateSourceWithoutName(t *testing.T) {
+	col := &collection.SkillCollection{
+		APIVersion: "skillimage.io/v1alpha1",
+		Kind:       "SkillCollection",
+		Metadata:   collection.Metadata{Name: "test", Version: "1.0.0"},
+		Skills: []collection.SkillRef{
+			{Source: "https://github.com/org/repo/tree/main/skill"},
+		},
+	}
+	errs := collection.Validate(col)
+	if len(errs) != 0 {
+		t.Errorf("source without name should be valid, got errors: %v", errs)
+	}
+}

--- a/pkg/source/clone.go
+++ b/pkg/source/clone.go
@@ -14,7 +14,8 @@ import (
 var commitSHAPattern = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
 
 type CloneOptions struct {
-	RefOverride string
+	RefOverride    string
+	DisableSparse  bool
 }
 
 type CloneResult struct {
@@ -47,7 +48,7 @@ func Clone(ctx context.Context, src GitSource, opts CloneOptions) (*CloneResult,
 		ref = src.Ref
 	}
 
-	if err := cloneRepo(ctx, src.CloneURL, ref, src.SubPath, tmpDir); err != nil {
+	if err := cloneRepo(ctx, src.CloneURL, ref, src.SubPath, tmpDir, opts.DisableSparse); err != nil {
 		cleanup()
 		return nil, err
 	}
@@ -74,12 +75,12 @@ func isCommitSHA(ref string) bool {
 	return commitSHAPattern.MatchString(ref)
 }
 
-func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string) error {
+func cloneRepo(ctx context.Context, cloneURL, ref, subPath, destDir string, disableSparse bool) error {
 	if isCommitSHA(ref) {
 		return cloneAtCommit(ctx, cloneURL, ref, destDir)
 	}
 
-	if subPath != "" {
+	if subPath != "" && !disableSparse {
 		if err := sparseClone(ctx, cloneURL, ref, subPath, destDir); err == nil {
 			return nil
 		}

--- a/pkg/source/lsremote.go
+++ b/pkg/source/lsremote.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"strings"
 )
@@ -15,18 +16,20 @@ func LsRemote(ctx context.Context, cloneURL, ref string) (string, error) {
 		return "", err
 	}
 
+	safeURL := stripCredentials(cloneURL)
+
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "git", "ls-remote", cloneURL, ref)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git ls-remote %s %s: %s", cloneURL, ref, sanitizeGitOutput(stderr.String()))
+		return "", fmt.Errorf("git ls-remote %s %s: %s", safeURL, ref, sanitizeGitOutput(stderr.String()))
 	}
 
 	output := strings.TrimSpace(stdout.String())
 	if output == "" {
-		return "", fmt.Errorf("ref %q not found in %s", ref, cloneURL)
+		return "", fmt.Errorf("ref %q not found in %s", ref, safeURL)
 	}
 
 	// Output format: "<sha>\t<refname>\n" — may have multiple lines.
@@ -34,8 +37,17 @@ func LsRemote(ctx context.Context, cloneURL, ref string) (string, error) {
 	firstLine := strings.SplitN(output, "\n", 2)[0]
 	fields := strings.Fields(firstLine)
 	if len(fields) < 1 {
-		return "", fmt.Errorf("unexpected ls-remote output for %s %s", cloneURL, ref)
+		return "", fmt.Errorf("unexpected ls-remote output for %s %s", safeURL, ref)
 	}
 
 	return fields[0], nil
+}
+
+func stripCredentials(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
 }

--- a/pkg/source/lsremote.go
+++ b/pkg/source/lsremote.go
@@ -1,0 +1,41 @@
+package source
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// LsRemote queries a remote Git repository for the commit SHA
+// of the given ref without cloning. Returns the full commit SHA.
+func LsRemote(ctx context.Context, cloneURL, ref string) (string, error) {
+	if err := CheckGit(); err != nil {
+		return "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", cloneURL, ref)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git ls-remote %s %s: %s", cloneURL, ref, sanitizeGitOutput(stderr.String()))
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if output == "" {
+		return "", fmt.Errorf("ref %q not found in %s", ref, cloneURL)
+	}
+
+	// Output format: "<sha>\t<refname>\n" — may have multiple lines.
+	// Take the first line's SHA.
+	firstLine := strings.SplitN(output, "\n", 2)[0]
+	fields := strings.Fields(firstLine)
+	if len(fields) < 1 {
+		return "", fmt.Errorf("unexpected ls-remote output for %s %s", cloneURL, ref)
+	}
+
+	return fields[0], nil
+}

--- a/pkg/source/lsremote_test.go
+++ b/pkg/source/lsremote_test.go
@@ -1,0 +1,35 @@
+package source
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLsRemoteReturnsCommitSHA(t *testing.T) {
+	if err := CheckGit(); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Use a well-known public repo with a known branch.
+	sha, err := LsRemote(context.Background(), "https://github.com/octocat/Hello-World.git", "master")
+	if err != nil {
+		t.Fatalf("LsRemote: %v", err)
+	}
+	if len(sha) < 7 {
+		t.Errorf("expected commit SHA, got %q", sha)
+	}
+	if !commitSHAPattern.MatchString(sha) {
+		t.Errorf("SHA %q does not match commit pattern", sha)
+	}
+}
+
+func TestLsRemoteBadRef(t *testing.T) {
+	if err := CheckGit(); err != nil {
+		t.Skip("git not available")
+	}
+
+	_, err := LsRemote(context.Background(), "https://github.com/octocat/Hello-World.git", "nonexistent-branch-xyz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent ref")
+	}
+}

--- a/pkg/source/lsremote_test.go
+++ b/pkg/source/lsremote_test.go
@@ -3,15 +3,21 @@ package source
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestLsRemoteReturnsCommitSHA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network test in short mode")
+	}
 	if err := CheckGit(); err != nil {
 		t.Skip("git not available")
 	}
 
-	// Use a well-known public repo with a known branch.
-	sha, err := LsRemote(context.Background(), "https://github.com/octocat/Hello-World.git", "master")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sha, err := LsRemote(ctx, "https://github.com/octocat/Hello-World.git", "master")
 	if err != nil {
 		t.Fatalf("LsRemote: %v", err)
 	}
@@ -24,11 +30,17 @@ func TestLsRemoteReturnsCommitSHA(t *testing.T) {
 }
 
 func TestLsRemoteBadRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping network test in short mode")
+	}
 	if err := CheckGit(); err != nil {
 		t.Skip("git not available")
 	}
 
-	_, err := LsRemote(context.Background(), "https://github.com/octocat/Hello-World.git", "nonexistent-branch-xyz")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := LsRemote(ctx, "https://github.com/octocat/Hello-World.git", "nonexistent-branch-xyz")
 	if err == nil {
 		t.Fatal("expected error for nonexistent ref")
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -55,6 +55,15 @@ func Resolve(ctx context.Context, input string, ref string, filter string) (*Res
 	}
 
 	discovered, err := Discover(cloneResult.Dir, filter)
+	if err != nil && src.SubPath != "" {
+		// Sparse checkout may produce broken symlinks; retry with full shallow clone.
+		cloneResult.Cleanup()
+		cloneResult, err = Clone(ctx, src, CloneOptions{RefOverride: ref, DisableSparse: true})
+		if err != nil {
+			return nil, err
+		}
+		discovered, err = Discover(cloneResult.Dir, filter)
+	}
 	if err != nil {
 		cloneResult.Cleanup()
 		return nil, err


### PR DESCRIPTION
## Summary

- Add `source:` field to collection YAML `SkillRef` for Git repo URLs, mutually exclusive with `image:`
- Add `skillctl collection install` subcommand that installs skills from a collection YAML (`-f` local file or positional Git URL) into agent skill directories (`--target` or `-o`)
- Source entries: clone → build → install with SHA-based skip logic via `git ls-remote`
- Image entries: pull from registry with digest-based skip logic; `--force` overrides both

## Test plan

- [x] `pkg/collection/` unit tests: source field parsing, mutual exclusivity, optional name validation
- [x] `pkg/source/` unit tests: `LsRemote` returns SHA, errors on bad ref
- [x] `internal/cli/` tests: input validation, target resolution, invalid YAML, validation errors
- [x] Full test suite passes (`make test`)
- [x] Linter passes (`make lint`)
- [x] Smoke test: `skillctl collection install --help` shows correct flags
- [ ] Manual test: install from local collection YAML with image entries
- [ ] Manual test: install from collection YAML with source entries pointing to Git repos

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `collection install` command to install skills from collection manifests.
  * Example collection manifest demonstrating both Git-based and OCI image-based skills.

* **Improvements**
  * Collection validation strengthened to require either a Git source or image per skill and enforce naming rules.
  * More robust Git handling for subpath clones and remote-ref resolution to improve install reliability.

* **Tests**
  * Added unit and end-to-end tests covering collection install, parsing/validation, and Git resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->