### PR TITLE
fix: split colon-separated skill names into namespace and name

### DIFF
--- a/internal/cli/collection.go
+++ b/internal/cli/collection.go
@@ -378,7 +378,7 @@ func installFromSource(ctx context.Context, client *oci.Client, s collection.Ski
 		return "", fmt.Errorf("unpacking: %w", err)
 	}
 
-	skillDir := filepath.Join(destDir, skill.Name)
+	skillDir := filepath.Join(destDir, skill.SkillCard.Metadata.Name)
 	writeSourceProvenance(skillDir, skill.SkillCard)
 
 	fmt.Fprintf(w, "  installed\n")

--- a/pkg/source/generate.go
+++ b/pkg/source/generate.go
@@ -24,6 +24,9 @@ func GenerateSkillCard(skillDir, cloneURL, orgFallback string) (*skillcard.Skill
 		namespace = before
 		name = after
 	}
+	if ns := stringFromMapNested(fm, "metadata", "namespace", ""); ns != "" {
+		namespace = ns
+	}
 
 	sc := &skillcard.SkillCard{
 		APIVersion: "skillimage.io/v1alpha1",

--- a/pkg/source/generate.go
+++ b/pkg/source/generate.go
@@ -19,12 +19,18 @@ func GenerateSkillCard(skillDir, cloneURL, orgFallback string) (*skillcard.Skill
 	fm := parseFrontmatterRaw(data)
 	body := stripFrontmatterStr(string(data))
 
+	name, namespace := stringFromMap(fm, "name", filepath.Base(skillDir)), orgFallback
+	if before, after, ok := strings.Cut(name, ":"); ok && before != "" && after != "" {
+		namespace = before
+		name = after
+	}
+
 	sc := &skillcard.SkillCard{
 		APIVersion: "skillimage.io/v1alpha1",
 		Kind:       "SkillCard",
 		Metadata: skillcard.Metadata{
-			Name:          stringFromMap(fm, "name", filepath.Base(skillDir)),
-			Namespace:     orgFallback,
+			Name:          name,
+			Namespace:     namespace,
 			Version:       normalizeVersion(stringFromMapNested(fm, "metadata", "version", "0.1.0")),
 			Description:   stringFromMap(fm, "description", firstSentence(body)),
 			License:       stringFromMap(fm, "license", ""),

--- a/pkg/source/generate_test.go
+++ b/pkg/source/generate_test.go
@@ -87,6 +87,38 @@ func TestGenerateSkillCardColonSeparatedName(t *testing.T) {
 	}
 }
 
+func TestGenerateSkillCardFrontmatterNamespace(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "---\nname: resume-reviewer\ndescription: Reviews resumes.\nmetadata:\n  namespace: business/hr\n---\nContent.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/acme/skills.git", "acme")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+	if sc.Metadata.Name != "resume-reviewer" {
+		t.Errorf("Name = %q, want resume-reviewer", sc.Metadata.Name)
+	}
+	if sc.Metadata.Namespace != "business/hr" {
+		t.Errorf("Namespace = %q, want business/hr", sc.Metadata.Namespace)
+	}
+}
+
+func TestGenerateSkillCardNamespaceOverridesColon(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "---\nname: old-group:my-skill\nmetadata:\n  namespace: correct-ns\n---\nContent.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/org/repo.git", "org")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+	if sc.Metadata.Name != "my-skill" {
+		t.Errorf("Name = %q, want my-skill", sc.Metadata.Name)
+	}
+	if sc.Metadata.Namespace != "correct-ns" {
+		t.Errorf("Namespace = %q, want correct-ns (explicit overrides colon)", sc.Metadata.Namespace)
+	}
+}
+
 func TestGenerateSkillCardMalformedFrontmatter(t *testing.T) {
 	dir := t.TempDir()
 	writeSkillMD(t, dir, "---\nbad: [yaml: {{\n---\nContent here.")

--- a/pkg/source/generate_test.go
+++ b/pkg/source/generate_test.go
@@ -71,6 +71,22 @@ func TestGenerateSkillCardFallbacks(t *testing.T) {
 	}
 }
 
+func TestGenerateSkillCardColonSeparatedName(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillMD(t, dir, "---\nname: agnosticv:catalog-builder\ndescription: Builds catalogs.\n---\nContent.")
+
+	sc, err := source.GenerateSkillCard(dir, "https://github.com/rhpds/rhdp-skills.git", "rhpds")
+	if err != nil {
+		t.Fatalf("GenerateSkillCard: %v", err)
+	}
+	if sc.Metadata.Name != "catalog-builder" {
+		t.Errorf("Name = %q, want catalog-builder", sc.Metadata.Name)
+	}
+	if sc.Metadata.Namespace != "agnosticv" {
+		t.Errorf("Namespace = %q, want agnosticv (from colon prefix)", sc.Metadata.Namespace)
+	}
+}
+
 func TestGenerateSkillCardMalformedFrontmatter(t *testing.T) {
 	dir := t.TempDir()
 	writeSkillMD(t, dir, "---\nbad: [yaml: {{\n---\nContent here.")

--- a/pkg/source/generate_test.go
+++ b/pkg/source/generate_test.go
@@ -87,6 +87,36 @@ func TestGenerateSkillCardColonSeparatedName(t *testing.T) {
 	}
 }
 
+func TestGenerateSkillCardColonEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantNS    string
+	}{
+		{"multiple colons", "foo:bar:baz", "bar:baz", "foo"},
+		{"leading colon", ":bar", ":bar", "org"},
+		{"trailing colon", "\"foo:\"", "foo:", "org"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeSkillMD(t, dir, "---\nname: "+tt.input+"\n---\nContent.")
+
+			sc, err := source.GenerateSkillCard(dir, "https://github.com/org/repo.git", "org")
+			if err != nil {
+				t.Fatalf("GenerateSkillCard: %v", err)
+			}
+			if sc.Metadata.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", sc.Metadata.Name, tt.wantName)
+			}
+			if sc.Metadata.Namespace != tt.wantNS {
+				t.Errorf("Namespace = %q, want %q", sc.Metadata.Namespace, tt.wantNS)
+			}
+		})
+	}
+}
+
 func TestGenerateSkillCardFrontmatterNamespace(t *testing.T) {
 	dir := t.TempDir()
 	writeSkillMD(t, dir, "---\nname: resume-reviewer\ndescription: Reviews resumes.\nmetadata:\n  namespace: business/hr\n---\nContent.")


### PR DESCRIPTION
## Summary

- Split colon-separated names in SKILL.md frontmatter (e.g., `agnosticv:catalog-builder`) into `namespace=agnosticv`, `name=catalog-builder`
- Fix provenance path to use resolved SkillCard name instead of raw discovered name

## Context

Skills in repos like [rhpds/rhdp-skills-marketplace](https://github.com/rhpds/rhdp-skills-marketplace) use colon-separated names following the Claude Code plugin namespacing convention. These failed OCI name validation (`^[a-z0-9]+(-[a-z0-9]+)*$`) because colons aren't valid in OCI image names.

The colon maps naturally to our existing `namespace` + `name` fields — the prefix becomes namespace, the suffix becomes name.

## Test plan

- [x] Unit test for colon-split in `generate_test.go`
- [x] Full test suite passes
- [x] Linter passes
- [x] Manual test: `collection install` with rhdp-collection.yaml installs all 5 skills
- [x] Provenance written correctly with split name/namespace

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now support colon-separated naming conventions in frontmatter to automatically derive namespace and name values.
  * Enhanced skill metadata name resolution for improved directory organization during installation.

* **Tests**
  * Added test coverage for skill metadata name and namespace derivation, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->