### PR TITLE
feat: improve list output to match container tool conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -15,7 +16,6 @@ require (
 )
 
 require (
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"text/tabwriter"
+	"time"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/redhat-et/skillimage/pkg/installed"
@@ -139,4 +142,34 @@ func runListInstalled(cmd *cobra.Command, target, outputDir string, upgradable b
 
 func resolveListTargets(target, outputDir string) (map[string]string, error) {
 	return resolveTargetDirs(target, outputDir, true)
+}
+
+func formatDigest(digest string, noTrunc bool) string {
+	if digest == "" {
+		return ""
+	}
+	if noTrunc {
+		return digest
+	}
+	if idx := strings.IndexByte(digest, ':'); idx >= 0 {
+		digest = digest[idx+1:]
+	}
+	if len(digest) > 12 {
+		digest = digest[:12]
+	}
+	return digest
+}
+
+func formatCreated(created string, noTrunc bool) string {
+	if created == "" {
+		return ""
+	}
+	if noTrunc {
+		return created
+	}
+	t, err := time.Parse(time.RFC3339, created)
+	if err != nil {
+		return created
+	}
+	return humanize.Time(t)
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -18,6 +18,7 @@ func newListCmd() *cobra.Command {
 	var target string
 	var outputDir string
 	var upgradable bool
+	var noTrunc bool
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -43,7 +44,7 @@ Supported targets for --installed:
 			if showInstalled {
 				return runListInstalled(cmd, target, outputDir, upgradable)
 			}
-			return runList(cmd)
+			return runList(cmd, noTrunc)
 		},
 	}
 
@@ -51,11 +52,12 @@ Supported targets for --installed:
 	cmd.Flags().StringVarP(&target, "target", "t", "", "filter to a specific agent target")
 	cmd.Flags().StringVarP(&outputDir, "output", "o", "", "scan a custom directory")
 	cmd.Flags().BoolVarP(&upgradable, "upgradable", "u", false, "show only upgradable skills (requires --installed)")
+	cmd.Flags().BoolVar(&noTrunc, "no-trunc", false, "show full digest and raw timestamps")
 
 	return cmd
 }
 
-func runList(cmd *cobra.Command) error {
+func runList(cmd *cobra.Command, noTrunc bool) error {
 	client, err := defaultClient()
 	if err != nil {
 		return err
@@ -74,12 +76,10 @@ func runList(cmd *cobra.Command) error {
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tTAG\tSTATUS\tDIGEST\tCREATED")
 	for _, img := range images {
-		shortDigest := img.Digest
-		if len(shortDigest) > 19 {
-			shortDigest = shortDigest[:19]
-		}
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			img.Name, img.Tag, img.Status, shortDigest, img.Created)
+			img.Name, img.Tag, img.Status,
+			formatDigest(img.Digest, noTrunc),
+			formatCreated(img.Created, noTrunc))
 	}
 	return w.Flush()
 }

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatDigest(t *testing.T) {
+	tests := []struct {
+		name    string
+		digest  string
+		noTrunc bool
+		want    string
+	}{
+		{
+			name:   "strips sha256 prefix and truncates",
+			digest: "sha256:a593244d38f0e1b2c3d4e5f6a7b8c9d0e1f2a3b4",
+			want:   "a593244d38f0",
+		},
+		{
+			name:   "strips other algo prefix",
+			digest: "sha512:abcdef123456789012345678",
+			want:   "abcdef123456",
+		},
+		{
+			name:   "handles digest shorter than 12 chars",
+			digest: "sha256:abcd",
+			want:   "abcd",
+		},
+		{
+			name:   "handles digest with no prefix",
+			digest: "a593244d38f0e1b2c3d4",
+			want:   "a593244d38f0",
+		},
+		{
+			name:    "no-trunc preserves full digest",
+			digest:  "sha256:a593244d38f0e1b2c3d4e5f6a7b8c9d0e1f2a3b4",
+			noTrunc: true,
+			want:    "sha256:a593244d38f0e1b2c3d4e5f6a7b8c9d0e1f2a3b4",
+		},
+		{
+			name:   "empty digest",
+			digest: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDigest(tt.digest, tt.noTrunc)
+			if got != tt.want {
+				t.Errorf("formatDigest(%q, %v) = %q, want %q",
+					tt.digest, tt.noTrunc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatCreated(t *testing.T) {
+	tests := []struct {
+		name    string
+		created string
+		noTrunc bool
+		want    string
+	}{
+		{
+			name:    "no-trunc returns raw timestamp",
+			created: "2026-04-29T22:07:29Z",
+			noTrunc: true,
+			want:    "2026-04-29T22:07:29Z",
+		},
+		{
+			name:    "empty string returns empty",
+			created: "",
+			want:    "",
+		},
+		{
+			name:    "unparseable falls back to raw string",
+			created: "not-a-timestamp",
+			want:    "not-a-timestamp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCreated(tt.created, tt.noTrunc)
+			if got != tt.want {
+				t.Errorf("formatCreated(%q, %v) = %q, want %q",
+					tt.created, tt.noTrunc, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("recent timestamp shows relative time", func(t *testing.T) {
+		recent := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+		got := formatCreated(recent, false)
+		if got == recent {
+			t.Errorf("expected humanized time, got raw timestamp %q", got)
+		}
+		if got == "" {
+			t.Error("expected non-empty result")
+		}
+	})
+}

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -39,6 +39,11 @@ func TestFormatDigest(t *testing.T) {
 			want:    "sha256:a593244d38f0e1b2c3d4e5f6a7b8c9d0e1f2a3b4",
 		},
 		{
+			name:   "digest exactly 12 chars no prefix",
+			digest: "a593244d38f0",
+			want:   "a593244d38f0",
+		},
+		{
 			name:   "empty digest",
 			digest: "",
 			want:   "",


### PR DESCRIPTION
## Summary

- Strip `sha256:` prefix from digest column, show 12 hex chars (matching Docker/Podman conventions)
- Humanize timestamps ("2 days ago" instead of `2026-04-29T22:07:29Z`) using `dustin/go-humanize`
- Add `--no-trunc` flag to preserve full digest and raw RFC 3339 timestamps for scripting

Closes #23

## Test plan

- [x] `TestFormatDigest` — 6 subtests: prefix stripping, other algorithms, short digest, no prefix, no-trunc, empty
- [x] `TestFormatCreated` — 4 subtests: no-trunc, empty, unparseable fallback, recent relative time
- [x] `make lint` passes
- [x] Smoke test: `skillctl list` and `skillctl list --no-trunc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-trunc` flag to the list command for controlling output format details. By default, image digest hashes are truncated and creation timestamps are displayed in a human-readable format. Using `--no-trunc` displays the complete digest hash and raw RFC3339 timestamps for advanced troubleshooting and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->