### PR TITLE
docs: fix accent color on bold text in slide deck

### DIFF
--- a/docs/slides/oci-skill-distribution-deck.html
+++ b/docs/slides/oci-skill-distribution-deck.html
@@ -7,7 +7,7 @@
  * @auto-scaling true
  * @size 16:9 1280px 720px
  * @size 4:3 960px 720px
- */div#\:\$p > svg > foreignObject > section [data-theme=light],div#\:\$p > svg > foreignObject > section{color-scheme:light}div#\:\$p > svg > foreignObject > section [data-theme=dark],div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background-color:var(--bgColor-default);color:var(--fgColor-default);font-family:var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");font-size:16px;font-weight:var(--base-text-weight-normal, 400);line-height:1.5;margin:0;word-wrap:break-word}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:16px}div#\:\$p > svg > foreignObject > section a{text-decoration:underline;text-underline-offset:calc(var(--marpit-root-font-size, 1rem) * .2)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link:before{background-color:currentColor;content:" ";display:inline-block;height:16px;-webkit-mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');width:16px}div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section figcaption,div#\:\$p > svg > foreignObject > section figure{display:block}div#\:\$p > svg > foreignObject > section summary{display:list-item}div#\:\$p > svg > foreignObject > section [hidden]{display:none!important}div#\:\$p > svg > foreignObject > section a{background-color:transparent;color:var(--fgColor-accent);text-decoration:none}div#\:\$p > svg > foreignObject > section abbr[title]{border-bottom:none;-webkit-text-decoration:underline dotted;text-decoration:underline dotted}div#\:\$p > svg > foreignObject > section b,div#\:\$p > svg > foreignObject > section strong{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section dfn{font-style:italic}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){border-bottom:1px solid var(--borderColor-muted);font-size:2em;font-weight:var(--base-text-weight-semibold, 600);margin:.67em 0;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section mark{background-color:var(--bgColor-attention-muted);color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section small{font-size:90%}div#\:\$p > svg > foreignObject > section sub,div#\:\$p > svg > foreignObject > section sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}div#\:\$p > svg > foreignObject > section sub{bottom:-.25em}div#\:\$p > svg > foreignObject > section sup{top:-.5em}div#\:\$p > svg > foreignObject > section img{border-style:none;box-sizing:content-box;max-width:100%}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section kbd,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp{font-family:monospace;font-size:1em}div#\:\$p > svg > foreignObject > section figure{margin:1em var(--base-size-40)}div#\:\$p > svg > foreignObject > section hr{background:transparent;background-color:var(--borderColor-default);border:0;box-sizing:content-box;height:.25em;margin:var(--base-size-24) 0;overflow:hidden;padding:0}div#\:\$p > svg > foreignObject > section input{font:inherit;font-family:inherit;font-size:inherit;line-height:inherit;margin:0;overflow:visible}div#\:\$p > svg > foreignObject > section [type=button],div#\:\$p > svg > foreignObject > section [type=reset],div#\:\$p > svg > foreignObject > section [type=submit]{-webkit-appearance:button;-moz-appearance:button;appearance:button}div#\:\$p > svg > foreignObject > section [type=checkbox],div#\:\$p > svg > foreignObject > section [type=radio]{box-sizing:border-box;padding:0}div#\:\$p > svg > foreignObject > section [type=number]::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section [type=number]::-webkit-outer-spin-button{height:auto}div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-cancel-button,div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-decoration{-webkit-appearance:none;appearance:none}div#\:\$p > svg > foreignObject > section ::-webkit-input-placeholder{color:inherit;opacity:.54}div#\:\$p > svg > foreignObject > section ::-webkit-file-upload-button{-webkit-appearance:button;appearance:button;font:inherit}div#\:\$p > svg > foreignObject > section a:hover{text-decoration:underline}div#\:\$p > svg > foreignObject > section ::-moz-placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section ::placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section hr:after,div#\:\$p > svg > foreignObject > section hr:before{content:"";display:table}div#\:\$p > svg > foreignObject > section hr:after{clear:both}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;border-spacing:0;display:block;font-variant:tabular-nums;max-width:100%;overflow:auto;width:-moz-max-content;width:max-content}div#\:\$p > svg > foreignObject > section td,div#\:\$p > svg > foreignObject > section th{padding:0}div#\:\$p > svg > foreignObject > section details summary{cursor:pointer}div#\:\$p > svg > foreignObject > section [role=button]:focus,div#\:\$p > svg > foreignObject > section a:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=radio]:focus:not(:focus-visible){outline:1px solid transparent}div#\:\$p > svg > foreignObject > section [role=button]:focus-visible,div#\:\$p > svg > foreignObject > section a:focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section a:not([class]):focus,div#\:\$p > svg > foreignObject > section a:not([class]):focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{outline-offset:0}div#\:\$p > svg > foreignObject > section kbd{background-color:var(--bgColor-muted);border-bottom-color:var(--borderColor-neutral-muted);border:1px solid var(--borderColor-neutral-muted);border-radius:6px;box-shadow:inset 0 -1px 0 var(--borderColor-neutral-muted);color:var(--fgColor-default);display:inline-block;font:11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);line-height:10px;padding:var(--base-size-4);vertical-align:middle}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-weight:var(--base-text-weight-semibold, 600);line-height:1.25;margin-bottom:var(--base-size-16);margin-top:var(--base-size-24)}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:1px solid var(--borderColor-muted);font-size:1.5em;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.25em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:.875em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){color:var(--fgColor-muted);font-size:.85em;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section p{margin-bottom:10px;margin-top:0}div#\:\$p > svg > foreignObject > section blockquote{border-left:.25em solid var(--borderColor-default);color:var(--fgColor-muted);margin:0;padding:0 1em}div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section ul{margin-bottom:0;margin-top:0;padding-left:2em}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ul ol{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol ol ol,div#\:\$p > svg > foreignObject > section ol ul ol,div#\:\$p > svg > foreignObject > section ul ol ol,div#\:\$p > svg > foreignObject > section ul ul ol{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section dd{margin-left:0}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp,div#\:\$p > svg > foreignObject > section tt{font-family:var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);font-size:12px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){margin-bottom:0;margin-top:0;word-wrap:normal}div#\:\$p > svg > foreignObject > section .octicon{display:inline-block;fill:currentColor;overflow:visible!important;vertical-align:text-bottom}div#\:\$p > svg > foreignObject > section input::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section input::-webkit-outer-spin-button{-webkit-appearance:none;appearance:none;margin:0}div#\:\$p > svg > foreignObject > section .mr-2{margin-right:var(--base-size-8, 8px)!important}div#\:\$p > svg > foreignObject > section:after,div#\:\$p > svg > foreignObject > section:before{display:table}div#\:\$p > svg > foreignObject > section:after{clear:both}div#\:\$p > svg > foreignObject > section>:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section>:last-child{margin-bottom:0!important}div#\:\$p > svg > foreignObject > section a:not([href]){color:inherit;text-decoration:none}div#\:\$p > svg > foreignObject > section .absent{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section .anchor{float:left;line-height:1;margin-left:-20px;padding-right:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .anchor:focus{outline:none}div#\:\$p > svg > foreignObject > section blockquote,div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section dl,div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section p,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section table,div#\:\$p > svg > foreignObject > section ul{margin-bottom:var(--base-size-16);margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) .octicon-link{color:var(--fgColor-default);vertical-align:middle;visibility:hidden}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor{text-decoration:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link{visibility:visible}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) code,div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) tt,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) code,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) tt,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) code,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) tt,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) code,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) tt,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) code,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) tt,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) code,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) tt{font-size:inherit;padding:0 .2em}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6){display:inline-block}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6) .anchor{margin-left:-40px}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2){border-bottom:0;padding-bottom:0}div#\:\$p > svg > foreignObject > section ol.no-list,div#\:\$p > svg > foreignObject > section ul.no-list{list-style-type:none;padding:0}div#\:\$p > svg > foreignObject > section ol[type="a s"]{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section ol[type="A s"]{list-style-type:upper-alpha}div#\:\$p > svg > foreignObject > section ol[type="i s"]{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol[type="I s"]{list-style-type:upper-roman}div#\:\$p > svg > foreignObject > section div>ol:not([type]),div#\:\$p > svg > foreignObject > section ol[type="1"]{list-style-type:decimal}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ol ul,div#\:\$p > svg > foreignObject > section ul ol,div#\:\$p > svg > foreignObject > section ul ul{margin-bottom:0;margin-top:0}div#\:\$p > svg > foreignObject > section li>p{margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section li+li{margin-top:.25em}div#\:\$p > svg > foreignObject > section dl{padding:0}div#\:\$p > svg > foreignObject > section dl dt{font-size:1em;font-style:italic;font-weight:var(--base-text-weight-semibold, 600);margin-top:var(--base-size-16);padding:0}div#\:\$p > svg > foreignObject > section dl dd{margin-bottom:var(--base-size-16);padding:0 var(--base-size-16)}div#\:\$p > svg > foreignObject > section table th{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border:1px solid var(--borderColor-default);padding:6px 13px}div#\:\$p > svg > foreignObject > section table td>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section table tr{background-color:var(--bgColor-default);border-top:1px solid var(--borderColor-muted)}div#\:\$p > svg > foreignObject > section table tr:nth-child(2n){background-color:var(--bgColor-muted)}div#\:\$p > svg > foreignObject > section table img{background-color:transparent}div#\:\$p > svg > foreignObject > section img[align=right]{padding-left:20px}div#\:\$p > svg > foreignObject > section img[align=left]{padding-right:20px}div#\:\$p > svg > foreignObject > section .emoji{background-color:transparent;max-width:none;vertical-align:text-top}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame,div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){border:1px solid var(--borderColor-default);float:left;margin:13px 0 0;padding:7px;width:auto}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) img{display:block;float:left}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) :is(span, marp-span){clear:both;color:var(--fgColor-default);display:block;padding:5px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center :is(span, marp-span) img{margin:0 auto;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right>:is(span, marp-span){display:block;margin:13px 0 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right :is(span, marp-span) img{margin:0;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left{display:block;float:left;margin-right:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left :is(span, marp-span){margin:13px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right{display:block;float:right;margin-left:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section tt{background-color:var(--bgColor-neutral-muted);border-radius:6px;font-size:85%;margin:0;padding:.2em .4em;white-space:break-spaces}div#\:\$p > svg > foreignObject > section code br,div#\:\$p > svg > foreignObject > section tt br{display:none}div#\:\$p > svg > foreignObject > section del code{text-decoration:inherit}div#\:\$p > svg > foreignObject > section samp{font-size:85%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{font-size:100%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent;border:0;margin:0;padding:0;white-space:pre;word-break:normal}div#\:\$p > svg > foreignObject > section .highlight{margin-bottom:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre){margin-bottom:0;word-break:normal}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background-color:var(--bgColor-muted);border-radius:6px;color:var(--fgColor-default);font-size:85%;line-height:1.45;overflow:auto;padding:var(--base-size-16)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) tt{display:inline;line-height:inherit;margin:0;overflow:visible;padding:0;word-wrap:normal;background-color:transparent;border:0}div#\:\$p > svg > foreignObject > section .csv-data td,div#\:\$p > svg > foreignObject > section .csv-data th{font-size:12px;line-height:1;overflow:hidden;padding:5px;text-align:left;white-space:nowrap}div#\:\$p > svg > foreignObject > section .csv-data .blob-num{background:var(--bgColor-default);border:0;padding:10px var(--base-size-8) 9px;text-align:right}div#\:\$p > svg > foreignObject > section .csv-data tr{border-top:0}div#\:\$p > svg > foreignObject > section .csv-data th{background:var(--bgColor-muted);border-top:0;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:before{content:"["}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:after{content:"]"}div#\:\$p > svg > foreignObject > section .footnotes{border-top:1px solid var(--borderColor-default);color:var(--fgColor-muted);font-size:12px}div#\:\$p > svg > foreignObject > section div#\:\$p > svg > foreignObject > section section.footnotes{--marpit-root-font-size:12px}div#\:\$p > svg > foreignObject > section .footnotes ol,div#\:\$p > svg > foreignObject > section .footnotes ol ul{padding-left:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes ol ul{display:inline-block;margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes li{position:relative}div#\:\$p > svg > foreignObject > section .footnotes li:target:before{border:2px solid var(--borderColor-accent-emphasis);border-radius:6px;bottom:calc(var(--base-size-8)*-1);content:"";left:calc(var(--base-size-24)*-1);pointer-events:none;position:absolute;right:calc(var(--base-size-8)*-1);top:calc(var(--base-size-8)*-1)}div#\:\$p > svg > foreignObject > section .footnotes li:target{color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section .footnotes .data-footnote-backref g-emoji{font-family:monospace}div#\:\$p > svg > foreignObject > section .pl-c{color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section .pl-c1,div#\:\$p > svg > foreignObject > section .pl-s .pl-v{color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section .pl-e,div#\:\$p > svg > foreignObject > section .pl-en{color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section .pl-s .pl-s1,div#\:\$p > svg > foreignObject > section .pl-smi{color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section .pl-ent{color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section .pl-k{color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section .pl-pds,div#\:\$p > svg > foreignObject > section .pl-s,div#\:\$p > svg > foreignObject > section .pl-s .pl-pse .pl-s1,div#\:\$p > svg > foreignObject > section .pl-sr,div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sra,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sre{color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section .pl-smw,div#\:\$p > svg > foreignObject > section .pl-v{color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section .pl-bu{color:var(--color-prettylights-syntax-brackethighlighter-unmatched)}div#\:\$p > svg > foreignObject > section .pl-ii{background-color:var(--color-prettylights-syntax-invalid-illegal-bg);color:var(--color-prettylights-syntax-invalid-illegal-text)}div#\:\$p > svg > foreignObject > section .pl-c2{background-color:var(--color-prettylights-syntax-carriage-return-bg);color:var(--color-prettylights-syntax-carriage-return-text)}div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce{color:var(--color-prettylights-syntax-string-regexp);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ml{color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section .pl-mh,div#\:\$p > svg > foreignObject > section .pl-mh .pl-en,div#\:\$p > svg > foreignObject > section .pl-ms{color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-mi{color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section .pl-mb{color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-md{background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section .pl-mi1{background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section .pl-mc{background-color:var(--color-prettylights-syntax-markup-changed-bg);color:var(--color-prettylights-syntax-markup-changed-text)}div#\:\$p > svg > foreignObject > section .pl-mi2{background-color:var(--color-prettylights-syntax-markup-ignored-bg);color:var(--color-prettylights-syntax-markup-ignored-text)}div#\:\$p > svg > foreignObject > section .pl-mdr{color:var(--color-prettylights-syntax-meta-diff-range);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ba{color:var(--color-prettylights-syntax-brackethighlighter-angle)}div#\:\$p > svg > foreignObject > section .pl-sg{color:var(--color-prettylights-syntax-sublimelinter-gutter-mark)}div#\:\$p > svg > foreignObject > section .pl-corl{color:var(--color-prettylights-syntax-constant-other-reference-link);text-decoration:underline}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section button:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section summary:focus:not(:focus-visible){box-shadow:none;outline:none}div#\:\$p > svg > foreignObject > section [tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section details-dialog:focus:not(:focus-visible){outline:none}div#\:\$p > svg > foreignObject > section g-emoji{display:inline-block;font-family:Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;font-size:1em;font-style:normal!important;font-weight:var(--base-text-weight-normal, 400);line-height:1;min-width:1ch;vertical-align:-.075em}div#\:\$p > svg > foreignObject > section g-emoji img{height:1em;width:1em}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote){display:block}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):not(:has(.snippet-clipboard-content,>:is(pre, marp-pre))){width:-moz-fit-content;width:fit-content}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):has(.snippet-clipboard-content,>:is(pre, marp-pre)):focus-visible{outline:2px solid var(--focus-outlineColor);outline-offset:2px}div#\:\$p > svg > foreignObject > section .task-list-item{list-style-type:none}div#\:\$p > svg > foreignObject > section .task-list-item label{font-weight:var(--base-text-weight-normal, 400)}div#\:\$p > svg > foreignObject > section .task-list-item.enabled label{cursor:pointer}div#\:\$p > svg > foreignObject > section .task-list-item+.task-list-item{margin-top:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .task-list-item .handle{display:none}div#\:\$p > svg > foreignObject > section .task-list-item-checkbox{margin:0 .2em .25em -1.4em;vertical-align:middle}div#\:\$p > svg > foreignObject > section ul:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section ol:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section .contains-task-list:focus-within .task-list-item-convert-container,div#\:\$p > svg > foreignObject > section .contains-task-list:hover .task-list-item-convert-container{clip-path:none;display:block;height:24px;overflow:visible;width:auto}div#\:\$p > svg > foreignObject > section ::-webkit-calendar-picker-indicator{filter:invert(50%)}div#\:\$p > svg > foreignObject > section .markdown-alert{border-left:.25em solid var(--borderColor-default);color:inherit;margin-bottom:var(--base-size-16);padding:var(--base-size-8) var(--base-size-16)}div#\:\$p > svg > foreignObject > section .markdown-alert>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section .markdown-alert>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section .markdown-alert .markdown-alert-title{align-items:center;display:flex;font-weight:var(--base-text-weight-medium, 500);line-height:1}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note{border-left-color:var(--borderColor-accent-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note .markdown-alert-title{color:var(--fgColor-accent)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important{border-left-color:var(--borderColor-done-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important .markdown-alert-title{color:var(--fgColor-done)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning{border-left-color:var(--borderColor-attention-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning .markdown-alert-title{color:var(--fgColor-attention)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip{border-left-color:var(--borderColor-success-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip .markdown-alert-title{color:var(--fgColor-success)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution{border-left-color:var(--borderColor-danger-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution .markdown-alert-title{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section>:first-child>.heading-element:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre):has(+.zeroclipboard-container){min-height:52px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:var(--h1-color);font-size:1.6em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:none}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-size:1.3em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1.05em}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-size:.9em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--heading-strong-color);font-weight:inherit}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6)::part(auto-scaling){max-height:563px}div#\:\$p > svg > foreignObject > section hr{height:0;padding-top:.25em}div#\:\$p > svg > foreignObject > section img{background-color:transparent}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){border:1px solid var(--borderColor-default);line-height:1.15;overflow:visible}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)::part(auto-scaling){max-height:529px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-doctag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-tag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-variable),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-type),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable.language_){color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_.inherited__),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.function_){color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attribute),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-literal),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-number),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-operator),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-class),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-id),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable){color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-string),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-regexp),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-string){color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-built_in),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-symbol){color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-code),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-comment),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-formula){color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-name),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-quote),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-pseudo),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-tag){color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-subst){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-section){color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-bullet){color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-emphasis){color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-strong){color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-addition){background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-deletion){background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header{color:var(--header-footer-color);font-size:18px;left:30px;margin:0;position:absolute}div#\:\$p > svg > foreignObject > section header{top:21px}div#\:\$p > svg > foreignObject > section footer{bottom:21px}div#\:\$p > svg > foreignObject > section{--h1-color:light-dark(#246, #cee7ff);--header-footer-color:light-dark(hsla(0,0%,40%,.75), hsla(0,0%,60%,.75));--heading-strong-color:light-dark(#48c, #7bf);--paginate-color:light-dark(#777, #999);--base-size-4:4px;--base-size-8:8px;--base-size-16:16px;--base-size-24:24px;--base-size-40:40px;align-items:stretch;display:block;flex-flow:column nowrap;font-size:29px;height:720px;padding:78.5px;place-content:safe center center;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:29px}div#\:\$p > svg > foreignObject > section>:last-child,div#\:\$p > svg > foreignObject > section[data-footer]>:nth-last-child(2){margin-bottom:0}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:after{bottom:21px;color:var(--paginate-color);font-size:24px;padding:0;position:absolute;right:30px}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:24px}div#\:\$p > svg > foreignObject > section[data-color] :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section[data-color] :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section[data-color] :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section[data-color] :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section[data-color] :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section[data-color] :is(h6, marp-h6){color:currentcolor}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > :where(section):not([\20 root]){--color-background: #000000;--color-foreground: #ffffff;--color-highlight: #ee0000;--color-dimmed: #a3a3a3;}div#\:\$p > svg > foreignObject > section{font-family:'Red Hat Text', sans-serif;background:#000000;color:#ffffff}div#\:\$p > svg > foreignObject > section::after{color:#a3a3a3;font-family:'Red Hat Mono', monospace;font-size:0.7em}div#\:\$p > svg > foreignObject > section::after{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1), div#\:\$p > svg > foreignObject > section :is(h2, marp-h2), div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-family:'Red Hat Display', sans-serif;color:#ffffff}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-weight:900}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-weight:700}div#\:\$p > svg > foreignObject > section code{font-family:'Red Hat Mono', monospace;background:#292929;border-radius:3px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:#1f1f1f;border:1px solid #383838;border-radius:3px}div#\:\$p > svg > foreignObject > section a{color:#f56e6e}div#\:\$p > svg > foreignObject > section strong{color:#ffffff}div#\:\$p > svg > foreignObject > section em{color:#c7c7c7}div#\:\$p > svg > foreignObject > section .accent{color:#ee0000}div#\:\$p > svg > foreignObject > section .tag{display:inline-block;padding:2px 14px;border:1px solid #383838;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#c7c7c7;margin:2px}div#\:\$p > svg > foreignObject > section section.tag{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .tag-accent{display:inline-block;padding:2px 14px;border:1px solid #ee0000;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#ee0000;margin:2px}div#\:\$p > svg > foreignObject > section section.tag-accent{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .muted{color:#a3a3a3}div#\:\$p > svg > foreignObject > section .small{font-size:0.75em}div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 0.75em}div#\:\$p > svg > foreignObject > section.lead :is(h1, marp-h1){font-size:2.8em}div#\:\$p > svg > foreignObject > section.lead .subtitle{color:#a3a3a3;font-size:1.1em;max-width:680px}div#\:\$p > svg > foreignObject > section.lead div#\:\$p > svg > foreignObject > section section.subtitle{--marpit-root-font-size: 1.1em}div#\:\$p > svg > foreignObject > section table{font-size:0.85em;background:transparent}div#\:\$p > svg > foreignObject > section th{background:#1f1f1f;border-color:#383838}div#\:\$p > svg > foreignObject > section td{border-color:#383838}div#\:\$p > svg > foreignObject > section.thankyou :is(h1, marp-h1){font-size:5em;text-align:center}div#\:\$p > svg > foreignObject > section.thankyou{display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
+ */div#\:\$p > svg > foreignObject > section [data-theme=light],div#\:\$p > svg > foreignObject > section{color-scheme:light}div#\:\$p > svg > foreignObject > section [data-theme=dark],div#\:\$p > svg > foreignObject > section:where(.invert){color-scheme:dark}div#\:\$p > svg > foreignObject > section{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;background-color:var(--bgColor-default);color:var(--fgColor-default);font-family:var(--fontStack-sansSerif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");font-size:16px;font-weight:var(--base-text-weight-normal, 400);line-height:1.5;margin:0;word-wrap:break-word}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:16px}div#\:\$p > svg > foreignObject > section a{text-decoration:underline;text-underline-offset:calc(var(--marpit-root-font-size, 1rem) * .2)}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link:before,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link:before{background-color:currentColor;content:" ";display:inline-block;height:16px;-webkit-mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');mask-image:url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 0 0 1.06 1.06l1.25-1.25a2 2 0 1 1 2.83 2.83l-2.5 2.5a2 2 0 0 1-2.83 0 .75.75 0 0 0-1.06 1.06 3.5 3.5 0 0 0 4.95 0l2.5-2.5a3.5 3.5 0 0 0-4.95-4.95zm-4.69 9.64a2 2 0 0 1 0-2.83l2.5-2.5a2 2 0 0 1 2.83 0 .75.75 0 0 0 1.06-1.06 3.5 3.5 0 0 0-4.95 0l-2.5 2.5a3.5 3.5 0 0 0 4.95 4.95l1.25-1.25a.75.75 0 0 0-1.06-1.06l-1.25 1.25a2 2 0 0 1-2.83 0"/></svg>');width:16px}div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section figcaption,div#\:\$p > svg > foreignObject > section figure{display:block}div#\:\$p > svg > foreignObject > section summary{display:list-item}div#\:\$p > svg > foreignObject > section [hidden]{display:none!important}div#\:\$p > svg > foreignObject > section a{background-color:transparent;color:var(--fgColor-accent);text-decoration:none}div#\:\$p > svg > foreignObject > section abbr[title]{border-bottom:none;-webkit-text-decoration:underline dotted;text-decoration:underline dotted}div#\:\$p > svg > foreignObject > section b,div#\:\$p > svg > foreignObject > section strong{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section dfn{font-style:italic}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){border-bottom:1px solid var(--borderColor-muted);font-size:2em;font-weight:var(--base-text-weight-semibold, 600);margin:.67em 0;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section mark{background-color:var(--bgColor-attention-muted);color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section small{font-size:90%}div#\:\$p > svg > foreignObject > section sub,div#\:\$p > svg > foreignObject > section sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}div#\:\$p > svg > foreignObject > section sub{bottom:-.25em}div#\:\$p > svg > foreignObject > section sup{top:-.5em}div#\:\$p > svg > foreignObject > section img{border-style:none;box-sizing:content-box;max-width:100%}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section kbd,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp{font-family:monospace;font-size:1em}div#\:\$p > svg > foreignObject > section figure{margin:1em var(--base-size-40)}div#\:\$p > svg > foreignObject > section hr{background:transparent;background-color:var(--borderColor-default);border:0;box-sizing:content-box;height:.25em;margin:var(--base-size-24) 0;overflow:hidden;padding:0}div#\:\$p > svg > foreignObject > section input{font:inherit;font-family:inherit;font-size:inherit;line-height:inherit;margin:0;overflow:visible}div#\:\$p > svg > foreignObject > section [type=button],div#\:\$p > svg > foreignObject > section [type=reset],div#\:\$p > svg > foreignObject > section [type=submit]{-webkit-appearance:button;-moz-appearance:button;appearance:button}div#\:\$p > svg > foreignObject > section [type=checkbox],div#\:\$p > svg > foreignObject > section [type=radio]{box-sizing:border-box;padding:0}div#\:\$p > svg > foreignObject > section [type=number]::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section [type=number]::-webkit-outer-spin-button{height:auto}div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-cancel-button,div#\:\$p > svg > foreignObject > section [type=search]::-webkit-search-decoration{-webkit-appearance:none;appearance:none}div#\:\$p > svg > foreignObject > section ::-webkit-input-placeholder{color:inherit;opacity:.54}div#\:\$p > svg > foreignObject > section ::-webkit-file-upload-button{-webkit-appearance:button;appearance:button;font:inherit}div#\:\$p > svg > foreignObject > section a:hover{text-decoration:underline}div#\:\$p > svg > foreignObject > section ::-moz-placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section ::placeholder{color:var(--fgColor-muted);opacity:1}div#\:\$p > svg > foreignObject > section hr:after,div#\:\$p > svg > foreignObject > section hr:before{content:"";display:table}div#\:\$p > svg > foreignObject > section hr:after{clear:both}div#\:\$p > svg > foreignObject > section table{border-collapse:collapse;border-spacing:0;display:block;font-variant:tabular-nums;max-width:100%;overflow:auto;width:-moz-max-content;width:max-content}div#\:\$p > svg > foreignObject > section td,div#\:\$p > svg > foreignObject > section th{padding:0}div#\:\$p > svg > foreignObject > section details summary{cursor:pointer}div#\:\$p > svg > foreignObject > section [role=button]:focus,div#\:\$p > svg > foreignObject > section a:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section input[type=radio]:focus:not(:focus-visible){outline:1px solid transparent}div#\:\$p > svg > foreignObject > section [role=button]:focus-visible,div#\:\$p > svg > foreignObject > section a:focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{box-shadow:none;outline:2px solid var(--focus-outlineColor);outline-offset:-2px}div#\:\$p > svg > foreignObject > section a:not([class]):focus,div#\:\$p > svg > foreignObject > section a:not([class]):focus-visible,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus,div#\:\$p > svg > foreignObject > section input[type=checkbox]:focus-visible,div#\:\$p > svg > foreignObject > section input[type=radio]:focus,div#\:\$p > svg > foreignObject > section input[type=radio]:focus-visible{outline-offset:0}div#\:\$p > svg > foreignObject > section kbd{background-color:var(--bgColor-muted);border-bottom-color:var(--borderColor-neutral-muted);border:1px solid var(--borderColor-neutral-muted);border-radius:6px;box-shadow:inset 0 -1px 0 var(--borderColor-neutral-muted);color:var(--fgColor-default);display:inline-block;font:11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);line-height:10px;padding:var(--base-size-4);vertical-align:middle}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-weight:var(--base-text-weight-semibold, 600);line-height:1.25;margin-bottom:var(--base-size-16);margin-top:var(--base-size-24)}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:1px solid var(--borderColor-muted);font-size:1.5em;padding-bottom:.3em}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.25em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:.875em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){color:var(--fgColor-muted);font-size:.85em;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section p{margin-bottom:10px;margin-top:0}div#\:\$p > svg > foreignObject > section blockquote{border-left:.25em solid var(--borderColor-default);color:var(--fgColor-muted);margin:0;padding:0 1em}div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section ul{margin-bottom:0;margin-top:0;padding-left:2em}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ul ol{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol ol ol,div#\:\$p > svg > foreignObject > section ol ul ol,div#\:\$p > svg > foreignObject > section ul ol ol,div#\:\$p > svg > foreignObject > section ul ul ol{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section dd{margin-left:0}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section samp,div#\:\$p > svg > foreignObject > section tt{font-family:var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);font-size:12px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){margin-bottom:0;margin-top:0;word-wrap:normal}div#\:\$p > svg > foreignObject > section .octicon{display:inline-block;fill:currentColor;overflow:visible!important;vertical-align:text-bottom}div#\:\$p > svg > foreignObject > section input::-webkit-inner-spin-button,div#\:\$p > svg > foreignObject > section input::-webkit-outer-spin-button{-webkit-appearance:none;appearance:none;margin:0}div#\:\$p > svg > foreignObject > section .mr-2{margin-right:var(--base-size-8, 8px)!important}div#\:\$p > svg > foreignObject > section:after,div#\:\$p > svg > foreignObject > section:before{display:table}div#\:\$p > svg > foreignObject > section:after{clear:both}div#\:\$p > svg > foreignObject > section>:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section>:last-child{margin-bottom:0!important}div#\:\$p > svg > foreignObject > section a:not([href]){color:inherit;text-decoration:none}div#\:\$p > svg > foreignObject > section .absent{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section .anchor{float:left;line-height:1;margin-left:-20px;padding-right:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .anchor:focus{outline:none}div#\:\$p > svg > foreignObject > section blockquote,div#\:\$p > svg > foreignObject > section details,div#\:\$p > svg > foreignObject > section dl,div#\:\$p > svg > foreignObject > section ol,div#\:\$p > svg > foreignObject > section p,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre),div#\:\$p > svg > foreignObject > section table,div#\:\$p > svg > foreignObject > section ul{margin-bottom:var(--base-size-16);margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section blockquote>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) .octicon-link{color:var(--fgColor-default);vertical-align:middle;visibility:hidden}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor{text-decoration:none}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5):hover .anchor .octicon-link,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6):hover .anchor .octicon-link{visibility:visible}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) code,div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) tt,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) code,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) tt,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) code,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) tt,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) code,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) tt,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) code,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) tt,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) code,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) tt{font-size:inherit;padding:0 .2em}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6){display:inline-block}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h3, marp-h3) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h4, marp-h4) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h5, marp-h5) .anchor,div#\:\$p > svg > foreignObject > section summary :is(h6, marp-h6) .anchor{margin-left:-40px}div#\:\$p > svg > foreignObject > section summary :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section summary :is(h2, marp-h2){border-bottom:0;padding-bottom:0}div#\:\$p > svg > foreignObject > section ol.no-list,div#\:\$p > svg > foreignObject > section ul.no-list{list-style-type:none;padding:0}div#\:\$p > svg > foreignObject > section ol[type="a s"]{list-style-type:lower-alpha}div#\:\$p > svg > foreignObject > section ol[type="A s"]{list-style-type:upper-alpha}div#\:\$p > svg > foreignObject > section ol[type="i s"]{list-style-type:lower-roman}div#\:\$p > svg > foreignObject > section ol[type="I s"]{list-style-type:upper-roman}div#\:\$p > svg > foreignObject > section div>ol:not([type]),div#\:\$p > svg > foreignObject > section ol[type="1"]{list-style-type:decimal}div#\:\$p > svg > foreignObject > section ol ol,div#\:\$p > svg > foreignObject > section ol ul,div#\:\$p > svg > foreignObject > section ul ol,div#\:\$p > svg > foreignObject > section ul ul{margin-bottom:0;margin-top:0}div#\:\$p > svg > foreignObject > section li>p{margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section li+li{margin-top:.25em}div#\:\$p > svg > foreignObject > section dl{padding:0}div#\:\$p > svg > foreignObject > section dl dt{font-size:1em;font-style:italic;font-weight:var(--base-text-weight-semibold, 600);margin-top:var(--base-size-16);padding:0}div#\:\$p > svg > foreignObject > section dl dd{margin-bottom:var(--base-size-16);padding:0 var(--base-size-16)}div#\:\$p > svg > foreignObject > section table th{font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section table td,div#\:\$p > svg > foreignObject > section table th{border:1px solid var(--borderColor-default);padding:6px 13px}div#\:\$p > svg > foreignObject > section table td>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section table tr{background-color:var(--bgColor-default);border-top:1px solid var(--borderColor-muted)}div#\:\$p > svg > foreignObject > section table tr:nth-child(2n){background-color:var(--bgColor-muted)}div#\:\$p > svg > foreignObject > section table img{background-color:transparent}div#\:\$p > svg > foreignObject > section img[align=right]{padding-left:20px}div#\:\$p > svg > foreignObject > section img[align=left]{padding-right:20px}div#\:\$p > svg > foreignObject > section .emoji{background-color:transparent;max-width:none;vertical-align:text-top}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame,div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame>:is(span, marp-span){border:1px solid var(--borderColor-default);float:left;margin:13px 0 0;padding:7px;width:auto}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) img{display:block;float:left}div#\:\$p > svg > foreignObject > section :is(span, marp-span).frame :is(span, marp-span) :is(span, marp-span){clear:both;color:var(--fgColor-default);display:block;padding:5px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-center :is(span, marp-span) img{margin:0 auto;text-align:center}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right{clear:both;display:block;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right>:is(span, marp-span){display:block;margin:13px 0 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).align-right :is(span, marp-span) img{margin:0;text-align:right}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left{display:block;float:left;margin-right:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-left :is(span, marp-span){margin:13px 0 0}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right{display:block;float:right;margin-left:13px;overflow:hidden}div#\:\$p > svg > foreignObject > section :is(span, marp-span).float-right>:is(span, marp-span){display:block;margin:13px auto 0;overflow:hidden;text-align:right}div#\:\$p > svg > foreignObject > section code,div#\:\$p > svg > foreignObject > section tt{background-color:var(--bgColor-neutral-muted);border-radius:6px;font-size:85%;margin:0;padding:.2em .4em;white-space:break-spaces}div#\:\$p > svg > foreignObject > section code br,div#\:\$p > svg > foreignObject > section tt br{display:none}div#\:\$p > svg > foreignObject > section del code{text-decoration:inherit}div#\:\$p > svg > foreignObject > section samp{font-size:85%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code{font-size:100%}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)>code{background:transparent;border:0;margin:0;padding:0;white-space:pre;word-break:normal}div#\:\$p > svg > foreignObject > section .highlight{margin-bottom:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre){margin-bottom:0;word-break:normal}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background-color:var(--bgColor-muted);border-radius:6px;color:var(--fgColor-default);font-size:85%;line-height:1.45;overflow:auto;padding:var(--base-size-16)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) code,div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) tt{display:inline;line-height:inherit;margin:0;overflow:visible;padding:0;word-wrap:normal;background-color:transparent;border:0}div#\:\$p > svg > foreignObject > section .csv-data td,div#\:\$p > svg > foreignObject > section .csv-data th{font-size:12px;line-height:1;overflow:hidden;padding:5px;text-align:left;white-space:nowrap}div#\:\$p > svg > foreignObject > section .csv-data .blob-num{background:var(--bgColor-default);border:0;padding:10px var(--base-size-8) 9px;text-align:right}div#\:\$p > svg > foreignObject > section .csv-data tr{border-top:0}div#\:\$p > svg > foreignObject > section .csv-data th{background:var(--bgColor-muted);border-top:0;font-weight:var(--base-text-weight-semibold, 600)}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:before{content:"["}div#\:\$p > svg > foreignObject > section [data-footnote-ref]:after{content:"]"}div#\:\$p > svg > foreignObject > section .footnotes{border-top:1px solid var(--borderColor-default);color:var(--fgColor-muted);font-size:12px}div#\:\$p > svg > foreignObject > section div#\:\$p > svg > foreignObject > section section.footnotes{--marpit-root-font-size:12px}div#\:\$p > svg > foreignObject > section .footnotes ol,div#\:\$p > svg > foreignObject > section .footnotes ol ul{padding-left:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes ol ul{display:inline-block;margin-top:var(--base-size-16)}div#\:\$p > svg > foreignObject > section .footnotes li{position:relative}div#\:\$p > svg > foreignObject > section .footnotes li:target:before{border:2px solid var(--borderColor-accent-emphasis);border-radius:6px;bottom:calc(var(--base-size-8)*-1);content:"";left:calc(var(--base-size-24)*-1);pointer-events:none;position:absolute;right:calc(var(--base-size-8)*-1);top:calc(var(--base-size-8)*-1)}div#\:\$p > svg > foreignObject > section .footnotes li:target{color:var(--fgColor-default)}div#\:\$p > svg > foreignObject > section .footnotes .data-footnote-backref g-emoji{font-family:monospace}div#\:\$p > svg > foreignObject > section .pl-c{color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section .pl-c1,div#\:\$p > svg > foreignObject > section .pl-s .pl-v{color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section .pl-e,div#\:\$p > svg > foreignObject > section .pl-en{color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section .pl-s .pl-s1,div#\:\$p > svg > foreignObject > section .pl-smi{color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section .pl-ent{color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section .pl-k{color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section .pl-pds,div#\:\$p > svg > foreignObject > section .pl-s,div#\:\$p > svg > foreignObject > section .pl-s .pl-pse .pl-s1,div#\:\$p > svg > foreignObject > section .pl-sr,div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sra,div#\:\$p > svg > foreignObject > section .pl-sr .pl-sre{color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section .pl-smw,div#\:\$p > svg > foreignObject > section .pl-v{color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section .pl-bu{color:var(--color-prettylights-syntax-brackethighlighter-unmatched)}div#\:\$p > svg > foreignObject > section .pl-ii{background-color:var(--color-prettylights-syntax-invalid-illegal-bg);color:var(--color-prettylights-syntax-invalid-illegal-text)}div#\:\$p > svg > foreignObject > section .pl-c2{background-color:var(--color-prettylights-syntax-carriage-return-bg);color:var(--color-prettylights-syntax-carriage-return-text)}div#\:\$p > svg > foreignObject > section .pl-sr .pl-cce{color:var(--color-prettylights-syntax-string-regexp);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ml{color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section .pl-mh,div#\:\$p > svg > foreignObject > section .pl-mh .pl-en,div#\:\$p > svg > foreignObject > section .pl-ms{color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-mi{color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section .pl-mb{color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-md{background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section .pl-mi1{background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section .pl-mc{background-color:var(--color-prettylights-syntax-markup-changed-bg);color:var(--color-prettylights-syntax-markup-changed-text)}div#\:\$p > svg > foreignObject > section .pl-mi2{background-color:var(--color-prettylights-syntax-markup-ignored-bg);color:var(--color-prettylights-syntax-markup-ignored-text)}div#\:\$p > svg > foreignObject > section .pl-mdr{color:var(--color-prettylights-syntax-meta-diff-range);font-weight:700}div#\:\$p > svg > foreignObject > section .pl-ba{color:var(--color-prettylights-syntax-brackethighlighter-angle)}div#\:\$p > svg > foreignObject > section .pl-sg{color:var(--color-prettylights-syntax-sublimelinter-gutter-mark)}div#\:\$p > svg > foreignObject > section .pl-corl{color:var(--color-prettylights-syntax-constant-other-reference-link);text-decoration:underline}div#\:\$p > svg > foreignObject > section [role=button]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section a:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section button:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section summary:focus:not(:focus-visible){box-shadow:none;outline:none}div#\:\$p > svg > foreignObject > section [tabindex="0"]:focus:not(:focus-visible),div#\:\$p > svg > foreignObject > section details-dialog:focus:not(:focus-visible){outline:none}div#\:\$p > svg > foreignObject > section g-emoji{display:inline-block;font-family:Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;font-size:1em;font-style:normal!important;font-weight:var(--base-text-weight-normal, 400);line-height:1;min-width:1ch;vertical-align:-.075em}div#\:\$p > svg > foreignObject > section g-emoji img{height:1em;width:1em}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote){display:block}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):not(:has(.snippet-clipboard-content,>:is(pre, marp-pre))){width:-moz-fit-content;width:fit-content}div#\:\$p > svg > foreignObject > section a:has(>p,>div,>:is(pre, marp-pre),>blockquote):has(.snippet-clipboard-content,>:is(pre, marp-pre)):focus-visible{outline:2px solid var(--focus-outlineColor);outline-offset:2px}div#\:\$p > svg > foreignObject > section .task-list-item{list-style-type:none}div#\:\$p > svg > foreignObject > section .task-list-item label{font-weight:var(--base-text-weight-normal, 400)}div#\:\$p > svg > foreignObject > section .task-list-item.enabled label{cursor:pointer}div#\:\$p > svg > foreignObject > section .task-list-item+.task-list-item{margin-top:var(--base-size-4)}div#\:\$p > svg > foreignObject > section .task-list-item .handle{display:none}div#\:\$p > svg > foreignObject > section .task-list-item-checkbox{margin:0 .2em .25em -1.4em;vertical-align:middle}div#\:\$p > svg > foreignObject > section ul:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section ol:dir(rtl) .task-list-item-checkbox{margin:0 -1.6em .25em .2em}div#\:\$p > svg > foreignObject > section .contains-task-list:focus-within .task-list-item-convert-container,div#\:\$p > svg > foreignObject > section .contains-task-list:hover .task-list-item-convert-container{clip-path:none;display:block;height:24px;overflow:visible;width:auto}div#\:\$p > svg > foreignObject > section ::-webkit-calendar-picker-indicator{filter:invert(50%)}div#\:\$p > svg > foreignObject > section .markdown-alert{border-left:.25em solid var(--borderColor-default);color:inherit;margin-bottom:var(--base-size-16);padding:var(--base-size-8) var(--base-size-16)}div#\:\$p > svg > foreignObject > section .markdown-alert>:first-child{margin-top:0}div#\:\$p > svg > foreignObject > section .markdown-alert>:last-child{margin-bottom:0}div#\:\$p > svg > foreignObject > section .markdown-alert .markdown-alert-title{align-items:center;display:flex;font-weight:var(--base-text-weight-medium, 500);line-height:1}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note{border-left-color:var(--borderColor-accent-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-note .markdown-alert-title{color:var(--fgColor-accent)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important{border-left-color:var(--borderColor-done-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-important .markdown-alert-title{color:var(--fgColor-done)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning{border-left-color:var(--borderColor-attention-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-warning .markdown-alert-title{color:var(--fgColor-attention)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip{border-left-color:var(--borderColor-success-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-tip .markdown-alert-title{color:var(--fgColor-success)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution{border-left-color:var(--borderColor-danger-emphasis)}div#\:\$p > svg > foreignObject > section .markdown-alert.markdown-alert-caution .markdown-alert-title{color:var(--fgColor-danger)}div#\:\$p > svg > foreignObject > section>:first-child>.heading-element:first-child{margin-top:0!important}div#\:\$p > svg > foreignObject > section .highlight :is(pre, marp-pre):has(+.zeroclipboard-container){min-height:52px}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){color:var(--h1-color);font-size:1.6em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){border-bottom:none}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-size:1.3em}div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-size:1.1em}div#\:\$p > svg > foreignObject > section :is(h4, marp-h4){font-size:1.05em}div#\:\$p > svg > foreignObject > section :is(h5, marp-h5){font-size:1em}div#\:\$p > svg > foreignObject > section :is(h6, marp-h6){font-size:.9em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1) strong,div#\:\$p > svg > foreignObject > section :is(h2, marp-h2) strong,div#\:\$p > svg > foreignObject > section :is(h3, marp-h3) strong,div#\:\$p > svg > foreignObject > section :is(h4, marp-h4) strong,div#\:\$p > svg > foreignObject > section :is(h5, marp-h5) strong,div#\:\$p > svg > foreignObject > section :is(h6, marp-h6) strong{color:var(--heading-strong-color);font-weight:inherit}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h2, marp-h2)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h3, marp-h3)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h4, marp-h4)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h5, marp-h5)::part(auto-scaling),div#\:\$p > svg > foreignObject > section :is(h6, marp-h6)::part(auto-scaling){max-height:563px}div#\:\$p > svg > foreignObject > section hr{height:0;padding-top:.25em}div#\:\$p > svg > foreignObject > section img{background-color:transparent}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){border:1px solid var(--borderColor-default);line-height:1.15;overflow:visible}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre)::part(auto-scaling){max-height:529px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-doctag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-keyword),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-tag),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-template-variable),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-type),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable.language_){color:var(--color-prettylights-syntax-keyword)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.class_.inherited__),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-title.function_){color:var(--color-prettylights-syntax-entity)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-attribute),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-literal),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-number),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-operator),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-attr),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-class),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-id),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-variable){color:var(--color-prettylights-syntax-constant)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-meta .hljs-string),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-regexp),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-string){color:var(--color-prettylights-syntax-string)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-built_in),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-symbol){color:var(--color-prettylights-syntax-variable)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-code),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-comment),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-formula){color:var(--color-prettylights-syntax-comment)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-name),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-quote),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-pseudo),div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-selector-tag){color:var(--color-prettylights-syntax-entity-tag)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-subst){color:var(--color-prettylights-syntax-storage-modifier-import)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-section){color:var(--color-prettylights-syntax-markup-heading);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-bullet){color:var(--color-prettylights-syntax-markup-list)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-emphasis){color:var(--color-prettylights-syntax-markup-italic);font-style:italic}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-strong){color:var(--color-prettylights-syntax-markup-bold);font-weight:700}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-addition){background-color:var(--color-prettylights-syntax-markup-inserted-bg);color:var(--color-prettylights-syntax-markup-inserted-text)}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre) :where(.hljs-deletion){background-color:var(--color-prettylights-syntax-markup-deleted-bg);color:var(--color-prettylights-syntax-markup-deleted-text)}div#\:\$p > svg > foreignObject > section footer,div#\:\$p > svg > foreignObject > section header{color:var(--header-footer-color);font-size:18px;left:30px;margin:0;position:absolute}div#\:\$p > svg > foreignObject > section header{top:21px}div#\:\$p > svg > foreignObject > section footer{bottom:21px}div#\:\$p > svg > foreignObject > section{--h1-color:light-dark(#246, #cee7ff);--header-footer-color:light-dark(hsla(0,0%,40%,.75), hsla(0,0%,60%,.75));--heading-strong-color:light-dark(#48c, #7bf);--paginate-color:light-dark(#777, #999);--base-size-4:4px;--base-size-8:8px;--base-size-16:16px;--base-size-24:24px;--base-size-40:40px;align-items:stretch;display:block;flex-flow:column nowrap;font-size:29px;height:720px;padding:78.5px;place-content:safe center center;width:1280px}div#\:\$p > svg > foreignObject > section{--marpit-root-font-size:29px}div#\:\$p > svg > foreignObject > section>:last-child,div#\:\$p > svg > foreignObject > section[data-footer]>:nth-last-child(2){margin-bottom:0}div#\:\$p > svg > foreignObject > section>:first-child,div#\:\$p > svg > foreignObject > section>header:first-child+*{margin-top:0}div#\:\$p > svg > foreignObject > section:after{bottom:21px;color:var(--paginate-color);font-size:24px;padding:0;position:absolute;right:30px}div#\:\$p > svg > foreignObject > section:after{--marpit-root-font-size:24px}div#\:\$p > svg > foreignObject > section[data-color] :is(h1, marp-h1),div#\:\$p > svg > foreignObject > section[data-color] :is(h2, marp-h2),div#\:\$p > svg > foreignObject > section[data-color] :is(h3, marp-h3),div#\:\$p > svg > foreignObject > section[data-color] :is(h4, marp-h4),div#\:\$p > svg > foreignObject > section[data-color] :is(h5, marp-h5),div#\:\$p > svg > foreignObject > section[data-color] :is(h6, marp-h6){color:currentcolor}div#\:\$p > svg > foreignObject > section{width:1280px;height:720px}div#\:\$p > svg > foreignObject > :where(section):not([\20 root]){--color-background: #000000;--color-foreground: #ffffff;--color-highlight: #ee0000;--color-dimmed: #a3a3a3;}div#\:\$p > svg > foreignObject > section{font-family:'Red Hat Text', sans-serif;background:#000000;color:#ffffff}div#\:\$p > svg > foreignObject > section::after{color:#a3a3a3;font-family:'Red Hat Mono', monospace;font-size:0.7em}div#\:\$p > svg > foreignObject > section::after{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1), div#\:\$p > svg > foreignObject > section :is(h2, marp-h2), div#\:\$p > svg > foreignObject > section :is(h3, marp-h3){font-family:'Red Hat Display', sans-serif;color:#ffffff}div#\:\$p > svg > foreignObject > section :is(h1, marp-h1){font-weight:900}div#\:\$p > svg > foreignObject > section :is(h2, marp-h2){font-weight:700}div#\:\$p > svg > foreignObject > section code{font-family:'Red Hat Mono', monospace;background:#292929;border-radius:3px}div#\:\$p > svg > foreignObject > section :is(pre, marp-pre){background:#1f1f1f;border:1px solid #383838;border-radius:3px}div#\:\$p > svg > foreignObject > section a{color:#f56e6e}div#\:\$p > svg > foreignObject > section strong{color:#ffffff}div#\:\$p > svg > foreignObject > section em{color:#c7c7c7}div#\:\$p > svg > foreignObject > section .accent{color:#ee0000}div#\:\$p > svg > foreignObject > section .accent strong{color:inherit}div#\:\$p > svg > foreignObject > section .tag{display:inline-block;padding:2px 14px;border:1px solid #383838;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#c7c7c7;margin:2px}div#\:\$p > svg > foreignObject > section section.tag{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .tag-accent{display:inline-block;padding:2px 14px;border:1px solid #ee0000;border-radius:64px;font-family:'Red Hat Mono', monospace;font-size:0.7em;letter-spacing:0.05em;text-transform:uppercase;color:#ee0000;margin:2px}div#\:\$p > svg > foreignObject > section section.tag-accent{--marpit-root-font-size: 0.7em}div#\:\$p > svg > foreignObject > section .muted{color:#a3a3a3}div#\:\$p > svg > foreignObject > section .small{font-size:0.75em}div#\:\$p > svg > foreignObject > section section.small{--marpit-root-font-size: 0.75em}div#\:\$p > svg > foreignObject > section.lead :is(h1, marp-h1){font-size:2.8em}div#\:\$p > svg > foreignObject > section.lead .subtitle{color:#a3a3a3;font-size:1.1em;max-width:680px}div#\:\$p > svg > foreignObject > section.lead div#\:\$p > svg > foreignObject > section section.subtitle{--marpit-root-font-size: 1.1em}div#\:\$p > svg > foreignObject > section table{font-size:0.85em;background:transparent}div#\:\$p > svg > foreignObject > section th{background:#1f1f1f;border-color:#383838}div#\:\$p > svg > foreignObject > section td{border-color:#383838}div#\:\$p > svg > foreignObject > section.thankyou :is(h1, marp-h1){font-size:5em;text-align:center}div#\:\$p > svg > foreignObject > section.thankyou{display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]{columns:initial!important;display:block!important;padding:0!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"]::after, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::before, div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"]::after{display:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container]{all:initial;display:flex;flex-direction:row;height:100%;overflow:hidden;width:100%}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container][data-marpit-advanced-background-direction="vertical"]{flex-direction:column}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split] > div[data-marpit-advanced-background-container]{width:var(--marpit-advanced-background-split, 50%)}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"][data-marpit-advanced-background-split="right"] > div[data-marpit-advanced-background-container]{margin-left:calc(100% - var(--marpit-advanced-background-split, 50%))}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure{all:initial;background-position:center;background-repeat:no-repeat;background-size:cover;flex:auto;margin:0}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="background"] > div[data-marpit-advanced-background-container] > figure > figcaption{position:absolute;border:0;clip:rect(0, 0, 0, 0);height:1px;margin:-1px;overflow:hidden;padding:0;white-space:nowrap;width:1px}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="content"], div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"]{background:transparent!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background="pseudo"], div#\:\$p > svg[data-marpit-svg] > foreignObject[data-marpit-advanced-background="pseudo"]{pointer-events:none!important}div#\:\$p > svg > foreignObject > section[data-marpit-advanced-background-split]{width:100%;height:100%}
 </style></head><body><div class="bespoke-marp-osc"><button data-bespoke-marp-osc="prev" tabindex="-1" title="Previous slide">Previous slide</button><span data-bespoke-marp-osc="page"></span><button data-bespoke-marp-osc="next" tabindex="-1" title="Next slide">Next slide</button><button data-bespoke-marp-osc="fullscreen" tabindex="-1" title="Toggle fullscreen (f)">Toggle fullscreen</button><button data-bespoke-marp-osc="overview" tabindex="-1" title="Toggle overview view (o)">Toggle overview view</button><button data-bespoke-marp-osc="presenter" tabindex="-1" title="Open presenter view (p)">Open presenter view</button></div><div id=":$p"><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="1" data-paginate="true" data-class="lead" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
   --color-background: #000000;
@@ -45,6 +45,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -100,7 +101,7 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="lead" data-marpit-pagination="1" style="--paginate:true;--class:lead;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
+;" data-marpit-pagination-total="19" data-size="16:9">
 <h1 id="distributing-ai-skills-at-span-classaccententerprise-scalespan">Distributing AI Skills at <span class="accent">Enterprise Scale</span></h1>
 <p>Package, sign, and distribute agent skills as OCI artifacts — using the same registries and trust chains you already run for container images.</p>
 <p><span class="tag-accent">OCI Artifacts</span> <span class="tag">ORAS</span> <span class="tag">Sigstore</span> <span class="tag">Image Volumes</span></p>
@@ -143,6 +144,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -198,25 +200,27 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="2" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="your-agent-is-only-as-good-as-its-span-classaccentskillsspan">Your Agent Is Only as Good as Its <span class="accent">Skills</span></h2>
-<p>Skills are the unit of specialization. Each skill lives in its own subdirectory and gives the agent domain expertise.</p>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="what-is-a-skill">What is a skill?</h2>
 <ul>
-<li><strong>SKILL.md</strong> — instructions in Agent Skills spec format</li>
-<li><strong>skill.yaml</strong> — metadata: tools, resources, versioning</li>
+<li>A text (Markdown) file with instructions for the LLM
+<ul>
+<li>That includes a frontmatter explaining when and how to use it</li>
+<li>The format is defined by <a href="https://agentskills.io/">https://agentskills.io/</a> specification</li>
 </ul>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code>skills/
-├── resume-screener/
-│   ├── SKILL.md
-│   └── skill.yaml
-├── policy-comparator/
-│   ├── SKILL.md
-│   └── skill.yaml
-└── checklist-auditor/
-    ├── SKILL.md
-    └── skill.yaml
-</code></pre>
-<p><span class="muted small">Agent Skills Specification — agentskills.io</span></p>
+</li>
+<li>An optional set of additional files, e.g.:
+<ul>
+<li>Resource/reference files: web page style instructions</li>
+<li>Scripts or other executable files</li>
+</ul>
+</li>
+<li>Introduced by Anthropic in October 2025
+<ul>
+<li>Used by other agents widely</li>
+</ul>
+</li>
+</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="3" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -255,6 +259,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -310,8 +315,8 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="3" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="todays-skill-distribution-is-span-classaccentad-hocspan">Today's Skill Distribution Is <span class="accent">Ad-Hoc</span></h2>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="todays-skill-distribution-is-span-classaccentad-hocspan">Today's skill distribution is <span class="accent">ad-hoc</span></h2>
 <table>
 <thead>
 <tr>
@@ -331,14 +336,9 @@ section.thankyou {
 <td>git clone the repo, copy the directory</td>
 <td>No signing. No atomic versioning. Auth is coarse-grained.</td>
 </tr>
-<tr>
-<td><strong>Mount a ConfigMap</strong></td>
-<td>Embed skill text in a K8s ConfigMap</td>
-<td>1 MiB limit. No versioning. Mixes config with content.</td>
-</tr>
 </tbody>
 </table>
-<p>These get you started, but none provide the <strong>versioning, signing, and auditability</strong> that enterprise deployments require.</p>
+<p>These get you started, but none provide the <strong>versioning, provenance, signing, and auditability</strong> that enterprise deployments require.</p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="4" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -377,6 +377,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -432,15 +433,15 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="4" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="enterprise-deployments-need-span-classaccenttrust-infrastructurespan">Enterprise Deployments Need <span class="accent">Trust Infrastructure</span></h2>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="toxic-skills-are-real">Toxic Skills are real</h2>
+<p>Out of 3,984 skills from ClawHub and skills.sh (as of Feb 5th, 2026):</p>
 <ul>
-<li><img class="emoji" draggable="false" alt="🔒" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f512.svg" data-marp-twemoji=""/> <strong>Signing</strong> — Cryptographic proof of who published a skill and that it hasn't been tampered with</li>
-<li><img class="emoji" draggable="false" alt="📋" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cb.svg" data-marp-twemoji=""/> <strong>Auditability</strong> — Registry logs show who pulled what, when, and where it was deployed</li>
-<li><img class="emoji" draggable="false" alt="🔄" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f504.svg" data-marp-twemoji=""/> <strong>Versioning</strong> — Immutable tags, semantic versions, rollback to a known-good skill set</li>
-<li><img class="emoji" draggable="false" alt="📌" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cc.svg" data-marp-twemoji=""/> <strong>Reproducibility</strong> — Pin skills by digest (sha256) for byte-identical deployments across environments</li>
-<li><img class="emoji" draggable="false" alt="🔑" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f511.svg" data-marp-twemoji=""/> <strong>Access control</strong> — Registry RBAC, pull secrets, org-scoped namespaces — the same policies you use for images</li>
+<li><span class="accent"><strong>36.8%</strong></span> (1,467 skills) have at least one security flaw</li>
+<li><span class="accent"><strong>13.4%</strong></span> (534 skills) have at least one critical-level security issue</li>
 </ul>
+<p>Data by Snyk (Feb 5th, 2026)<br />
+<a href="https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/">https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/</a></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="5" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -479,6 +480,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -534,21 +536,15 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="5" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="oci-is-not-just-for-span-classaccentcontainer-imagesspan">OCI Is Not Just for <span class="accent">Container Images</span></h2>
-<p>The OCI Distribution Specification is <strong>content-agnostic</strong>. Any blob + a manifest + a media type = a valid OCI artifact.</p>
-<p>The <strong>ORAS</strong> project (OCI Registry As Storage) makes this practical: push any content to any OCI registry with standard tooling.</p>
-<p><span class="tag">Helm Charts</span> <span class="tag">WASM Modules</span> <span class="tag">ML Models</span> <span class="tag">Policy Bundles</span> <span class="tag-accent">Agent Skills</span></p>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code>┌────────────────────────────────────────────────────┐
-│      OCI Registry (Quay / GHCR / Harbor / Zot)     │
-└────────────────────────────────────────────────────┘
-    ↓  Same protocol, same auth, same RBAC  ↓
-┌──────────────┐  ┌──────────────┐  ┌──────────────┐
-│  Container   │  │    Helm      │  │    Agent     │
-│   Images     │  │   Charts     │  │   Skills ★   │
-└──────────────┘  └──────────────┘  └──────────────┘
-</code></pre>
-<p><span class="muted small">ORAS — oras.land · OCI Distribution Spec</span></p>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="enterprise-deployments-need-span-classaccenttrust-infrastructurespan">Enterprise deployments need <span class="accent">trust infrastructure</span></h2>
+<ul>
+<li><img class="emoji" draggable="false" alt="🔒" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f512.svg" data-marp-twemoji=""/> <strong>Signing</strong> — Cryptographic proof of who published a skill and that it hasn't been tampered with</li>
+<li><img class="emoji" draggable="false" alt="📋" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cb.svg" data-marp-twemoji=""/> <strong>Auditability</strong> — Registry logs show who pulled what, when, and where it was deployed</li>
+<li><img class="emoji" draggable="false" alt="🔄" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f504.svg" data-marp-twemoji=""/> <strong>Versioning</strong> — Immutable tags, semantic versions, rollback to a known-good skill set</li>
+<li><img class="emoji" draggable="false" alt="📌" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4cc.svg" data-marp-twemoji=""/> <strong>Reproducibility</strong> — Pin skills by digest (sha256) for byte-identical deployments across environments</li>
+<li><img class="emoji" draggable="false" alt="🔑" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f511.svg" data-marp-twemoji=""/> <strong>Access control</strong> — Registry RBAC, pull secrets, org-scoped namespaces — the same policies you use for images</li>
+</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="6" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -587,6 +583,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -642,22 +639,19 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="6" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="a-skill-becomes-an-span-classaccentoci-artifactspan">A Skill Becomes an <span class="accent">OCI Artifact</span></h2>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Skill Directory  →  skillctl pack  →  OCI Layout  →  skillctl push  →  Registry
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="we-have-solved-this-problem-already">We have solved this problem already</h2>
+<p>The OCI Distribution Spec is <strong>content-agnostic</strong>. Any blob + manifest + media type = a valid artifact. <strong>ORAS</strong> makes this practical.</p>
+<p><span class="tag">Helm Charts</span> <span class="tag">WASM Modules</span> <span class="tag">ML Models</span> <span class="tag">Policy Bundles</span> <span class="tag-accent">Agent Skills</span></p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-text">┌────────────────────────────────────────────────────┐
+│      OCI Registry (Quay / GHCR / Harbor / Zot)     │
+└────────────────────────────────────────────────────┘
+    ↓  Same protocol, same auth, same RBAC  ↓
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│  Container   │  │    Helm      │  │    Agent     │
+│   Images     │  │   Charts     │  │   Skills ★   │
+└──────────────┘  └──────────────┘  └──────────────┘
 </code></pre>
-<p><strong>What goes into the artifact:</strong></p>
-<ul>
-<li><code>SKILL.md</code> — instructions</li>
-<li><code>skill.yaml</code> — SkillCard metadata</li>
-<li>Any supporting files in the directory</li>
-</ul>
-<p><strong>What the registry provides:</strong></p>
-<ul>
-<li>Immutable digest + mutable tags</li>
-<li>RBAC &amp; pull secrets</li>
-<li>Cosign / sigstore signatures</li>
-</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="7" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -696,6 +690,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -751,24 +746,22 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="7" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="the-workflow-span-classaccentpack-push-mountspan">The Workflow: <span class="accent">Pack, Push, Mount</span></h2>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># Pack skill into a local OCI layout</span>
-$ skillctl pack examples/skills/resume-screener
-Packed skill → oci-layout · sha256:65af81ce... · 1226 bytes
-
-<span class="hljs-comment"># Push to registry (uses podman/docker credentials)</span>
-$ skillctl push examples/skills/resume-screener \
-    quay.io/docsclaw/skill-resume-screener:1.0.0
-Pushed → quay.io/docsclaw/skill-resume-screener:1.0.0
-
-<span class="hljs-comment"># Push as mountable image (for image volumes)</span>
-$ skillctl push --as-image examples/skills/resume-screener \
-    quay.io/docsclaw/skill-resume-screener:1.0.0-image
-
-<span class="hljs-comment"># Inspect remotely (no download needed)</span>
-$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
-Name: resume-screener · Version: 1.0.0 · Tools: [read_file]
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="your-agent-is-only-as-good-as-its-span-classaccentskillsspan">Your agent is only as good as its <span class="accent">skills</span></h2>
+<p>Skills are the unit of specialization. Each skill gives the agent domain expertise.</p>
+<ul>
+<li><strong>SKILL.md</strong> — instructions in Agent Skills spec format</li>
+<li><strong>skill.yaml</strong> — metadata: versioning, compatibility, licensing</li>
+<li><strong>Scripts</strong> — executable files (Python, Bash, etc.)</li>
+<li><strong>Anything else</strong> — supporting files, models, tools</li>
+</ul>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>skills/
+├── resume-screener/
+│   ├── SKILL.md
+│   └── skill.yaml
+└── policy-comparator/
+    ├── SKILL.md
+    └── skill.yaml
 </code></pre>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
@@ -808,6 +801,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -863,30 +857,22 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="8" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="every-skill-has-a-span-classaccentmachine-readable-identityspan">Every Skill Has a <span class="accent">Machine-Readable Identity</span></h2>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code>$ skillctl inspect quay.io/docsclaw/skill-resume-screener:1.0.0
-
-Name:          resume-screener
-Namespace:     official
-Version:       1.0.0
-Description:   Screen resumes against a job description...
-Author:        Red Hat ET
-License:       Apache-2.0
-Tools:         [read_file]
-Memory:        32Mi
-CPU:           100m
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="a-skill-becomes-an-span-classaccentoci-artifactspan">A skill becomes an <span class="accent">OCI artifact</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code>Skill Directory  →  skillctl build  →  OCI Image  →  skillctl push  →  Registry
 </code></pre>
-<p><strong>What SkillCard enables:</strong></p>
+<p><strong>What goes into the image:</strong></p>
 <ul>
-<li><img class="emoji" draggable="false" alt="🔍" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f50d.svg" data-marp-twemoji=""/> <strong>Discovery</strong> — search by name, namespace, category, author</li>
-<li><img class="emoji" draggable="false" alt="📐" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4d0.svg" data-marp-twemoji=""/> <strong>Resource planning</strong> — CPU and memory hints before deployment</li>
-<li><img class="emoji" draggable="false" alt="🔗" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f517.svg" data-marp-twemoji=""/> <strong>Compatibility</strong> — required tools, dependencies, min agent version</li>
-<li><img class="emoji" draggable="false" alt="✅" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/2705.svg" data-marp-twemoji=""/> <strong>Governance</strong> — license, author, namespace for org-level trust policies</li>
+<li><code>SKILL.md</code> — instructions</li>
+<li><code>skill.yaml</code> — SkillCard metadata</li>
+<li>Any supporting files in the directory</li>
 </ul>
-<blockquote>
-<p><strong>Future: Skill Catalog</strong> — A UI that queries registries, reads SkillCards, and presents a searchable catalog — browse by category, check signing status, deploy with one click.</p>
-</blockquote>
+<p><strong>What the registry provides:</strong></p>
+<ul>
+<li>Immutable digest + mutable tags</li>
+<li>RBAC &amp; pull secrets</li>
+<li>Cosign / sigstore signatures</li>
+</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -925,6 +911,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -980,27 +967,20 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="9" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="image-volumes-mount-skills-span-classaccentdirectlyspan">Image Volumes: Mount Skills <span class="accent">Directly</span></h2>
-<p>On OpenShift 4.20+ / Kubernetes 1.33+, the kubelet can mount an OCI image as a <strong>read-only volume</strong> — no init container needed.</p>
-<ul>
-<li>Kubelet pulls and caches skill images</li>
-<li>Read-only mount — immutable at runtime</li>
-<li>No emptyDir, no node storage consumed</li>
-</ul>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">volumes:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-resume-screener</span>
-    <span class="hljs-attr">image:</span>
-      <span class="hljs-attr">reference:</span> <span class="hljs-string">quay.io/docsclaw/skill-resume-screener:1.0.0</span>
-      <span class="hljs-attr">pullPolicy:</span> <span class="hljs-string">IfNotPresent</span>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="how-to-package-skills-span-classaccentbuild-tag-pushspan">How to package skills: <span class="accent">build, tag, push</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># Build skill into a local OCI image</span>
+$ skillctl build skills/resume-screener/
+Built resume-screener:1.0.0-draft (sha256:65af...)
 
-<span class="hljs-attr">containers:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">docsclaw</span>
-    <span class="hljs-attr">volumeMounts:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-resume-screener</span>
-        <span class="hljs-attr">mountPath:</span> <span class="hljs-string">/skills/resume-screener</span>
+<span class="hljs-comment"># Tag with registry tag</span>
+$ skillctl tag resume-screener:1.0.0-draft \
+    quay.io/myorg/resume-screener:1.0.0-draft
+
+
+<span class="hljs-comment"># Push to registry</span>
+$ skillctl push quay.io/myorg/resume-screener:1.0.0-draft
 </code></pre>
-<p><span class="muted small">KEP-4639 · Kubernetes 1.33+ · OpenShift 4.20+</span></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -1039,6 +1019,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1094,25 +1075,21 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="10" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="init-container-for-span-classaccentolder-clustersspan">Init Container for <span class="accent">Older Clusters</span></h2>
-<p>For Kubernetes &lt; 1.33 or OpenShift &lt; 4.20, use skillctl as an init container to pull skills before the agent starts.</p>
-<ul>
-<li>Pull at pod startup, verify signatures</li>
-<li>Cache on a PVC across restarts</li>
-<li>Share the volume with the main container</li>
-</ul>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">initContainers:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-puller</span>
-    <span class="hljs-attr">image:</span> <span class="hljs-string">ghcr.io/redhat-et/skillctl:latest</span>
-    <span class="hljs-attr">command:</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;skillctl&quot;</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;pull&quot;</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;--verify&quot;</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;-o&quot;</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;/skills&quot;</span>
-      <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;quay.io/docsclaw/skill-resume-screener:1.0.0&quot;</span>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="every-skill-has-a-span-classaccentmachine-readable-identityspan">Every skill has a <span class="accent">machine-readable identity</span></h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash">$ skillctl inspect quay.io/myorg/resume-screener:1.0.0
+Name:     myorg/resume-screener    Version: 1.0.0
+Status:   published                License: Apache-2.0
+Authors:  Red Hat OCTO             Compat:  claude-3.5-sonnet
+Tags:     [<span class="hljs-string">&quot;hr&quot;</span>,<span class="hljs-string">&quot;screening&quot;</span>]
 </code></pre>
+<p><strong>What SkillCard enables:</strong></p>
+<ul>
+<li><strong>Discovery</strong> — search by name, namespace, tags, author</li>
+<li><strong>Lifecycle</strong> — draft → testing → published → deprecated</li>
+<li><strong>Compatibility</strong> — target model compatibility hints</li>
+<li><strong>Governance</strong> — license, author, namespace for trust policies</li>
+</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="11" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -1151,6 +1128,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1206,54 +1184,26 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="11" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="from-ad-hoc-to-span-classaccentsupply-chainspan">From Ad-Hoc to <span class="accent">Supply Chain</span></h2>
-<table>
-<thead>
-<tr>
-<th></th>
-<th>Before</th>
-<th>After (OCI)</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>Distribution</strong></td>
-<td>git clone or manual copy</td>
-<td>Push/pull with standard tooling</td>
-</tr>
-<tr>
-<td><strong>Versioning</strong></td>
-<td>Branch/tag only</td>
-<td>Semver tags + immutable digests</td>
-</tr>
-<tr>
-<td><strong>Signing</strong></td>
-<td>None</td>
-<td>Cosign / sigstore signing</td>
-</tr>
-<tr>
-<td><strong>Audit</strong></td>
-<td>No trail</td>
-<td>Registry access logs</td>
-</tr>
-<tr>
-<td><strong>Auth</strong></td>
-<td>Repo level only</td>
-<td>Per-namespace RBAC + pull secrets</td>
-</tr>
-<tr>
-<td><strong>Size</strong></td>
-<td>ConfigMap 1 MiB limit</td>
-<td>No limits</td>
-</tr>
-<tr>
-<td><strong>Runtime</strong></td>
-<td>Mutable</td>
-<td>Read-only image volume mount</td>
-</tr>
-</tbody>
-</table>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="deploy-as-image-volumes-mount-skills-span-classaccentdirectlyspan">Deploy as image volumes: mount skills <span class="accent">directly</span></h2>
+<p>On OpenShift 4.20+ / K8s 1.33+, mount an OCI image as a <strong>read-only volume</strong>.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">volumes:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">resume-screener</span>
+    <span class="hljs-attr">image:</span>
+      <span class="hljs-attr">reference:</span> <span class="hljs-string">quay.io/myorg/resume-screener:1.0.0</span>
+      <span class="hljs-attr">pullPolicy:</span> <span class="hljs-string">IfNotPresent</span>
+<span class="hljs-attr">containers:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">agent</span>
+    <span class="hljs-attr">volumeMounts:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">resume-screener</span>
+        <span class="hljs-attr">mountPath:</span> <span class="hljs-string">/skills/resume-screener</span>
+</code></pre>
+<ul>
+<li>Kubelet pulls and caches skill images automatically</li>
+<li>Read-only mount — immutable at runtime</li>
+<li>Same pull policies, pull secrets, and mirrors as container images</li>
+</ul>
+<p><span class="muted small">KEP-4639 · Kubernetes 1.33+ · OpenShift 4.20+</span></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -1292,6 +1242,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1347,22 +1298,23 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="12" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="disconnected-and-span-classaccentair-gappedspan-environments">Disconnected and <span class="accent">Air-Gapped</span> Environments</h2>
-<p>Many enterprise OpenShift clusters operate in restricted networks with no external registry access. Skills must reach these environments reliably.</p>
-<p><strong>oc-mirror</strong> can mirror skill images alongside operator bundles to an internal registry — if the skill uses a recognizable MIME type.</p>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-text">Connected                              Disconnected
-┌──────────┐   oc-mirror   ┌──────────────────────────┐
-│ Quay.io  │ ───────────── │ Internal OCP Registry    │
-│          │   (mirrored)  │ image-registry.svc:5000  │
-└──────────┘               └──────────────────────────┘
-  Skills +                   Skills + Operators +
-  Operators                  Signatures preserved
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="init-container-for-span-classaccentolder-clustersspan">Init container for <span class="accent">older clusters</span></h2>
+<p>For K8s &lt; 1.33 / OpenShift &lt; 4.20, use skillctl as an init container.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-yaml"><span class="hljs-attr">initContainers:</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skill-puller</span>
+    <span class="hljs-attr">image:</span> <span class="hljs-string">ghcr.io/redhat-et/skillctl:latest</span>
+    <span class="hljs-attr">command:</span> [<span class="hljs-string">&quot;skillctl&quot;</span>, <span class="hljs-string">&quot;pull&quot;</span>, <span class="hljs-string">&quot;--verify&quot;</span>,
+              <span class="hljs-string">&quot;-o&quot;</span>, <span class="hljs-string">&quot;/skills&quot;</span>,
+              <span class="hljs-string">&quot;quay.io/myorg/resume-screener:1.0.0&quot;</span>]
+    <span class="hljs-attr">volumeMounts:</span>
+      <span class="hljs-bullet">-</span> <span class="hljs-attr">name:</span> <span class="hljs-string">skills</span>
+        <span class="hljs-attr">mountPath:</span> <span class="hljs-string">/skills</span>
 </code></pre>
 <ul>
-<li><strong>OLM integration</strong> — skills as related images in operator bundles, mirrored automatically</li>
-<li><strong>Internal registry</strong> — pull from the cluster's built-in image registry, no external access needed</li>
-<li><strong>Signature preservation</strong> — cosign signatures survive the mirror, verified at admission</li>
+<li>Pull and verify signatures at pod startup</li>
+<li>Cache on a PVC across restarts</li>
+<li>Share the volume with the agent container</li>
 </ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="13" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
@@ -1402,6 +1354,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1457,50 +1410,22 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="13" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="multiple-span-classaccentconsumptionspan-paths">Multiple <span class="accent">Consumption</span> Paths</h2>
-<p>Not every consumer can mount OCI images. skillctl supports multiple ways to get skills where they need to go.</p>
-<table>
-<thead>
-<tr>
-<th>Method</th>
-<th>Command</th>
-<th>Best for</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>Image volume</strong></td>
-<td>Pod spec <code>volumes.image</code></td>
-<td>OpenShift 4.20+ / K8s 1.33+</td>
-</tr>
-<tr>
-<td><strong>Init container</strong></td>
-<td><code>skillctl pull -o /skills</code></td>
-<td>Older clusters</td>
-</tr>
-<tr>
-<td><strong>CLI pull</strong></td>
-<td><code>skillctl pull -o ~/.claude/skills</code></td>
-<td>Developer workstations</td>
-</tr>
-<tr>
-<td><strong>Container extract</strong></td>
-<td><code>podman create</code> + <code>podman cp</code></td>
-<td>No skillctl installed</td>
-</tr>
-<tr>
-<td><strong>Zip download</strong></td>
-<td>Artifact repo or registry</td>
-<td>Non-OCI-aware tools</td>
-</tr>
-</tbody>
-</table>
-<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># No skillctl? Use podman to extract skill files directly:</span>
-$ podman create --name tmp quay.io/skills/resume-screener:1.0.0
-$ podman <span class="hljs-built_in">cp</span> tmp:/skills/resume-screener ./skills/
-$ podman <span class="hljs-built_in">rm</span> tmp
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="install-for-personal-use">Install for personal use</h2>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># Install into a target directory</span>
+skillctl pull -o TARGET_DIR
+
+<span class="hljs-comment"># Install for a specific agent</span>
+skillctl install --target claude
 </code></pre>
+<p>Supported targets:</p>
+<ul>
+<li>claude    <code>~/.claude/skills/</code></li>
+<li>cursor    <code>~/.cursor/skills/</code></li>
+<li>windsurf  <code>~/.codeium/windsurf/skills/</code></li>
+<li>opencode  <code>~/.config/opencode/skills/</code></li>
+<li>openclaw  <code>~/.openclaw/skills/</code></li>
+</ul>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="14" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
@@ -1539,6 +1464,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1594,18 +1520,56 @@ section.thankyou {
   text-align: center;
 }
 " lang="en-US" class="invert" data-marpit-pagination="14" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h2 id="try-it-span-classaccenttodayspan">Try It <span class="accent">Today</span></h2>
-<ul>
-<li><img class="emoji" draggable="false" alt="💻" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4bb.svg" data-marp-twemoji=""/> <strong>Hands-on:</strong> spin up a local Zot registry, pack a skill, push, inspect, pull — 5 minutes end to end</li>
-<li><img class="emoji" draggable="false" alt="🔀" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f500.svg" data-marp-twemoji=""/> <strong>Review the PR:</strong> design decisions, media types, and annotation schema are documented in the design spec — feedback welcome</li>
-<li><img class="emoji" draggable="false" alt="🤝" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f91d.svg" data-marp-twemoji=""/> <strong>Community:</strong> should we propose SkillCard alignment to the Agent Skills OCI Artifacts Specification?</li>
-<li><img class="emoji" draggable="false" alt="🔏" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f50f.svg" data-marp-twemoji=""/> <strong>Next milestone:</strong> full sigstore integration for keyless skill signing and verification</li>
-<li><img class="emoji" draggable="false" alt="🏢" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f3e2.svg" data-marp-twemoji=""/> <strong>OpenShift alignment:</strong> the platform team is building support for oc-mirror, OLM integration, and admission control</li>
-</ul>
-<p><span class="tag-accent">github.com/redhat-et/docsclaw</span></p>
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="from-ad-hoc-to-span-classaccentsupply-chainspan">From ad-hoc to <span class="accent">supply chain</span></h2>
+<table>
+<thead>
+<tr>
+<th></th>
+<th>Before</th>
+<th>After (OCI)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Distribution</strong></td>
+<td>git clone or manual copy</td>
+<td><code>skillctl install</code> from registry</td>
+</tr>
+<tr>
+<td><strong>Versioning</strong></td>
+<td>Branch/tag only</td>
+<td>Semver tags + immutable digests</td>
+</tr>
+<tr>
+<td><strong>Upgrades</strong></td>
+<td>Manual re-clone</td>
+<td><code>skillctl upgrade</code> with version check</td>
+</tr>
+<tr>
+<td><strong>Signing</strong></td>
+<td>None</td>
+<td>Cosign / sigstore signing</td>
+</tr>
+<tr>
+<td><strong>Audit</strong></td>
+<td>No trail</td>
+<td>Registry access logs</td>
+</tr>
+<tr>
+<td><strong>Auth</strong></td>
+<td>Repo level only</td>
+<td>Per-namespace RBAC + pull secrets</td>
+</tr>
+<tr>
+<td><strong>Runtime</strong></td>
+<td>Mutable</td>
+<td>Read-only image volume mount</td>
+</tr>
+</tbody>
+</table>
 </section>
-</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="15" data-paginate="true" data-class="thankyou" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="15" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
 :root {
   --color-background: #000000;
   --color-foreground: #ffffff;
@@ -1642,6 +1606,7 @@ a { color: #f56e6e; }
 strong { color: #ffffff; }
 em { color: #c7c7c7; }
 .accent { color: #ee0000; }
+.accent strong { color: inherit; }
 .tag {
   display: inline-block;
   padding: 2px 14px;
@@ -1696,32 +1661,478 @@ section.thankyou {
   align-items: center;
   text-align: center;
 }
-" lang="en-US" class="thankyou" data-marpit-pagination="15" style="--paginate:true;--class:thankyou;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="15" data-size="16:9">
-<h1 id="thank-span-classaccentyouspan">Thank <span class="accent">You</span></h1>
+" lang="en-US" class="invert" data-marpit-pagination="15" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="disconnected-and-span-classaccentair-gappedspan-environments">Disconnected and <span class="accent">air-gapped</span> environments</h2>
+<p><strong>oc-mirror</strong> mirrors skill images alongside operator bundles to internal registries.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-text">Connected                           Disconnected
+┌──────────┐   oc-mirror   ┌────────────────────────┐
+│ Quay.io  │ ────────────▸ │ Internal OCP Registry  │
+└──────────┘               └────────────────────────┘
+  Skills + Operators         Mirrored with signatures
+</code></pre>
+<ul>
+<li><strong>OLM integration</strong> — skills as related images, mirrored automatically</li>
+<li><strong>Internal registry</strong> — same <code>skillctl pull</code> workflow, no external access</li>
+<li><strong>Signatures preserved</strong> — cosign signatures survive the mirror</li>
+</ul>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="16" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.accent strong { color: inherit; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="16" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="multiple-span-classaccentconsumptionspan-paths">Multiple <span class="accent">consumption</span> paths</h2>
+<p>Skills are standard OCI images — any tool that pulls images can consume them.</p>
+<table>
+<thead>
+<tr>
+<th>Method</th>
+<th>Command</th>
+<th>Best for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>skillctl install</strong></td>
+<td><code>skillctl install &lt;ref&gt; --target claude</code></td>
+<td>Developer workstations</td>
+</tr>
+<tr>
+<td><strong>Image volume</strong></td>
+<td>Pod spec <code>volumes.image</code></td>
+<td>K8s 1.33+ / OCP 4.20+</td>
+</tr>
+<tr>
+<td><strong>Init container</strong></td>
+<td><code>skillctl pull -o /skills</code></td>
+<td>Older clusters</td>
+</tr>
+<tr>
+<td><strong>Container extract</strong></td>
+<td><code>podman create</code> + <code>podman cp</code></td>
+<td>No skillctl installed</td>
+</tr>
+</tbody>
+</table>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash"><span class="hljs-comment"># One-command install (auto-pulls from registry):</span>
+$ skillctl install quay.io/myorg/resume-screener:1.0.0 --target claude
+</code></pre>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="17" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.accent strong { color: inherit; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="17" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="brew-style-span-classaccentskill-managementspan">Brew-style <span class="accent">skill management</span></h2>
+<p>Like <code>dnf</code> for AI skills — install, list, upgrade in one command each.</p>
+<pre is="marp-pre" data-auto-scaling="downscale-only"><code class="language-bash">$ skillctl install quay.io/myorg/code-reviewer:1.0.0 --target claude
+Installed to ~/.claude/skills/code-reviewer
+
+$ skillctl list --installed --upgradable --target claude
+NAME            VERSION  LATEST  SOURCE                             TARGET
+code-reviewer   1.0.0    2.0.0   quay.io/myorg/code-reviewer:2.0.0  claude
+
+$ skillctl upgrade code-reviewer --target claude
+Upgraded code-reviewer 1.0.0 → 2.0.0 (claude)
+
+$ skillctl upgrade --all --target claude
+All skills are up to <span class="hljs-built_in">date</span>.
+</code></pre>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="18" data-paginate="true" data-class="invert" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.accent strong { color: inherit; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="invert" data-marpit-pagination="18" style="--paginate:true;--class:invert;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h2 id="try-it-span-classaccenttodayspan">Try it <span class="accent">today</span></h2>
+<ul>
+<li><img class="emoji" draggable="false" alt="💻" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f4bb.svg" data-marp-twemoji=""/> <strong>Install:</strong> <code>brew install pavelanni/tap/skillctl</code> — build, push, install, upgrade in minutes</li>
+<li><img class="emoji" draggable="false" alt="🔄" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f504.svg" data-marp-twemoji=""/> <strong>Full lifecycle:</strong> build → promote → push → install → upgrade → remove</li>
+<li><img class="emoji" draggable="false" alt="🤝" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f91d.svg" data-marp-twemoji=""/> <strong>Community:</strong> SkillCard aligns with the Agent Skills OCI Artifacts Specification</li>
+<li><img class="emoji" draggable="false" alt="🔏" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f50f.svg" data-marp-twemoji=""/> <strong>Next milestone:</strong> sigstore integration for keyless skill signing and verification</li>
+<li><img class="emoji" draggable="false" alt="🏢" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@17.0.2/assets/svg/1f3e2.svg" data-marp-twemoji=""/> <strong>OpenShift alignment:</strong> oc-mirror, OLM integration, and admission control</li>
+</ul>
+<p><span class="tag-accent">github.com/redhat-et/skillimage</span></p>
+</section>
+</foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="19" data-paginate="true" data-class="thankyou" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap');
+:root {
+  --color-background: #000000;
+  --color-foreground: #ffffff;
+  --color-highlight: #ee0000;
+  --color-dimmed: #a3a3a3;
+}
+section {
+  font-family: 'Red Hat Text', sans-serif;
+  background: #000000;
+  color: #ffffff;
+}
+section::after {
+  color: #a3a3a3;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+}
+h1, h2, h3 {
+  font-family: 'Red Hat Display', sans-serif;
+  color: #ffffff;
+}
+h1 { font-weight: 900; }
+h2 { font-weight: 700; }
+code {
+  font-family: 'Red Hat Mono', monospace;
+  background: #292929;
+  border-radius: 3px;
+}
+pre {
+  background: #1f1f1f;
+  border: 1px solid #383838;
+  border-radius: 3px;
+}
+a { color: #f56e6e; }
+strong { color: #ffffff; }
+em { color: #c7c7c7; }
+.accent { color: #ee0000; }
+.accent strong { color: inherit; }
+.tag {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #383838;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #c7c7c7;
+  margin: 2px;
+}
+.tag-accent {
+  display: inline-block;
+  padding: 2px 14px;
+  border: 1px solid #ee0000;
+  border-radius: 64px;
+  font-family: 'Red Hat Mono', monospace;
+  font-size: 0.7em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ee0000;
+  margin: 2px;
+}
+.muted { color: #a3a3a3; }
+.small { font-size: 0.75em; }
+section.lead h1 { font-size: 2.8em; }
+section.lead .subtitle {
+  color: #a3a3a3;
+  font-size: 1.1em;
+  max-width: 680px;
+}
+table {
+  font-size: 0.85em;
+  background: transparent;
+}
+th {
+  background: #1f1f1f;
+  border-color: #383838;
+}
+td {
+  border-color: #383838;
+}
+section.thankyou h1 {
+  font-size: 5em;
+  text-align: center;
+}
+section.thankyou {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+" lang="en-US" class="thankyou" data-marpit-pagination="19" style="--paginate:true;--class:thankyou;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;500;700;900&amp;family=Red+Hat+Text:wght@400;500;700&amp;family=Red+Hat+Mono:wght@400;700&amp;display=swap')
+;" data-marpit-pagination-total="19" data-size="16:9">
+<h1 id="thank-span-classaccentyouspan">Thank <span class="accent">you</span></h1>
 <p>Pavel Anni · Office of CTO · Red Hat</p>
 </section>
 <script>!function(){"use strict";const t={h1:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"1"},style:"display: block; font-size: 2em; margin-block-start: 0.67em; margin-block-end: 0.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h2:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"2"},style:"display: block; font-size: 1.5em; margin-block-start: 0.83em; margin-block-end: 0.83em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h3:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"3"},style:"display: block; font-size: 1.17em; margin-block-start: 1em; margin-block-end: 1em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h4:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"4"},style:"display: block; margin-block-start: 1.33em; margin-block-end: 1.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h5:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"5"},style:"display: block; font-size: 0.83em; margin-block-start: 1.67em; margin-block-end: 1.67em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},h6:{proto:()=>HTMLHeadingElement,attrs:{role:"heading","aria-level":"6"},style:"display: block; font-size: 0.67em; margin-block-start: 2.33em; margin-block-end: 2.33em; margin-inline-start: 0px; margin-inline-end: 0px; font-weight: bold;"},span:{proto:()=>HTMLSpanElement},pre:{proto:()=>HTMLElement,style:"display: block; font-family: monospace; white-space: pre; margin: 1em 0; --marp-auto-scaling-white-space: pre;"}},e="data-marp-auto-scaling-wrapper",i="data-marp-auto-scaling-svg",n="data-marp-auto-scaling-container";class s extends HTMLElement{container;containerSize;containerObserver;svg;svgComputedStyle;svgPreserveAspectRatio="xMinYMid meet";wrapper;wrapperSize;wrapperObserver;constructor(){super();const t=t=>([e])=>{const{width:i,height:n}=e.contentRect;this[t]={width:i,height:n},this.updateSVGRect()};this.attachShadow({mode:"open"}),this.containerObserver=new ResizeObserver(t("containerSize")),this.wrapperObserver=new ResizeObserver((...e)=>{t("wrapperSize")(...e),this.flushSvgDisplay()})}static get observedAttributes(){return["data-downscale-only"]}connectedCallback(){this.shadowRoot.innerHTML=`\n<style>\n  svg[${i}] { display: block; width: 100%; height: auto; vertical-align: top; }\n  span[${n}] { display: table; white-space: var(--marp-auto-scaling-white-space, nowrap); width: max-content; }\n</style>\n<div ${e}>\n  <svg part="svg" ${i}>\n    <foreignObject><span ${n}><slot></slot></span></foreignObject>\n  </svg>\n</div>\n    `.split(/\n\s*/).join(""),this.wrapper=this.shadowRoot.querySelector(`div[${e}]`)??void 0;const t=this.svg;this.svg=this.wrapper?.querySelector(`svg[${i}]`)??void 0,this.svg!==t&&(this.svgComputedStyle=this.svg?window.getComputedStyle(this.svg):void 0),this.container=this.svg?.querySelector(`span[${n}]`)??void 0,this.observe()}disconnectedCallback(){this.svg=void 0,this.svgComputedStyle=void 0,this.wrapper=void 0,this.container=void 0,this.observe()}attributeChangedCallback(){this.observe()}flushSvgDisplay(){const{svg:t}=this;t&&(t.style.display="inline",requestAnimationFrame(()=>{t.style.display=""}))}observe(){this.containerObserver.disconnect(),this.wrapperObserver.disconnect(),this.wrapper&&this.wrapperObserver.observe(this.wrapper),this.container&&this.containerObserver.observe(this.container),this.svgComputedStyle&&this.observeSVGStyle(this.svgComputedStyle)}observeSVGStyle(t){const e=()=>{const i=(()=>{const e=t.getPropertyValue("--preserve-aspect-ratio");if(e)return e.trim();return`x${(({textAlign:t,direction:e})=>{if(t.endsWith("left"))return"Min";if(t.endsWith("right"))return"Max";if("start"===t||"end"===t){let i="rtl"===e;return"end"===t&&(i=!i),i?"Max":"Min"}return"Mid"})(t)}YMid meet`})();i!==this.svgPreserveAspectRatio&&(this.svgPreserveAspectRatio=i,this.updateSVGRect()),t===this.svgComputedStyle&&requestAnimationFrame(e)};e()}updateSVGRect(){let t=Math.ceil(this.containerSize?.width??0);const e=Math.ceil(this.containerSize?.height??0);void 0!==this.dataset.downscaleOnly&&(t=Math.max(t,this.wrapperSize?.width??0));const i=this.svg?.querySelector(":scope > foreignObject");if(i?.setAttribute("width",`${t}`),i?.setAttribute("height",`${e}`),this.svg&&(this.svg.setAttribute("viewBox",`0 0 ${t} ${e}`),this.svg.setAttribute("preserveAspectRatio",this.svgPreserveAspectRatio),this.svg.style.height=t<=0||e<=0?"0":""),this.container){const t=this.svgPreserveAspectRatio.toLowerCase();this.container.style.marginLeft=t.startsWith("xmid")||t.startsWith("xmax")?"auto":"0",this.container.style.marginRight=t.startsWith("xmi")?"auto":"0"}}}const r=(t,{attrs:e={},style:i})=>class extends t{constructor(...t){super(...t);for(const[t,i]of Object.entries(e))this.hasAttribute(t)||this.setAttribute(t,i);this._shadow()}static get observedAttributes(){return["data-auto-scaling"]}connectedCallback(){this._update()}attributeChangedCallback(){this._update()}_shadow(){if(!this.shadowRoot)try{this.attachShadow({mode:"open"})}catch(t){if(!(t instanceof Error&&"NotSupportedError"===t.name))throw t}return this.shadowRoot}_update(){const t=this._shadow();if(t){const e=i?`<style>:host { ${i} }</style>`:"";let n="<slot></slot>";const{autoScaling:s}=this.dataset;if(void 0!==s){n=`<marp-auto-scaling exportparts="svg:auto-scaling" ${"downscale-only"===s?"data-downscale-only":""}>${n}</marp-auto-scaling>`}t.innerHTML=e+n}}};let o;const a=Symbol(),l=()=>o??(o=!!document.createElement("div",{is:"marp-auto-scaling"}).outerHTML.startsWith("<div is"),o);let c;const d="marpitSVGPolyfill:setZoomFactor,",h=Symbol(),g=Symbol();const p=()=>{const t="Apple Computer, Inc."===navigator.vendor,e=t?[v]:[],i={then:e=>(t?(async()=>{if(void 0===c){const t=document.createElement("canvas");t.width=10,t.height=10;const e=t.getContext("2d"),i=new Image(10,10),n=new Promise(t=>{i.addEventListener("load",()=>t())});i.crossOrigin="anonymous",i.src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%2210%22%20viewBox%3D%220%200%201%201%22%3E%3CforeignObject%20width%3D%221%22%20height%3D%221%22%20requiredExtensions%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%3E%3Cdiv%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxhtml%22%20style%3D%22width%3A%201px%3B%20height%3A%201px%3B%20background%3A%20red%3B%20position%3A%20relative%22%3E%3C%2Fdiv%3E%3C%2FforeignObject%3E%3C%2Fsvg%3E",await n,e.drawImage(i,0,0),c=e.getImageData(5,5,1,1).data[3]<128}return c})().then(t=>{null==e||e(t?[v]:[])}):null==e||e([]),i)};return Object.assign(e,i)};let m,u;function v(t){const e="object"==typeof t&&t.target||document,i="object"==typeof t?t.zoom:t;window[g]||(Object.defineProperty(window,g,{configurable:!0,value:!0}),document.body.style.zoom=1.0001,document.body.offsetHeight,document.body.style.zoom=1,window.addEventListener("message",({data:t,origin:e})=>{if(e===window.origin)try{if(t&&"string"==typeof t&&t.startsWith(d)){const[,e]=t.split(","),i=Number.parseFloat(e);Number.isNaN(i)||(u=i)}}catch(t){console.error(t)}}));let n=!1;Array.from(e.querySelectorAll("svg[data-marpit-svg]"),t=>{var e,s,r,o;t.style.transform||(t.style.transform="translateZ(0)");const a=i||u||t.currentScale||1;m!==a&&(m=a,n=a);const l=t.getBoundingClientRect(),{length:c}=t.children;for(let i=0;i<c;i+=1){const n=t.children[i];if(n.getScreenCTM){const t=n.getScreenCTM();if(t){const i=null!==(s=null===(e=n.x)||void 0===e?void 0:e.baseVal.value)&&void 0!==s?s:0,c=null!==(o=null===(r=n.y)||void 0===r?void 0:r.baseVal.value)&&void 0!==o?o:0,d=n.children.length;for(let e=0;e<d;e+=1){const s=n.children[e];if("SECTION"===s.tagName){const{style:e}=s;e.transformOrigin||(e.transformOrigin=`${-i}px ${-c}px`),e.transform=`scale(${a}) matrix(${t.a}, ${t.b}, ${t.c}, ${t.d}, ${t.e-l.left}, ${t.f-l.top}) translateZ(0.0001px)`;break}}}}}}),!1!==n&&Array.from(e.querySelectorAll("iframe"),({contentWindow:t})=>{null==t||t.postMessage(`${d}${n}`,"null"===window.origin?"*":window.origin)})}function w({once:t=!1,target:e=document}={}){const i=function(t=document){if(t[h])return t[h];let e=!0;const i=()=>{e=!1,delete t[h]};Object.defineProperty(t,h,{configurable:!0,value:i});let n=[],s=!1;(async()=>{try{n=await p()}finally{s=!0}})();const r=()=>{for(const e of n)e({target:t});s&&0===n.length||e&&window.requestAnimationFrame(r)};return r(),i}(e);return t?(i(),()=>{}):i}m=1,u=void 0;const b=Symbol(),y=(e=document)=>{if("undefined"==typeof window)throw new Error("Marp Core's browser script is valid only in browser context.");if(((e=document)=>{const i=window[a];i||customElements.define("marp-auto-scaling",s);for(const n of Object.keys(t)){const s=`marp-${n}`,o=t[n].proto();l()&&o!==HTMLElement?i||customElements.define(s,r(o,{style:t[n].style}),{extends:n}):(i||customElements.define(s,r(HTMLElement,t[n])),e.querySelectorAll(`${n}[is="${s}"]`).forEach(t=>{t.outerHTML=t.outerHTML.replace(new RegExp(`^<${n}`,"i"),`<${s}`).replace(new RegExp(`</${n}>$`,"i"),`</${s}>`)}))}window[a]=!0})(e),e[b])return e[b];const i=w({target:e}),n=()=>{i(),delete e[b]},o=Object.assign(n,{cleanup:n,update:()=>y(e)});return Object.defineProperty(e,b,{configurable:!0,value:o}),o},f=document.currentScript;y(f?f.getRootNode():document)}();
 </script></foreignObject></svg></div><div class="bespoke-marp-note" data-index="0" tabindex="0"><p>Tips: Arrow keys or click to navigate. Press N to toggle notes.
-Context: This feature was implemented in PR #21 on redhat-et/docsclaw.
-The design spec is at docs/dev/2026-04-12-oci-skill-distribution-design.md.</p></div><div class="bespoke-marp-note" data-index="1" tabindex="0"><p>Agent Skills Specification: agentskills.io/specification
-
-Skills are the unit of specialization for an agent. Each skill is a self-contained
-directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
-discovers and loads them at startup.
-
-Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.</p></div><div class="bespoke-marp-note" data-index="2" tabindex="0"><p>Each of these methods gets progressively closer to enterprise readiness —
+Project: github.com/redhat-et/skillimage</p></div><div class="bespoke-marp-note" data-index="2" tabindex="0"><p>Each of these methods gets progressively closer to enterprise readiness —
 ConfigMaps are already Kubernetes-native — but all three lack the supply chain
 guarantees (signing, versioning, audit) that regulated environments require.
 
 ConfigMaps have a 1 MiB size limit (etcd constraint), so larger skills with
-examples or data files won't fit.</p></div><div class="bespoke-marp-note" data-index="3" tabindex="0"><p>This is the core motivation. When you deploy AI agents in a regulated enterprise,
+examples or data files won't fit.</p></div><div class="bespoke-marp-note" data-index="4" tabindex="0"><p>This is the core motivation. When you deploy AI agents in a regulated enterprise,
 you need the same supply chain guarantees you have for container images: signed
 artifacts, vulnerability scanning, access control, and audit logs.
 
 Reproducibility matters because you need to prove which exact skill version
 produced an agent's output — especially in regulated industries (finance,
-healthcare, government).</p></div><div class="bespoke-marp-note" data-index="4" tabindex="0"><p>ORAS (OCI Registry As Storage): oras.land
+healthcare, government).</p></div><div class="bespoke-marp-note" data-index="5" tabindex="0"><p>ORAS (OCI Registry As Storage): oras.land
 
 The OCI Distribution Specification was designed to be content-agnostic. Media types
 let registries and tools distinguish content without special handling. Helm charts
@@ -1729,42 +2140,46 @@ have been distributed as OCI artifacts since Helm 3.8 (2022). WASM modules, ML m
 and policy bundles are also distributed this way.
 
 Key insight: your Quay/Harbor/GHCR registry can already store and serve non-image content.
-No infrastructure changes needed.</p></div><div class="bespoke-marp-note" data-index="5" tabindex="0"><p>Community alignment: This implementation aligns with the Agent Skills OCI Artifacts
-Specification by Thomas Vitale.
+No infrastructure changes needed.</p></div><div class="bespoke-marp-note" data-index="6" tabindex="0"><p>Agent Skills Specification: agentskills.io/specification
+
+Skills are the unit of specialization for an agent. Each skill is a self-contained
+directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
+discovers and loads them at startup.
+
+Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.</p></div><div class="bespoke-marp-note" data-index="7" tabindex="0"><p>Skills are packaged as standard OCI images (FROM scratch), not ORAS artifacts.
+This means podman pull, skopeo copy, and Kubernetes ImageVolumes all work natively.
 
 Media types used:
 - application/vnd.oci.image.layer.v1.tar+gzip (skill content layer)
-- application/vnd.oci.image.config.v1+json (config with SkillCard metadata)
+- application/vnd.oci.image.config.v1+json (config)
 
-The custom annotations (io.docsclaw.skill.*) carry SkillCard metadata in the manifest
-for fast inspection without pulling the full layer.</p></div><div class="bespoke-marp-note" data-index="6" tabindex="0"><p>The --as-image flag produces an OCI image (with rootfs layer) instead of an OCI artifact.
-This is required for Kubernetes image volumes, which expect a proper container image that
-the kubelet can pull via the container runtime.
+Skill metadata is stored in OCI manifest annotations (io.skillimage.*) for fast
+inspection without pulling the full layer.</p></div><div class="bespoke-marp-note" data-index="8" tabindex="0"><p>skillctl build produces standard OCI images (FROM scratch). Since skills are OCI images,
+podman pull, skopeo copy, and Kubernetes ImageVolumes all work natively.
 
-Credential resolution is automatic: skillctl reads podman/docker auth configs, so if you've
-done 'podman login quay.io', push/pull just works.</p></div><div class="bespoke-marp-note" data-index="7" tabindex="0"><p>SkillCard schema: docsclaw.io/v1alpha1 kind: SkillCard. The metadata travels inside the
-OCI manifest annotations, so 'skill inspect' reads it without pulling the full layer.
-
-Future vision: a Skill Catalog UI that queries registries, reads SkillCard metadata, and
-presents a searchable, browsable catalog of available skills — like a curated app store
-for agent capabilities.
+Install auto-pulls from remote registries if the image isn't in the local store.
+Provenance (source registry and digest) is recorded in the installed skill's skill.yaml
+for later upgrade tracking.</p></div><div class="bespoke-marp-note" data-index="9" tabindex="0"><p>SkillCard schema: skillimage.io/v1alpha1 kind: SkillCard. The metadata travels inside the
+OCI manifest annotations, so 'skillctl inspect' reads it without pulling the full layer.
 
 The SkillCard schema is intentionally extensible: additional fields (compatibility matrix,
-test results, usage metrics) can be added without breaking existing skills.</p></div><div class="bespoke-marp-note" data-index="8" tabindex="0"><p>Image Volumes (KEP-4639): GA in Kubernetes 1.33 / OpenShift 4.20.
+test results, usage metrics) can be added without breaking existing skills.</p></div><div class="bespoke-marp-note" data-index="10" tabindex="0"><p>Image Volumes (KEP-4639): GA in Kubernetes 1.33 / OpenShift 4.20.
 
 The kubelet pulls the image via the container runtime and mounts it read-only into the pod.
 No init container, no PVC, no emptyDir. The image is cached in the node's container image
 store — subsequent pods that use the same skill image don't need to pull again.
 
 This is the exact same mechanism used for container images, so existing image pull policies
-(IfNotPresent, Always), pull secrets, and registry mirrors all work.</p></div><div class="bespoke-marp-note" data-index="9" tabindex="0"><p>For older clusters, the init container approach uses skillctl to pull skills from the
+(IfNotPresent, Always), pull secrets, and registry mirrors all work.</p></div><div class="bespoke-marp-note" data-index="11" tabindex="0"><p>For older clusters, the init container approach uses skillctl to pull skills from the
 registry before the main container starts. Use a PVC (not emptyDir) to persist the skill
 cache across pod restarts and avoid filling node ephemeral storage.
 
 Signature verification happens at pull time: --verify + --key flags enforce cosign
-verification before extracting the skill.</p></div><div class="bespoke-marp-note" data-index="10" tabindex="0"><p>The before/after contrast highlights what OCI distribution adds to the picture. All the
+verification before extracting the skill.</p></div><div class="bespoke-marp-note" data-index="12" tabindex="0"><p>skillctl install is the easiest way to get started. It pulls the skill image from the
+registry and extracts it into the target directory. The --target flag lets you specify
+the agent you're installing for, so the skill is extracted to the correct location.</p></div><div class="bespoke-marp-note" data-index="13" tabindex="0"><p>The before/after contrast highlights what OCI distribution adds to the picture. All the
 &quot;after&quot; properties come for free from the OCI ecosystem — registries, sigstore, RBAC,
-pull policies — we're just reusing existing infrastructure.</p></div><div class="bespoke-marp-note" data-index="11" tabindex="0"><p>The OpenShift platform team is also building support for this. The oc-mirror tool needs a
+pull policies — we're just reusing existing infrastructure.</p></div><div class="bespoke-marp-note" data-index="14" tabindex="0"><p>The OpenShift platform team is also building support for this. The oc-mirror tool needs a
 recognizable MIME type (application/vnd.redhat.agentskill.layer.v1+tar) to
 identify skill artifacts for mirroring. skillctl supports this as an optional
 media type alongside the standard OCI types.
@@ -1775,22 +2190,15 @@ Quay.io — skillctl pull works the same way.
 
 OLM integration: operators can declare skills as related images in their
 ClusterServiceVersion. When oc-mirror processes the operator catalog, it
-automatically includes the skill images.</p></div><div class="bespoke-marp-note" data-index="12" tabindex="0"><p>The podman/docker extraction path is important for users who don't want to install
-skillctl. Since skills are standard OCI images, any container runtime can pull and
-extract the content.
+automatically includes the skill images.</p></div><div class="bespoke-marp-note" data-index="15" tabindex="0"><p>skillctl install is the simplest path for developers. Supports Claude Code, Cursor,
+Windsurf, OpenCode, and OpenClaw. Since skills are standard OCI images, any container
+runtime can also pull and extract the content.</p></div><div class="bespoke-marp-note" data-index="16" tabindex="0"><p>skillctl tracks provenance (source registry and digest) in each installed skill's
+skill.yaml. This lets it check for newer published versions and upgrade in place.
 
-Zip format: skillctl can bundle a .zip alongside the OCI image for consumers that
-can't work with OCI natively (e.g. some coding assistants). Low implementation
-effort — just create a zip of the skill directory and push as an additional layer
-or separate artifact.
-
-Ann Marie Fred (OpenShift AI) noted that coding assistants can't natively load OCI
-artifacts yet. Multiple consumption paths lower the barrier to adoption.</p></div><div class="bespoke-marp-note" data-index="13" tabindex="0"><p>Resources:
-- OpenShift platform: agent skill packaging, OLM operator integration, skill discovery
-- PR #21: github.com/redhat-et/docsclaw/pull/21
-- Design spec: docs/dev/2026-04-12-oci-skill-distribution-design.md
-- OCI skills guide: docs/oci-skills-guide.md
+The upgrade command only considers published versions (no -draft or -testing suffixes)
+and uses strict semver comparison. Local skills without provenance are skipped.</p></div><div class="bespoke-marp-note" data-index="17" tabindex="0"><p>Resources:
+- Project: github.com/redhat-et/skillimage
 - Agent Skills OCI Spec: github.com/ThomasVitale/agents-skills-oci-artifacts-spec
 - ORAS project: oras.land
-- Zot registry: zotregistry.dev</p></div><div class="bespoke-marp-note" data-index="14" tabindex="0"><p>Thank you for your time. Questions and feedback welcome.</p></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
+- Zot registry: zotregistry.dev</p></div><div class="bespoke-marp-note" data-index="18" tabindex="0"><p>Thank you for your time. Questions and feedback welcome.</p></div><script>/*!! License: https://unpkg.com/@marp-team/marp-cli@4.3.1/lib/bespoke.js.LICENSE.txt */
 !function(){"use strict";function e(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var t,n,r=(n||(n=1,t={from:function(e,t){var n,r=1===(e.parent||e).nodeType?e.parent||e:document.querySelector(e.parent||e),o=[].filter.call("string"==typeof e.slides?r.querySelectorAll(e.slides):e.slides||r.children,function(e){return"SCRIPT"!==e.nodeName}),i={},a=function(e,t){return(t=t||{}).index=o.indexOf(e),t.slide=e,t},s=function(e,t){i[e]=(i[e]||[]).filter(function(e){return e!==t})},l=function(e,t){return(i[e]||[]).reduce(function(e,n){return e&&!1!==n(t)},!0)},c=function(e,t){o[e]&&(n&&l("deactivate",a(n,t)),n=o[e],l("activate",a(n,t)))},d=function(e,t){var r=o.indexOf(n)+e;l(e>0?"next":"prev",a(n,t))&&c(r,t)},u={off:s,on:function(e,t){return(i[e]||(i[e]=[])).push(t),s.bind(null,e,t)},fire:l,slide:function(e,t){if(!arguments.length)return o.indexOf(n);l("slide",a(o[e],t))&&c(e,t)},next:d.bind(null,1),prev:d.bind(null,-1),parent:r,slides:o,destroy:function(e){l("destroy",a(n,e)),i={}}};return(t||[]).forEach(function(e){e(u)}),n||c(0),u}}),t),o=e(r);const i=document.body,a=(...e)=>history.replaceState(...e),s="",l="presenter",c="next",d="overview",u=["",l,d,c],f="bespoke-marp-",m=`data-${f}`,g=(e,{protocol:t,host:n,pathname:r,hash:o}=location)=>{const i=e.toString();return`${t}//${n}${r}${i?"?":""}${i}${o}`},p=()=>i.dataset.bespokeView,v=e=>new URLSearchParams(location.search).get(e),h=(e,t={})=>{const n={location,setter:a,...t},r=new URLSearchParams(n.location.search);for(const t of Object.keys(e)){const n=e[t];"string"==typeof n?r.set(t,n):r.delete(t)}try{n.setter({...window.history.state??{}},"",g(r,n.location))}catch(e){console.error(e)}},w=(()=>{const e="bespoke-marp";try{return localStorage.setItem(e,e),localStorage.removeItem(e),!0}catch{return!1}})(),y=e=>{try{return localStorage.getItem(e)}catch{return null}},b=(e,t)=>{try{return localStorage.setItem(e,t),!0}catch{return!1}},k=e=>{try{return localStorage.removeItem(e),!0}catch{return!1}},x=(e,t)=>{const n="aria-hidden";t?e.setAttribute(n,"true"):e.removeAttribute(n)},E=e=>{e.parent.classList.add(`${f}parent`),e.slides.forEach(e=>e.classList.add(`${f}slide`)),e.on("activate",t=>{const n=`${f}active`,r=t.slide,o=r.classList,i=!o.contains(n);if(e.slides.forEach(e=>{e.classList.remove(n),x(e,!0)}),o.add(n),x(r,!1),i){const e=`${n}-ready`;o.add(e),document.body.clientHeight,o.remove(e)}})},$=e=>{let t=0,n=0;Object.defineProperty(e,"fragments",{enumerable:!0,value:e.slides.map(e=>[null,...e.querySelectorAll("[data-marpit-fragment]")])});const r=r=>void 0!==e.fragments[t][n+r],o=(r,o)=>{t=r,n=o,e.fragments.forEach((e,t)=>{e.forEach((e,n)=>{if(null==e)return;const i=t<r||t===r&&n<=o;e.setAttribute(`${m}fragment`,(i?"":"in")+"active");const a=`${m}current-fragment`;t===r&&n===o?e.setAttribute(a,"current"):e.removeAttribute(a)})}),e.fragmentIndex=o;const i={slide:e.slides[r],index:r,fragments:e.fragments[r],fragmentIndex:o};e.fire("fragment",i)};e.on("next",({fragment:i=!0})=>{if(i){if(r(1))return o(t,n+1),!1;const i=t+1;e.fragments[i]&&o(i,0)}else{const r=e.fragments[t].length;if(n+1<r)return o(t,r-1),!1;const i=e.fragments[t+1];i&&o(t+1,i.length-1)}}),e.on("prev",({fragment:i=!0})=>{if(r(-1)&&i)return o(t,n-1),!1;const a=t-1;e.fragments[a]&&o(a,e.fragments[a].length-1)}),e.on("slide",({index:t,fragment:n})=>{let r=0;if(void 0!==n){const o=e.fragments[t];if(o){const{length:e}=o;r=-1===n?e-1:Math.min(Math.max(n,0),e-1)}}o(t,r)}),o(0,0)},L=document,S=()=>!(!L.fullscreenEnabled&&!L.webkitFullscreenEnabled),P=()=>!(!L.fullscreenElement&&!L.webkitFullscreenElement),_=e=>{e.fullscreen=()=>{S()&&(async()=>{P()?(L.exitFullscreen||L.webkitExitFullscreen)?.call(L):((e=L.body)=>{(e.requestFullscreen||e.webkitRequestFullscreen)?.call(e)})()})()},document.addEventListener("keydown",t=>{"f"!==t.key&&"F11"!==t.key||t.altKey||t.ctrlKey||t.metaKey||!S()||(e.fullscreen(),t.preventDefault())})},O=`${f}inactive`,T=(e=2e3)=>({parent:t,fire:n})=>{const r=t.classList,o=e=>n(`marp-${e?"":"in"}active`);let i;const a=()=>{i&&clearTimeout(i),i=setTimeout(()=>{r.add(O),o()},e),r.contains(O)&&(r.remove(O),o(!0))};for(const e of["mousedown","mousemove","touchend"])document.addEventListener(e,a);setTimeout(a,0)},I=["AUDIO","BUTTON","INPUT","SELECT","TEXTAREA","VIDEO"],M=e=>{e.parent.addEventListener("keydown",e=>{if(!e.target)return;const t=e.target;(I.includes(t.nodeName)||"true"===t.contentEditable)&&e.stopPropagation()})},A=e=>{window.addEventListener("load",()=>{for(const t of e.slides){const e=t.querySelector("marp-auto-scaling, [data-auto-scaling], [data-marp-fitting]");t.setAttribute(`${m}load`,e?"":"hideable")}})},C=({interval:e=250}={})=>t=>{document.addEventListener("keydown",e=>{if(" "===e.key&&e.shiftKey)t.prev();else if("ArrowLeft"===e.key||"ArrowUp"===e.key||"PageUp"===e.key)t.prev({fragment:!e.shiftKey});else if(" "!==e.key||e.shiftKey)if("ArrowRight"===e.key||"ArrowDown"===e.key||"PageDown"===e.key)t.next({fragment:!e.shiftKey});else if("End"===e.key)t.slide(t.slides.length-1,{fragment:-1});else{if("Home"!==e.key)return;t.slide(0)}else t.next();e.preventDefault()});let n,r,o=0;t.parent.addEventListener("wheel",i=>{let a=!1;const s=(e,t)=>{e&&(a=a||((e,t)=>((e,t)=>{const n="X"===t?"Width":"Height";return e[`client${n}`]<e[`scroll${n}`]})(e,t)&&((e,t)=>{const{overflow:n}=e,r=e[`overflow${t}`];return"auto"===n||"scroll"===n||"auto"===r||"scroll"===r})(getComputedStyle(e),t))(e,t)),e?.parentElement&&s(e.parentElement,t)};if(0!==i.deltaX&&s(i.target,"X"),0!==i.deltaY&&s(i.target,"Y"),a)return;i.preventDefault();const l=Math.sqrt(i.deltaX**2+i.deltaY**2);if(void 0!==i.wheelDelta){if(void 0===i.webkitForce&&Math.abs(i.wheelDelta)<40)return;if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<4)return}else if(i.deltaMode===i.DOM_DELTA_PIXEL&&l<12)return;r&&clearTimeout(r),r=setTimeout(()=>{n=0},e);const c=Date.now()-o<e,d=l<=n;if(n=l,c||d)return;let u;(i.deltaX>0||i.deltaY>0)&&(u="next"),(i.deltaX<0||i.deltaY<0)&&(u="prev"),u&&(t[u](),o=Date.now())})},D=(e=`.${f}osc`)=>{const t=document.querySelector(e);if(!t)return()=>{};const n=(e,n)=>{t.querySelectorAll(`[${m}osc=${JSON.stringify(e)}]`).forEach(n)};if(S()||n("fullscreen",e=>e.style.display="none"),!w){const e=(e,t)=>{e.disabled=!0,e.title=`${t} is disabled due to restricted localStorage.`};n("presenter",t=>e(t,"Presenter view")),n("overview",t=>e(t,"Overview view"))}return e=>{t.addEventListener("click",t=>{if(t.target instanceof HTMLElement){const{bespokeMarpOsc:n}=t.target.dataset;n&&t.target.blur();const r={fragment:!t.shiftKey};"next"===n?e.next(r):"prev"===n?e.prev(r):"fullscreen"===n?e?.fullscreen():"presenter"===n?e.openPresenterView():"overview"===n&&e.toggleOverviewView()}}),e.parent.appendChild(t),e.on("activate",({index:t})=>{n("page",n=>n.textContent=`Page ${t+1} of ${e.slides.length}`)}),e.on("fragment",({index:t,fragments:r,fragmentIndex:o})=>{n("prev",e=>e.disabled=0===t&&0===o),n("next",n=>n.disabled=t===e.slides.length-1&&o===r.length-1)}),e.on("marp-active",()=>x(t,!1)),e.on("marp-inactive",()=>x(t,!0)),S()&&(e=>{for(const t of["","webkit"])L.addEventListener(t+"fullscreenchange",e)})(()=>n("fullscreen",e=>e.classList.toggle("exit",S()&&P())))}},N=e=>{if(e.syncKey&&"string"==typeof e.syncKey)return!0;throw new Error("The current instance of Bespoke.js is incompatible with Marp bespoke sync plugin.")},B=(e={})=>{const t=e.key||window.history.state?.marpBespokeSyncKey||Math.random().toString(36).slice(2),n=`bespoke-marp-sync-${t}`;var r;r={marpBespokeSyncKey:t},h({},{setter:(e,...t)=>a({...e,...r},...t)});const o=()=>{const e=y(n);return e?JSON.parse(e):Object.create(null)},i=e=>{const t=o(),r={...t,...e(t)};return b(n,JSON.stringify(r)),r},s=()=>{window.removeEventListener("pageshow",s),i(e=>({reference:(e.reference||0)+1}))};return e=>{s(),Object.defineProperty(e,"syncKey",{value:t,enumerable:!0});let r=!0;setTimeout(()=>{e.on("fragment",e=>{r&&i(()=>({index:e.index,fragmentIndex:e.fragmentIndex}))})},0),window.addEventListener("storage",t=>{if(t.key===n&&t.oldValue&&t.newValue){const n=JSON.parse(t.oldValue),o=JSON.parse(t.newValue);if(n.index!==o.index||n.fragmentIndex!==o.fragmentIndex)try{r=!1,e.slide(o.index,{fragment:o.fragmentIndex,forSync:!0})}finally{r=!0}}});const a=()=>{const{reference:e}=o();void 0===e||e<=1?k(n):i(()=>({reference:e-1}))};window.addEventListener("pagehide",e=>{e.persisted&&window.addEventListener("pageshow",s),a()}),e.on("destroy",a)}},K=e=>{w&&document.addEventListener("keydown",t=>{("o"!==t.key||t.altKey||t.ctrlKey||t.metaKey)&&"Escape"!==t.key||(t.preventDefault(),e())})};let q=null;const V=({closeOnSelect:e=!0}={})=>t=>{N(t);const n=n=>{const r=(()=>{if(!q||!q.isConnected){q=document.createElement("div"),q.className=`${f}overview`,q.inert=!0;const n=document.createElement("iframe");n.src=(()=>{const n=new URLSearchParams(location.search);return n.set("view","overview"),n.set("sync",t.syncKey),e&&n.set("closeOnSelect","1"),g(n)})(),q.append(n),document.body.append(q)}return q})(),o=n??!r.dataset.open;setTimeout(()=>{if(r.dataset.open=o?"1":"",r.inert=!o,t.skipTransition=o,o){const e=r.querySelector("iframe");try{e?.contentWindow?.focus()}catch{e?.focus()}}else window.focus()},0)};Object.defineProperties(t,{toggleOverviewView:{enumerable:!0,value:n}}),window.addEventListener("message",e=>{e.origin===window.origin&&"closeOverview"===e.data&&n(!1)}),K(n)},j=e=>{const{title:t}=document;document.title="[Overview]"+(t?` - ${t}`:"");const n=!!v("closeOnSelect"),r=()=>{window.parent.postMessage("closeOverview","null"===window.origin?"*":window.origin)};if(e.slides.forEach((t,o)=>{t.tabIndex=0;const i=()=>{e.slide(o,{fragment:-1}),n&&r()};t.addEventListener("click",i),t.addEventListener("keydown",e=>{"Enter"!==e.key&&" "!==e.key||(e.preventDefault(),i())})}),window.addEventListener("keydown",t=>{const n=e.slide(),r=t=>{const r=t=>{const n=e.slides[t].getBoundingClientRect();return[Math.round((n.left+n.right)/2),Math.round((n.top+n.bottom)/2)]};let o=null,i=n;do{const e=r(i);if(o){if(Math.abs(e[0]-o[0])<2)return i}else o=e;i+=t}while(i>=0&&i<e.slides.length);return n};if("ArrowLeft"===t.key)e.slide(Math.max(n-1,0),{fragment:-1});else if("ArrowRight"===t.key)e.slide(Math.min(n+1,e.slides.length-1),{fragment:-1});else if("ArrowUp"===t.key)e.slide(r(-1),{fragment:-1});else if("ArrowDown"===t.key)e.slide(r(1),{fragment:-1});else if("End"===t.key)e.slide(e.slides.length-1,{fragment:-1});else{if("Home"!==t.key)return;e.slide(0,{fragment:-1})}t.preventDefault();const o=e.slide();e.slides[o]?.focus?.(),e.slides[o]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),e.on("slide",({index:t})=>{e.slides[t]?.scrollIntoView?.({behavior:"smooth",block:"nearest"})}),window.parent!==window){K(r);const e=document.createElement("header");e.className=`${f}overview-header`;const t=document.createElement("button");t.className=`${f}overview-close`,t.type="button",t.title="Close overview",t.textContent=t.title,t.addEventListener("click",r),e.append(t),document.body.prepend(e)}},F=()=>{const e=p();return{[s]:V(),[l]:V({closeOnSelect:!1}),[d]:j}[e]},U=e=>{window.addEventListener("message",t=>{if(t.origin!==window.origin)return;const[n,r]=t.data.split(":");if("navigate"===n){const[t,n]=r.split(",");let o=Number.parseInt(t,10),i=Number.parseInt(n,10)+1;i>=e.fragments[o].length&&(o+=1,i=0),e.slide(o,{fragment:i})}})};var R,X,H,W,J,Y,z,G={exports:{}},Q=(R||(R=1,G.exports=(X=["area","base","br","col","command","embed","hr","img","input","keygen","link","meta","param","source","track","wbr"],H=function(e){return String(e).replace(/[&<>"']/g,function(e){return"&"+W[e]+";"})},W={"&":"amp","<":"lt",">":"gt",'"':"quot","'":"apos"},J="dangerouslySetInnerHTML",Y={className:"class",htmlFor:"for"},z={},function(e,t){var n=[],r="";t=t||{};for(var o=arguments.length;o-- >2;)n.push(arguments[o]);if("function"==typeof e)return t.children=n.reverse(),e(t);if(e){if(r+="<"+e,t)for(var i in t)!1!==t[i]&&null!=t[i]&&i!==J&&(r+=" "+(Y[i]?Y[i]:H(i))+'="'+H(t[i])+'"');r+=">"}if(-1===X.indexOf(e)){if(t[J])r+=t[J].__html;else for(;n.length;){var a=n.pop();if(a)if(a.pop)for(var s=a.length;s--;)n.push(a[s]);else r+=!0===z[a]?a:H(a)}r+=e?"</"+e+">":""}return z[r]=!0,r})),G.exports),Z=e(Q);const ee=({children:e})=>Z(null,null,...e),te=`${f}presenter-`,ne={container:`${te}container`,dragbar:`${te}dragbar-container`,next:`${te}next`,nextContainer:`${te}next-container`,noteContainer:`${te}note-container`,noteWrapper:`${te}note-wrapper`,noteButtons:`${te}note-buttons`,infoContainer:`${te}info-container`,infoPageArea:`${te}info-page-area`,infoPage:`${te}info-page`,infoPagePrev:`${te}info-page-prev`,infoPageNext:`${te}info-page-next`,noteButtonsBigger:`${te}note-bigger`,noteButtonsSmaller:`${te}note-smaller`,infoTime:`${te}info-time`,infoTimer:`${te}info-timer`},re=e=>{const{title:t}=document;document.title="[Presenter view]"+(t?` - ${t}`:"");const n={},r=e=>(n[e]=n[e]||document.querySelector(`.${e}`),n[e]);document.body.appendChild((e=>{const t=document.createElement("div");return t.className=ne.container,t.appendChild(e),t.insertAdjacentHTML("beforeend",Z(ee,null,Z("div",{class:ne.nextContainer},Z("iframe",{class:ne.next,src:"?view=next"})),Z("div",{class:ne.dragbar}),Z("div",{class:ne.noteContainer},Z("div",{class:ne.noteWrapper}),Z("div",{class:ne.noteButtons},Z("button",{class:ne.noteButtonsSmaller,tabindex:"-1",title:"Smaller notes font size"},"Smaller notes font size"),Z("button",{class:ne.noteButtonsBigger,tabindex:"-1",title:"Bigger notes font size"},"Bigger notes font size"))),Z("div",{class:ne.infoContainer},Z("div",{class:ne.infoPageArea},Z("button",{class:ne.infoPagePrev,tabindex:"-1",title:"Previous"},"Previous"),Z("button",{class:ne.infoPage}),Z("button",{class:ne.infoPageNext,tabindex:"-1",title:"Next"},"Next")),Z("time",{class:ne.infoTime,title:"Current time"}),Z("time",{class:ne.infoTimer,title:"Timer"})))),t})(e.parent)),(e=>{let t=!1;r(ne.dragbar).addEventListener("mousedown",()=>{t=!0,r(ne.dragbar).classList.add("active")}),window.addEventListener("mouseup",()=>{t=!1,r(ne.dragbar).classList.remove("active")}),window.addEventListener("mousemove",e=>{if(!t)return;const n=e.clientX/document.documentElement.clientWidth*100;r(ne.container).style.setProperty("--bespoke-marp-presenter-split-ratio",`${Math.max(0,Math.min(100,n))}%`)}),r(ne.nextContainer).addEventListener("click",()=>e.next());const n=r(ne.next),o=(i=n,(e,t)=>i.contentWindow?.postMessage(`navigate:${e},${t}`,"null"===window.origin?"*":window.origin));var i;n.addEventListener("load",()=>{r(ne.nextContainer).classList.add("active"),o(e.slide(),e.fragmentIndex),e.on("fragment",({index:e,fragmentIndex:t})=>o(e,t))});const a=document.querySelectorAll(".bespoke-marp-note");a.forEach(e=>{e.addEventListener("keydown",e=>e.stopPropagation()),r(ne.noteWrapper).appendChild(e)}),e.on("activate",()=>a.forEach(t=>t.classList.toggle("active",t.dataset.index==e.slide())));let s=0;const l=e=>{s=Math.max(-5,s+e),r(ne.noteContainer).style.setProperty("--bespoke-marp-note-font-scale",(1.2**s).toFixed(4))},c=()=>l(1),d=()=>l(-1),u=r(ne.noteButtonsBigger),f=r(ne.noteButtonsSmaller);u.addEventListener("click",()=>{u.blur(),c()}),f.addEventListener("click",()=>{f.blur(),d()}),document.addEventListener("keydown",e=>{"+"===e.key&&c(),"-"===e.key&&d()},!0);const m=r(ne.infoPage);e.on("activate",({index:t})=>{m.textContent=`${t+1} / ${e.slides.length}`}),m.addEventListener("click",()=>{m.blur(),e.toggleOverviewView()});const g=r(ne.infoPagePrev),p=r(ne.infoPageNext);g.addEventListener("click",t=>{g.blur(),e.prev({fragment:!t.shiftKey})}),p.addEventListener("click",t=>{p.blur(),e.next({fragment:!t.shiftKey})}),e.on("fragment",({index:t,fragments:n,fragmentIndex:r})=>{g.disabled=0===t&&0===r,p.disabled=t===e.slides.length-1&&r===n.length-1});let v=new Date;const h=()=>{const e=new Date,t=e=>`${Math.floor(e)}`.padStart(2,"0"),n=e.getTime()-v.getTime(),o=t(n/1e3%60),i=t(n/1e3/60%60),a=t(n/36e5%24);r(ne.infoTime).textContent=e.toLocaleTimeString(),r(ne.infoTimer).textContent=`${a}:${i}:${o}`};h(),setInterval(h,250),r(ne.infoTimer).addEventListener("click",()=>{v=new Date})})(e)},oe=e=>{N(e),Object.defineProperties(e,{openPresenterView:{enumerable:!0,value:ie},presenterUrl:{enumerable:!0,get:ae}}),w&&document.addEventListener("keydown",t=>{"p"!==t.key||t.altKey||t.ctrlKey||t.metaKey||(t.preventDefault(),e.openPresenterView())})};function ie(){const{max:e,floor:t}=Math,n=e(t(.85*window.innerWidth),640),r=e(t(.85*window.innerHeight),360);return window.open(this.presenterUrl,te+this.syncKey,`width=${n},height=${r},menubar=no,toolbar=no`)}function ae(){const e=new URLSearchParams(location.search);return e.set("view","presenter"),e.set("sync",this.syncKey),g(e)}const se=e=>{const t=p();return t===c&&e.appendChild(document.createElement("span")),{[s]:oe,[l]:re,[c]:U}[t]},le=e=>{e.on("activate",t=>{document.querySelectorAll(".bespoke-progress-parent > .bespoke-progress-bar").forEach(n=>{n.style.flexBasis=100*t.index/(e.slides.length-1)+"%"})})},ce=e=>{const t=Number.parseInt(e,10);return Number.isNaN(t)?null:t},de=(e={})=>{const t={history:!0,...e};return e=>{let n=!0;const r=e=>{const t=n;try{return n=!0,e()}finally{n=t}},o=(t={fragment:!0})=>{let n=t.fragment?ce(v("f")||""):null;((t,n)=>{const{min:r,max:o}=Math,{fragments:i,slides:a}=e,s=o(0,r(t,a.length-1)),l=o(0,r(n||0,i[s].length-1));s===e.slide()&&l===e.fragmentIndex||e.slide(s,{fragment:l})})((()=>{if(location.hash){const[t]=location.hash.slice(1).split(":~:");if(/^\d+$/.test(t))return(ce(t)??1)-1;const r=document.getElementById(t)||document.querySelector(`a[name="${CSS.escape(t)}"]`);if(r){const{length:t}=e.slides;for(let o=0;o<t;o+=1)if(e.slides[o].contains(r)){const t=e.fragments?.[o],i=r.closest("[data-marpit-fragment]");if(t&&i){const e=t.indexOf(i);e>=0&&(n=e)}return o}}}return 0})(),n)};e.on("fragment",({index:e,fragmentIndex:r})=>{n||h({f:0===r||r.toString()},{location:{...location,hash:`#${e+1}`},setter:(...e)=>t.history?history.pushState(...e):history.replaceState(...e)})}),setTimeout(()=>{o(),window.addEventListener("hashchange",()=>r(()=>{o({fragment:!1}),h({f:void 0})})),window.addEventListener("popstate",()=>{n||r(()=>o())}),n=!1},0)}},{PI:ue,abs:fe,sqrt:me,atan2:ge}=Math,pe={passive:!0},ve=({slope:e=-.7,swipeThreshold:t=30}={})=>n=>{let r;const o=n.parent,i=e=>{const t=o.getBoundingClientRect();return{x:e.pageX-(t.left+t.right)/2,y:e.pageY-(t.top+t.bottom)/2}};o.addEventListener("touchstart",({touches:e})=>{r=1===e.length?i(e[0]):void 0},pe),o.addEventListener("touchmove",e=>{if(r)if(1===e.touches.length){e.preventDefault();const t=i(e.touches[0]),n=t.x-r.x,o=t.y-r.y;r.delta=me(fe(n)**2+fe(o)**2),r.radian=ge(n,o)}else r=void 0}),o.addEventListener("touchend",o=>{if(r){if(r.delta&&r.delta>=t&&r.radian){const t=(r.radian-e+ue)%(2*ue)-ue;n[t<0?"next":"prev"](),o.stopPropagation()}r=void 0}},pe)},he=new Map;he.clear(),he.set("none",{backward:{both:void 0,incoming:void 0,outgoing:void 0},forward:{both:void 0,incoming:void 0,outgoing:void 0}});const we={both:"",outgoing:"outgoing-",incoming:"incoming-"},ye={forward:"",backward:"-backward"},be=e=>`--marp-bespoke-transition-animation-${e}`,ke=e=>`--marp-transition-${e}`,xe=be("name"),Ee=be("duration"),$e=e=>new Promise(t=>{const n={},r=document.createElement("div"),o=e=>{r.remove(),t(e)};r.addEventListener("animationstart",()=>o(n)),Object.assign(r.style,{animationName:e,animationDuration:"1s",animationFillMode:"both",animationPlayState:"paused",position:"absolute",pointerEvents:"none"}),document.body.appendChild(r);const i=getComputedStyle(r).getPropertyValue(ke("duration"));i&&Number.parseFloat(i)>=0&&(n.defaultDuration=i),((e,t)=>{requestAnimationFrame(()=>{e.style.animationPlayState="running",requestAnimationFrame(()=>t(void 0))})})(r,o)}),Le=async e=>he.has(e)?he.get(e):(e=>{const t={},n=[];for(const[r,o]of Object.entries(we))for(const[i,a]of Object.entries(ye)){const s=`marp-${o}transition${a}-${e}`;n.push($e(s).then(e=>{t[i]=t[i]||{},t[i][r]=e?{...e,name:s}:void 0}))}return Promise.all(n).then(()=>t)})(e).then(t=>(he.set(e,t),t)),Se=e=>Object.values(e).flatMap(Object.values).every(e=>!e),Pe=(e,{type:t,backward:n})=>{const r=e[n?"backward":"forward"],o=(()=>{const e=r[t],n=e=>({[xe]:e.name});if(e)return n(e);if(r.both){const e=n(r.both);return"incoming"===t&&(e[be("direction")]="reverse"),e}})();return!o&&n?Pe(e,{type:t,backward:!1}):o||{[xe]:"__bespoke_marp_transition_no_animation__"}},_e=e=>{if(e)try{const t=JSON.parse(e);if((e=>{if("object"!=typeof e)return!1;const t=e;return"string"==typeof t.name&&(void 0===t.duration||"string"==typeof t.duration)})(t))return t}catch{}},Oe="_tSId",Te="_tA",Ie="bespoke-marp-transition-warming-up",Me=window.matchMedia("(prefers-reduced-motion: reduce)"),Ae="__bespoke_marp_transition_reduced_outgoing__",Ce="__bespoke_marp_transition_reduced_incoming__",De={forward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}},backward:{both:void 0,incoming:{name:Ce},outgoing:{name:Ae}}},Ne=e=>{if(!document.startViewTransition)return;const t=t=>(void 0!==t&&(e._tD=t),e._tD);let n;t(!1),((...e)=>{CSS.registerProperty({name:ke("duration"),syntax:"<time>",inherits:!0,initialValue:"-1s"});const t=[...new Set(e).values()];return Promise.all(t.map(e=>Le(e))).then()})(...Array.from(document.querySelectorAll("section[data-transition], section[data-transition-back]")).flatMap(e=>[e.dataset.transition,e.dataset.transitionBack].flatMap(e=>{const t=_e(e);return[t?.name,t?.builtinFallback?`__builtin__${t.name}`:void 0]}).filter(e=>!!e))).then(()=>{document.querySelectorAll("style").forEach(e=>{e.innerHTML=e.innerHTML.replace(/--marp-transition-duration:[^;}]*[;}]/g,e=>e.slice(0,-1)+"!important"+e.slice(-1))})});const r=(n,{back:r,cond:o})=>i=>{const a=t();if(a)return!!i[Te]||!("object"!=typeof a||(a.skipTransition(),!i.forSync));if(e.skipTransition)return!0;if(!o(i))return!0;const s=e.slides[e.slide()],l=()=>i.back??r,c="data-transition"+(l()?"-back":""),d=s.querySelector(`section[${c}]`);if(!d)return!0;const u=_e(d.getAttribute(c)??void 0);return!u||((async(e,{builtinFallback:t=!0}={})=>{let n=await Le(e);if(Se(n)){if(!t)return;return n=await Le(`__builtin__${e}`),Se(n)?void 0:n}return n})(u.name,{builtinFallback:u.builtinFallback}).then(e=>{if(!e){t(!0);try{n(i)}finally{t(!1)}return}let r=e;Me.matches&&(console.warn("Use a constant animation to transition because preferring reduced motion by viewer has detected."),r=De);const o=document.getElementById(Oe);o&&o.remove();const a=document.createElement("style");a.id=Oe,document.head.appendChild(a),((e,t)=>{const n=[`:root{${ke("direction")}:${t.backward?-1:1};}`,":root:has(.bespoke-marp-inactive){cursor:none;}"],r=t=>{const n=e[t].both?.defaultDuration||e[t].outgoing?.defaultDuration||e[t].incoming?.defaultDuration;return"forward"===t?n:n||r("forward")},o=t.duration||r(t.backward?"backward":"forward");void 0!==o&&n.push(`::view-transition-group(*){${Ee}:${o};}`);const i=e=>Object.entries(e).map(([e,t])=>`${e}:${t};`).join("");return n.push(`::view-transition-old(root){${i(Pe(e,{...t,type:"outgoing"}))}}`,`::view-transition-new(root){${i(Pe(e,{...t,type:"incoming"}))}}`),n})(r,{backward:l(),duration:u.duration}).forEach(e=>a.sheet?.insertRule(e));const s=document.documentElement.classList;s.add(Ie);let c=!1;const d=()=>{c||(n(i),c=!0,s.remove(Ie))},f=()=>{t(!1),a.remove(),s.remove(Ie)};try{t(!0);const e=document.startViewTransition(d);t(e),e.finished.finally(f)}catch(e){console.error(e),d(),f()}}),!1)};e.on("prev",r(t=>e.prev({...t,[Te]:!0}),{back:!0,cond:e=>e.index>0&&!((e.fragment??1)&&n.fragmentIndex>0)})),e.on("next",r(t=>e.next({...t,[Te]:!0}),{cond:t=>t.index+1<e.slides.length&&!(n.fragmentIndex+1<n.fragments.length)})),setTimeout(()=>{e.on("slide",r(t=>e.slide(t.index,{...t,[Te]:!0}),{cond:t=>{const n=e.slide();return t.index!==n&&(t.back=t.index<n,!0)}}))},0),e.on("fragment",e=>{n=e})};let Be;const Ke=()=>(void 0===Be&&(Be="wakeLock"in navigator&&navigator.wakeLock),Be),qe=async()=>{const e=Ke();if(e)try{return await e.request("screen")}catch(e){console.warn(e)}return null},Ve=async()=>{if(!Ke())return;let e;const t=()=>{e&&"visible"===document.visibilityState&&qe()};for(const e of["visibilitychange","fullscreenchange"])document.addEventListener(e,t);return e=await qe(),e};((e=document.getElementById(":$p"))=>{(()=>{const e=v("view");i.dataset.bespokeView=u.some(t=>t&&t===e)?e:""})();const t=(e=>{const t=v(e);return h({[e]:void 0}),t})("sync")||void 0;o.from(e,((...e)=>{const t=u.findIndex(e=>p()===e);return e.map(([e,n])=>e[t]&&n).filter(e=>e)})([[1,1,1,0],B({key:t})],[[1,1,0,1],se(e)],[[1,1,0,0],M],[[1,1,1,1],E],[[1,0,0,0],T()],[[1,1,1,1],A],[[1,1,1,1],de({history:!1})],[[1,1,0,0],C()],[[1,1,1,0],_],[[1,0,0,0],le],[[1,1,0,0],ve()],[[1,0,0,0],D()],[[1,1,1,0],F()],[[1,0,0,0],Ne],[[1,1,1,1],$],[[1,1,1,0],Ve]))})()}();</script></body></html>

--- a/docs/slides/oci-skill-distribution-deck.md
+++ b/docs/slides/oci-skill-distribution-deck.md
@@ -44,6 +44,7 @@ style: |
   strong { color: #ffffff; }
   em { color: #c7c7c7; }
   .accent { color: #ee0000; }
+  .accent strong { color: inherit; }
   .tag {
     display: inline-block;
     padding: 2px 14px;
@@ -117,44 +118,27 @@ Project: github.com/redhat-et/skillimage
 
 ---
 
-## Your Agent Is Only as Good as Its <span class="accent">Skills</span>
+## What is a skill?
 
-Skills are the unit of specialization. Each skill gives the agent domain expertise.
-
-- **SKILL.md** — instructions in Agent Skills spec format
-- **skill.yaml** — metadata: versioning, compatibility, licensing
-
-```
-skills/
-├── resume-screener/
-│   ├── SKILL.md
-│   └── skill.yaml
-└── policy-comparator/
-    ├── SKILL.md
-    └── skill.yaml
-```
-
-<!--
-Agent Skills Specification: agentskills.io/specification
-
-Skills are the unit of specialization for an agent. Each skill is a self-contained
-directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
-discovers and loads them at startup.
-
-Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.
--->
+- A text (Markdown) file with instructions for the LLM
+  - That includes a frontmatter explaining when and how to use it
+  - The format is defined by https://agentskills.io/ specification
+- An optional set of additional files, e.g.:
+  - Resource/reference files: web page style instructions
+  - Scripts or other executable files
+- Introduced by Anthropic in October 2025
+  - Used by other agents widely
 
 ---
 
-## Today's Skill Distribution Is <span class="accent">Ad-Hoc</span>
+## Today's skill distribution is <span class="accent">ad-hoc</span>
 
-| Method | How it works | Drawback |
-| ------ | ------------ | -------- |
-| **Copy from a Friend** | Slack messages, email, shared drives | No versioning. No provenance. No audit trail. |
-| **Clone from GitHub** | git clone the repo, copy the directory | No signing. No atomic versioning. Auth is coarse-grained. |
-| **Mount a ConfigMap** | Embed skill text in a K8s ConfigMap | 1 MiB limit. No versioning. Mixes config with content. |
+| Method                 | How it works                           | Drawback                                                  |
+| ---------------------- | -------------------------------------- | --------------------------------------------------------- |
+| **Copy from a Friend** | Slack messages, email, shared drives   | No versioning. No provenance. No audit trail.             |
+| **Clone from GitHub**  | git clone the repo, copy the directory | No signing. No atomic versioning. Auth is coarse-grained. |
 
-These get you started, but none provide the **versioning, signing, and auditability** that enterprise deployments require.
+These get you started, but none provide the **versioning, provenance, signing, and auditability** that enterprise deployments require.
 
 <!--
 Each of these methods gets progressively closer to enterprise readiness —
@@ -167,7 +151,19 @@ examples or data files won't fit.
 
 ---
 
-## Enterprise Deployments Need <span class="accent">Trust Infrastructure</span>
+## Toxic Skills are real
+
+Out of 3,984 skills from ClawHub and skills.sh (as of Feb 5th, 2026):
+
+- <span class="accent">**36.8%**</span> (1,467 skills) have at least one security flaw
+- <span class="accent">**13.4%**</span> (534 skills) have at least one critical-level security issue
+
+Data by Snyk (Feb 5th, 2026)
+https://snyk.io/blog/toxicskills-malicious-ai-agent-skills-clawhub/
+
+---
+
+## Enterprise deployments need <span class="accent">trust infrastructure</span>
 
 - 🔒 **Signing** — Cryptographic proof of who published a skill and that it hasn't been tampered with
 - 📋 **Auditability** — Registry logs show who pulled what, when, and where it was deployed
@@ -187,13 +183,13 @@ healthcare, government).
 
 ---
 
-## OCI Is Not Just for <span class="accent">Container Images</span>
+## We have solved this problem already
 
 The OCI Distribution Spec is **content-agnostic**. Any blob + manifest + media type = a valid artifact. **ORAS** makes this practical.
 
 <span class="tag">Helm Charts</span> <span class="tag">WASM Modules</span> <span class="tag">ML Models</span> <span class="tag">Policy Bundles</span> <span class="tag-accent">Agent Skills</span>
 
-```
+```text
 ┌────────────────────────────────────────────────────┐
 │      OCI Registry (Quay / GHCR / Harbor / Zot)     │
 └────────────────────────────────────────────────────┘
@@ -218,18 +214,51 @@ No infrastructure changes needed.
 
 ---
 
-## A Skill Becomes an <span class="accent">OCI Artifact</span>
+## Your agent is only as good as its <span class="accent">skills</span>
+
+Skills are the unit of specialization. Each skill gives the agent domain expertise.
+
+- **SKILL.md** — instructions in Agent Skills spec format
+- **skill.yaml** — metadata: versioning, compatibility, licensing
+- **Scripts** — executable files (Python, Bash, etc.)
+- **Anything else** — supporting files, models, tools
+
+```
+skills/
+├── resume-screener/
+│   ├── SKILL.md
+│   └── skill.yaml
+└── policy-comparator/
+    ├── SKILL.md
+    └── skill.yaml
+```
+
+<!--
+Agent Skills Specification: agentskills.io/specification
+
+Skills are the unit of specialization for an agent. Each skill is a self-contained
+directory with instructions (SKILL.md) and optional metadata (skill.yaml). The agent
+discovers and loads them at startup.
+
+Think of skills like plugins: the agent provides the runtime, skills provide domain expertise.
+-->
+
+---
+
+## A skill becomes an <span class="accent">OCI artifact</span>
 
 ```
 Skill Directory  →  skillctl build  →  OCI Image  →  skillctl push  →  Registry
 ```
 
 **What goes into the image:**
+
 - `SKILL.md` — instructions
 - `skill.yaml` — SkillCard metadata
 - Any supporting files in the directory
 
 **What the registry provides:**
+
 - Immutable digest + mutable tags
 - RBAC & pull secrets
 - Cosign / sigstore signatures
@@ -248,23 +277,20 @@ inspection without pulling the full layer.
 
 ---
 
-## The Workflow: <span class="accent">Build, Push, Install</span>
+## How to package skills: <span class="accent">build, tag, push</span>
 
 ```bash
 # Build skill into a local OCI image
 $ skillctl build skills/resume-screener/
 Built resume-screener:1.0.0-draft (sha256:65af...)
 
-# Tag and push to registry
+# Tag with registry tag
 $ skillctl tag resume-screener:1.0.0-draft \
     quay.io/myorg/resume-screener:1.0.0-draft
-$ skillctl push quay.io/myorg/resume-screener:1.0.0-draft
 
-# Install directly from registry to Claude Code
-$ skillctl install quay.io/myorg/resume-screener:1.0.0 \
-    --target claude
-Pulling quay.io/myorg/resume-screener:1.0.0...
-Installed to ~/.claude/skills/resume-screener
+
+# Push to registry
+$ skillctl push quay.io/myorg/resume-screener:1.0.0-draft
 ```
 
 <!--
@@ -278,9 +304,9 @@ for later upgrade tracking.
 
 ---
 
-## Every Skill Has a <span class="accent">Machine-Readable Identity</span>
+## Every skill has a <span class="accent">machine-readable identity</span>
 
-```
+```bash
 $ skillctl inspect quay.io/myorg/resume-screener:1.0.0
 Name:     myorg/resume-screener    Version: 1.0.0
 Status:   published                License: Apache-2.0
@@ -304,7 +330,7 @@ test results, usage metrics) can be added without breaking existing skills.
 
 ---
 
-## Image Volumes: Mount Skills <span class="accent">Directly</span>
+## Deploy as image volumes: mount skills <span class="accent">directly</span>
 
 On OpenShift 4.20+ / K8s 1.33+, mount an OCI image as a **read-only volume**.
 
@@ -340,7 +366,7 @@ This is the exact same mechanism used for container images, so existing image pu
 
 ---
 
-## Init Container for <span class="accent">Older Clusters</span>
+## Init container for <span class="accent">older clusters</span>
 
 For K8s < 1.33 / OpenShift < 4.20, use skillctl as an init container.
 
@@ -371,17 +397,43 @@ verification before extracting the skill.
 
 ---
 
-## From Ad-Hoc to <span class="accent">Supply Chain</span>
+## Install for personal use
 
-| | Before | After (OCI) |
-| --- | ------ | ----------- |
-| **Distribution** | git clone or manual copy | `skillctl install` from registry |
-| **Versioning** | Branch/tag only | Semver tags + immutable digests |
-| **Upgrades** | Manual re-clone | `skillctl upgrade` with version check |
-| **Signing** | None | Cosign / sigstore signing |
-| **Audit** | No trail | Registry access logs |
-| **Auth** | Repo level only | Per-namespace RBAC + pull secrets |
-| **Runtime** | Mutable | Read-only image volume mount |
+```bash
+# Install into a target directory
+skillctl pull -o TARGET_DIR
+
+# Install for a specific agent
+skillctl install --target claude
+```
+
+Supported targets:
+
+- claude    `~/.claude/skills/`
+- cursor    `~/.cursor/skills/`
+- windsurf  `~/.codeium/windsurf/skills/`
+- opencode  `~/.config/opencode/skills/`
+- openclaw  `~/.openclaw/skills/`
+
+<!--
+skillctl install is the easiest way to get started. It pulls the skill image from the
+registry and extracts it into the target directory. The --target flag lets you specify
+the agent you're installing for, so the skill is extracted to the correct location.
+-->
+
+---
+
+## From ad-hoc to <span class="accent">supply chain</span>
+
+|                  | Before                   | After (OCI)                           |
+| ---------------- | ------------------------ | ------------------------------------- |
+| **Distribution** | git clone or manual copy | `skillctl install` from registry      |
+| **Versioning**   | Branch/tag only          | Semver tags + immutable digests       |
+| **Upgrades**     | Manual re-clone          | `skillctl upgrade` with version check |
+| **Signing**      | None                     | Cosign / sigstore signing             |
+| **Audit**        | No trail                 | Registry access logs                  |
+| **Auth**         | Repo level only          | Per-namespace RBAC + pull secrets     |
+| **Runtime**      | Mutable                  | Read-only image volume mount          |
 
 <!--
 The before/after contrast highlights what OCI distribution adds to the picture. All the
@@ -391,7 +443,7 @@ pull policies — we're just reusing existing infrastructure.
 
 ---
 
-## Disconnected and <span class="accent">Air-Gapped</span> Environments
+## Disconnected and <span class="accent">air-gapped</span> environments
 
 **oc-mirror** mirrors skill images alongside operator bundles to internal registries.
 
@@ -424,16 +476,16 @@ automatically includes the skill images.
 
 ---
 
-## Multiple <span class="accent">Consumption</span> Paths
+## Multiple <span class="accent">consumption</span> paths
 
 Skills are standard OCI images — any tool that pulls images can consume them.
 
-| Method | Command | Best for |
-| ------ | ------- | -------- |
-| **skillctl install** | `skillctl install <ref> --target claude` | Developer workstations |
-| **Image volume** | Pod spec `volumes.image` | K8s 1.33+ / OCP 4.20+ |
-| **Init container** | `skillctl pull -o /skills` | Older clusters |
-| **Container extract** | `podman create` + `podman cp` | No skillctl installed |
+| Method                | Command                                  | Best for               |
+| --------------------- | ---------------------------------------- | ---------------------- |
+| **skillctl install**  | `skillctl install <ref> --target claude` | Developer workstations |
+| **Image volume**      | Pod spec `volumes.image`                 | K8s 1.33+ / OCP 4.20+  |
+| **Init container**    | `skillctl pull -o /skills`               | Older clusters         |
+| **Container extract** | `podman create` + `podman cp`            | No skillctl installed  |
 
 ```bash
 # One-command install (auto-pulls from registry):
@@ -448,7 +500,7 @@ runtime can also pull and extract the content.
 
 ---
 
-## Brew-Style <span class="accent">Skill Management</span>
+## Brew-style <span class="accent">skill management</span>
 
 Like `dnf` for AI skills — install, list, upgrade in one command each.
 
@@ -477,7 +529,7 @@ and uses strict semver comparison. Local skills without provenance are skipped.
 
 ---
 
-## Try It <span class="accent">Today</span>
+## Try it <span class="accent">today</span>
 
 - 💻 **Install:** `brew install pavelanni/tap/skillctl` — build, push, install, upgrade in minutes
 - 🔄 **Full lifecycle:** build → promote → push → install → upgrade → remove
@@ -499,7 +551,7 @@ Resources:
 
 <!-- _class: thankyou -->
 
-# Thank <span class="accent">You</span>
+# Thank <span class="accent">you</span>
 
 Pavel Anni · Office of CTO · Red Hat
 


### PR DESCRIPTION
## Summary
- Add `.accent strong { color: inherit }` CSS rule so bold text inside accent spans displays in red instead of being overridden by the `strong { color: #ffffff }` rule
- Rebuild HTML from updated Marp markdown

## Test plan
- [ ] Open GitHub Pages site and verify "Toxic Skills are real" slide shows red percentages

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded OCI Skill distribution guide with new sections on building, tagging, pushing, and installing skills; added coverage of enterprise trust, governance, identity, signing, versioning, and air-gapped workflows with practical deployment paths and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->