### PR TITLE
examples: add TweetClaw OpenClaw skill example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ A skill is a directory with a `skill.yaml` (SkillCard metadata)
 and a `SKILL.md` (prompt content). See `examples/hello-world/`
 for a working example.
 
+For a plugin-backed workflow example, see `examples/tweetclaw-openclaw/`.
+It packages a TweetClaw OpenClaw workflow with source provenance and explicit
+approval boundaries for X/Twitter actions.
+
 ```yaml
 apiVersion: skillimage.io/v1alpha1
 kind: SkillCard

--- a/examples/tweetclaw-openclaw/SKILL.md
+++ b/examples/tweetclaw-openclaw/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: tweetclaw-openclaw
+description: Package an approval-gated OpenClaw plugin workflow for TweetClaw and Xquik.
+license: Apache-2.0
+metadata:
+  author: skillimage-contributors
+  version: "1.0"
+---
+
+Use this skill when an OpenClaw agent needs X/Twitter data or reviewed
+account actions through TweetClaw.
+
+## Install
+
+Install the published OpenClaw plugin before using this skill:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Configure the Xquik API key in OpenClaw config or a local environment file.
+Do not paste private values into chats, prompts, runbooks, logs, or generated
+artifacts.
+
+## Tools
+
+Use `explore` first to inspect available TweetClaw operations. Use `tweetclaw`
+only after the user has confirmed the intended account, task, and side effects.
+
+## Good Tasks
+
+- scrape tweets and search tweets
+- search tweet replies
+- export followers and look up users
+- upload or download media
+- monitor tweets and deliver webhooks
+- run giveaway draws
+- post tweets or post replies after explicit review
+
+## Approval Boundary
+
+Treat posting, replying, direct messages, follows, profile changes, webhook
+creation, new monitors, and giveaway draws as approval-gated actions. Present
+the structured action request first and wait for user approval before calling
+`tweetclaw`.
+
+Keep drafting, scoring, scheduling, analytics, and voice decisions in the
+calling workflow. TweetClaw supplies X/Twitter evidence and approved execution,
+but the agent remains responsible for its own review policy.

--- a/examples/tweetclaw-openclaw/SKILL.md
+++ b/examples/tweetclaw-openclaw/SKILL.md
@@ -4,7 +4,7 @@ description: Package an approval-gated OpenClaw plugin workflow for TweetClaw an
 license: Apache-2.0
 metadata:
   author: skillimage-contributors
-  version: "1.0"
+  version: "1.0.0"
 ---
 
 Use this skill when an OpenClaw agent needs X/Twitter data or reviewed

--- a/examples/tweetclaw-openclaw/skill.yaml
+++ b/examples/tweetclaw-openclaw/skill.yaml
@@ -1,0 +1,32 @@
+apiVersion: skillimage.io/v1alpha1
+kind: SkillCard
+metadata:
+  name: tweetclaw-openclaw
+  namespace: examples
+  version: 1.0.0
+  display-name: "TweetClaw OpenClaw Workflow"
+  description: >
+    Packages an approval-gated OpenClaw plugin workflow for TweetClaw and Xquik
+    X/Twitter data, media, monitoring, giveaway, and reviewed posting tasks.
+  license: Apache-2.0
+  tags:
+    - openclaw
+    - x-twitter
+    - social
+    - plugin
+    - approval
+  compatibility: openclaw
+  authors:
+    - name: SkillImage contributors
+provenance:
+  source: https://github.com/Xquik-dev/tweetclaw
+  commit: 4f30d17a46c778c9f02c27bc70b40714ac2dc091
+  path: skills/tweetclaw
+spec:
+  prompt: SKILL.md
+  examples:
+    - input: "Search recent replies before preparing a support response."
+      output: >
+        Use explore to confirm the TweetClaw search reply operation, collect the
+        requested reply context, summarize findings, and ask before any
+        write-like follow-up.


### PR DESCRIPTION
Adds a SkillImage example that packages a TweetClaw OpenClaw workflow as a SkillCard-backed skill image sample.

Why:
- Demonstrates provenance metadata for a plugin-backed skill source.
- Shows how approval-gated X/Twitter workflows fit SkillImage examples.
- Keeps TweetClaw execution inside OpenClaw tool approval boundaries.

Validation:
- go run ./cmd/skillctl validate examples/tweetclaw-openclaw/
- go test ./...
- npx markdown-link-check README.md examples/tweetclaw-openclaw/SKILL.md
- git diff whitespace check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TweetClaw OpenClaw workflow example to the quick start guide, demonstrating plugin-backed workflows with explicit source provenance and approval boundaries for social media actions.
  * Included comprehensive skill documentation and configuration, covering setup, usage guidance, and approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->